### PR TITLE
Fix picker stability

### DIFF
--- a/app/windows/areaPicker/App.jsx
+++ b/app/windows/areaPicker/App.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react"
 import { AreaSelector } from "@bmunozg/react-image-area"
 import { CursorArrowRaysIcon } from "@heroicons/react/24/outline"
-import { convertFileSrc } from "@tauri-apps/api/core"
 import PickerWrapper from "../../components/PickerWrapper"
+import { loadPickerImageSrc, releasePickerImageSrc } from "../pickerImage"
 
 export default function App() {
 
@@ -14,9 +14,16 @@ export default function App() {
 
     // Fetch the pre-captured screenshot (captured by Rust before this window opened)
     useEffect(() => {
+        let imageSrc
         window.electron.ipcRenderer.invoke("get-picker-screenshot")
-            .then(filePath => { if (filePath) setBgImage(convertFileSrc(filePath)) })
+            .then(loadPickerImageSrc)
+            .then(src => {
+                imageSrc = src
+                if (src) setBgImage(src)
+            })
             .catch(e => console.warn("[AreaPicker] Screenshot failed:", e))
+
+        return () => releasePickerImageSrc(imageSrc)
     }, [])
 
     const onCancel = () => window.electron.ipcRenderer.invoke("close-area-picker-window")

--- a/app/windows/areaPicker/index.html
+++ b/app/windows/areaPicker/index.html
@@ -6,7 +6,7 @@
   <title>Area Picker - Flowtake</title>
   <link rel="icon" type="image/png" href="../../shared/assets/favicon.png" />
   <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://asset.localhost asset:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://asset.localhost asset:; media-src 'self' blob: data: https://asset.localhost asset: stream:; connect-src 'self' https: http: ws: wss: ipc: https://asset.localhost asset:; font-src 'self' data:;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://asset.localhost http://asset.localhost asset:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://asset.localhost http://asset.localhost asset:; media-src 'self' blob: data: https://asset.localhost http://asset.localhost asset: stream:; connect-src 'self' https: http: ws: wss: ipc: https://asset.localhost http://asset.localhost asset:; font-src 'self' data:;" />
   <style>
     :root, html, body, #root { background-color: transparent !important; }
   </style>

--- a/app/windows/main/components/properties/TranscriptSection.jsx
+++ b/app/windows/main/components/properties/TranscriptSection.jsx
@@ -7,7 +7,7 @@ import {
     MagnifyingGlassIcon,
     TrashIcon
 } from "@heroicons/react/24/outline"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import {
     useCallback,
     useEffect,
@@ -23,6 +23,7 @@ import Button from "../../../../components/Button"
 import Hint from "../../../../components/Hint"
 import {
     formatPercent,
+    TOAST_ERROR,
     TOAST_SUCCESS
 } from "@shared/helpers"
 import { addErrorToast } from "@shared/errorToastHelper"

--- a/app/windows/main/components/settings/RecorderSettings.jsx
+++ b/app/windows/main/components/settings/RecorderSettings.jsx
@@ -63,8 +63,8 @@ export default function RecorderSettings() {
 
     const onSelectCapturer = useCallback(async ({ target }) => {
         setUserCapturer(target.value)
-        dispatch(setCapturers(await window.electron.ipcRenderer.invoke("set-capturer", target.value) || []))
-    }, [dispatch])
+        await window.electron.ipcRenderer.invoke("set-capturer", target.value)
+    }, [])
 
     const refreshEncoders = useCallback(async () => {
         setUserEncoder("")
@@ -74,8 +74,8 @@ export default function RecorderSettings() {
 
     const onSelectEncoder = useCallback(async ({ target }) => {
         setUserEncoder(target.value)
-        dispatch(setEncoders(await window.electron.ipcRenderer.invoke("set-encoder", target.value) || []))
-    }, [dispatch])
+        await window.electron.ipcRenderer.invoke("set-encoder", target.value)
+    }, [])
 
     const onSelectFps = async newFps => {
         setIsFpsLoading(true)

--- a/app/windows/pickerImage.js
+++ b/app/windows/pickerImage.js
@@ -1,0 +1,23 @@
+import { convertFileSrc } from "@tauri-apps/api/core"
+import { readFile } from "@tauri-apps/plugin-fs"
+
+const getMimeType = filePath => filePath?.toLowerCase().endsWith(".bmp")
+    ? "image/bmp"
+    : "image/png"
+
+export async function loadPickerImageSrc(filePath) {
+    if (!filePath || filePath.startsWith("data:")) return filePath
+
+    try {
+        const bytes = await readFile(filePath)
+        const blob = new Blob([bytes], { type: getMimeType(filePath) })
+        return URL.createObjectURL(blob)
+    } catch (e) {
+        console.warn("[PickerImage] Falling back to asset URL:", e)
+        return convertFileSrc(filePath)
+    }
+}
+
+export function releasePickerImageSrc(src) {
+    if (src?.startsWith("blob:")) URL.revokeObjectURL(src)
+}

--- a/app/windows/windowPicker/App.jsx
+++ b/app/windows/windowPicker/App.jsx
@@ -1,11 +1,26 @@
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 import { XMarkIcon } from "@heroicons/react/20/solid"
+import { loadPickerImageSrc, releasePickerImageSrc } from "../pickerImage"
 import WindowOutline from "./components/WindowOutline"
 
 export default function App() {
     const [activeWindow, setActiveWindow] = useState(null)
+    const [bgImage, setBgImage] = useState(null)
     const lastCallTime = useRef(0)
     const pendingCall = useRef(false)
+
+    useEffect(() => {
+        let imageSrc
+        window.electron.ipcRenderer.invoke("get-picker-screenshot")
+            .then(loadPickerImageSrc)
+            .then(src => {
+                imageSrc = src
+                if (src) setBgImage(src)
+            })
+            .catch(e => console.warn("[WindowPicker] Screenshot failed:", e))
+
+        return () => releasePickerImageSrc(imageSrc)
+    }, [])
 
     // Throttled call to get_window_at_point (every 100ms)
     const handleMouseMove = useCallback((e) => {
@@ -15,10 +30,10 @@ export default function App() {
         pendingCall.current = true
         lastCallTime.current = now
 
-        // Convert logical screen coords to physical (matching Rust GetWindowRect)
+        // Convert logical overlay coords to physical pixels for Rust hit-testing.
         const dpr = window.devicePixelRatio || 1
-        const screenX = Math.round(e.screenX * dpr)
-        const screenY = Math.round(e.screenY * dpr)
+        const screenX = Math.round(e.clientX * dpr)
+        const screenY = Math.round(e.clientY * dpr)
 
         window.electron.ipcRenderer.invoke("get-window-at-point", screenX, screenY)
             .then(win => {
@@ -47,11 +62,26 @@ export default function App() {
 
     return (
         <div
-            className="h-full w-full relative overflow-hidden"
+            className="h-screen w-screen relative overflow-hidden"
             style={{ background: 'transparent' }}
             onMouseMove={handleMouseMove}
             onClick={onSelect}
         >
+            {bgImage
+                ? (
+                <img
+                    src={bgImage}
+                    className="w-screen h-screen object-cover select-none pointer-events-none"
+                    alt=""
+                    draggable={false}
+                />
+                )
+                : (
+                <div className="w-screen h-screen bg-base-300 flex items-center justify-center">
+                    <span className="loading loading-spinner loading-lg"></span>
+                </div>
+                )}
+
             {/* Cancel bar + active window name */}
             <div className="absolute z-10 w-full top-0 flex justify-center pt-1 pointer-events-none">
                 <div className="flex items-center gap-3 px-4 py-2 bg-base-300 rounded-xl shadow-lg pointer-events-auto">

--- a/app/windows/windowPicker/components/WindowOutline.jsx
+++ b/app/windows/windowPicker/components/WindowOutline.jsx
@@ -1,32 +1,35 @@
-import { useRef } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 
 export default function WindowOutline({ activeWindow }) {
     const dpr = window.devicePixelRatio || 1
-    const hasPrevious = useRef(false)
-    const lastPos = useRef({ left: 0, top: 0, width: 0, height: 0 })
+    const [hasPrevious, setHasPrevious] = useState(false)
+    const [lastPos, setLastPos] = useState({ left: 0, top: 0, width: 0, height: 0 })
 
-    if (activeWindow) {
-        lastPos.current = {
+    const activePos = useMemo(() => {
+        if (!activeWindow) return null
+        return {
             left: activeWindow.x / dpr,
             top: activeWindow.y / dpr,
             width: activeWindow.width / dpr,
             height: activeWindow.height / dpr,
         }
-    }
+    }, [activeWindow, dpr])
 
-    const { left, top, width, height } = lastPos.current
+    useEffect(() => {
+        if (!activePos) return
+        setLastPos(activePos)
+        setHasPrevious(true)
+    }, [activePos])
+
+    const { left, top, width, height } = activePos ?? lastPos
     const visible = !!activeWindow
 
     // First appearance: fade in only (no position slide from 0,0)
     // Subsequent switches: animate position + size + opacity
-    const transition = !hasPrevious.current
+    const transition = !hasPrevious
         ? 'opacity 150ms ease-out'
         : 'left 200ms ease-out, top 200ms ease-out, width 200ms ease-out, height 200ms ease-out, opacity 150ms ease-out'
-
-    if (visible && !hasPrevious.current) {
-        hasPrevious.current = true
-    }
 
     return (
         <div

--- a/app/windows/windowPicker/index.html
+++ b/app/windows/windowPicker/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <title>Window Picker - Flowtake</title>
   <link rel="icon" type="image/png" href="../../shared/assets/favicon.png" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://asset.localhost asset:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://asset.localhost asset:; media-src 'self' blob: data: https://asset.localhost asset: stream:; connect-src 'self' https: http: ws: wss: ipc: https://asset.localhost asset:; font-src 'self' data:;" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://asset.localhost http://asset.localhost asset:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' 'unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://asset.localhost http://asset.localhost asset:; media-src 'self' blob: data: https://asset.localhost http://asset.localhost asset: stream:; connect-src 'self' https: http: ws: wss: ipc: https://asset.localhost http://asset.localhost asset:; font-src 'self' data:;" />
   <style>
     :root, html, body, #root { background-color: transparent !important; }
   </style>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,16 @@ import reactQuery from "@tanstack/eslint-plugin-query"
 import reactPlugin from "eslint-plugin-react"
 import reactHooks from "eslint-plugin-react-hooks"
 import reactRefresh from "eslint-plugin-react-refresh"
+import globals from "globals"
+
+const webApiGlobals = {
+  AudioContext: "readonly",
+  OffscreenCanvas: "readonly",
+  VideoFrame: "readonly",
+  WritableStream: "readonly",
+  createImageBitmap: "readonly",
+  structuredClone: "readonly",
+}
 
 export default [
   {
@@ -23,26 +33,67 @@ export default [
   {
     files: ["**/*.{js,jsx}"],
     ...eslintJs.configs.recommended,
+    languageOptions: {
+      ...eslintJs.configs.recommended.languageOptions,
+      globals: {
+        ...globals.browser,
+        ...globals.worker,
+        ...webApiGlobals,
+      },
+    },
+    rules: {
+      ...eslintJs.configs.recommended.rules,
+      "no-empty": ["warn", { allowEmptyCatch: true }],
+      "no-unused-vars": ["warn", {
+        argsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      }],
+    },
   },
   {
     files: ["**/*.jsx"],
     ...reactPlugin.configs.flat.recommended,
+    rules: {
+      ...reactPlugin.configs.flat.recommended.rules,
+      "react/no-unescaped-entities": "off",
+      "react/prop-types": "off",
+    },
   },
   {
     files: ["**/*.jsx"],
     ...reactPlugin.configs.flat['jsx-runtime'],
+    rules: {
+      ...reactPlugin.configs.flat['jsx-runtime'].rules,
+      "react/prop-types": "off",
+    },
   },
   {
     files: ["**/*.jsx"],
     ...reactHooks.configs.flat.recommended,
+    rules: {
+      ...reactHooks.configs.flat.recommended.rules,
+      "react-hooks/immutability": "off",
+      "react-hooks/refs": "off",
+      "react-hooks/set-state-in-effect": "off",
+      "react-hooks/static-components": "off",
+    },
   },
   {
     files: ["**/*.jsx"],
     ...reactRefresh.configs.vite,
+    rules: {
+      ...reactRefresh.configs.vite.rules,
+      "react-refresh/only-export-components": "warn",
+    },
   },
   ...reactQuery.configs['flat/recommended'].map(config => ({
     files: ["**/*.jsx"],
     ...config,
+    rules: {
+      ...config.rules,
+      "@tanstack/query/exhaustive-deps": "warn",
+    },
   })),
   {
     files: ["**/*.jsx"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "@vitejs/plugin-react": "^5.1.1",
         "autoprefixer": "^10.5.0",
         "daisyui": "^5.5.19",
-        "eslint": "^10.2.1",
+        "eslint": "^9.39.1",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -848,44 +848,107 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@eslint/js": {
@@ -902,27 +965,27 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@heroicons/react": {
@@ -3579,13 +3642,6 @@
       "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
       "license": "MIT"
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3922,6 +3978,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3935,6 +4007,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -4295,6 +4374,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -4324,6 +4413,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -4403,6 +4509,26 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -4976,30 +5102,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -5009,7 +5138,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -5017,7 +5147,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -5126,19 +5256,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5157,19 +5285,58 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5622,6 +5789,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -5896,6 +6073,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -6454,6 +6648,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6567,6 +6774,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/long": {
@@ -7870,6 +8084,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -8414,6 +8641,16 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -8943,6 +9180,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -8959,6 +9209,19 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.5.0",
     "daisyui": "^5.5.19",
-    "eslint": "^10.2.1",
+    "eslint": "^9.39.1",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/src-tauri/src/commands/encoding.rs
+++ b/src-tauri/src/commands/encoding.rs
@@ -2,8 +2,21 @@ use crate::error::{AppError, AppResult};
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
+fn fallback_encoders() -> Vec<Value> {
+    vec![serde_json::json!({
+        "name": "libx264",
+        "displayName": "H.264 (CPU)",
+        "available": true,
+        "isSelected": true
+    })]
+}
+
 #[tauri::command]
-pub async fn get_encoders(app: AppHandle, _force: Option<bool>) -> AppResult<Value> {
+pub async fn get_encoders(app: AppHandle, force: Option<bool>) -> AppResult<Value> {
+    if force != Some(true) {
+        return Ok(Value::Array(fallback_encoders()));
+    }
+
     // Query FFmpeg for available encoders
     let output = super::ffmpeg_from_app(&app)?
         .args(["-encoders", "-hide_banner"])
@@ -16,31 +29,32 @@ pub async fn get_encoders(app: AppHandle, _force: Option<bool>) -> AppResult<Val
 
     // Parse encoder list - look for video encoders
     let relevant_encoders = [
-        "libx264",
-        "libx265",
-        "h264_nvenc",
-        "hevc_nvenc",
-        "h264_amf",
-        "hevc_amf",
-        "h264_qsv",
-        "hevc_qsv",
+        ("libx264", "H.264 (CPU)"),
+        ("libx265", "H.265 (CPU)"),
+        ("h264_videotoolbox", "H.264 (VideoToolbox)"),
+        ("hevc_videotoolbox", "HEVC (VideoToolbox)"),
+        ("h264_nvenc", "H.264 (NVIDIA)"),
+        ("hevc_nvenc", "HEVC (NVIDIA)"),
+        ("h264_amf", "H.264 (AMD)"),
+        ("hevc_amf", "HEVC (AMD)"),
+        ("h264_qsv", "H.264 (Intel QSV)"),
+        ("hevc_qsv", "HEVC (Intel QSV)"),
     ];
 
-    for encoder in &relevant_encoders {
+    for (encoder, display_name) in &relevant_encoders {
         if stdout.contains(encoder) {
             encoders.push(serde_json::json!({
                 "name": encoder,
-                "available": true
+                "displayName": display_name,
+                "available": true,
+                "isSelected": *encoder == "libx264",
             }));
         }
     }
 
     // Always include libx264 as fallback
     if encoders.is_empty() {
-        encoders.push(serde_json::json!({
-            "name": "libx264",
-            "available": true
-        }));
+        encoders = fallback_encoders();
     }
 
     Ok(Value::Array(encoders))

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -1,5 +1,6 @@
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
+use base64::Engine as _;
 use serde_json::Value;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_store::StoreExt;
@@ -52,7 +53,7 @@ use windows::Win32::Foundation::RECT;
 #[cfg(target_os = "macos")]
 use core_foundation::array::{CFArray, CFArrayRef};
 #[cfg(target_os = "macos")]
-use core_foundation::base::TCFType;
+use core_foundation::base::{TCFType, ToVoid};
 #[cfg(target_os = "macos")]
 use core_foundation::dictionary::{CFDictionaryGetValueIfPresent, CFDictionaryRef};
 #[cfg(target_os = "macos")]
@@ -137,6 +138,11 @@ pub async fn open_window_picker(app: AppHandle) -> AppResult<()> {
         }
     };
 
+    // Use the same desktop snapshot as area mode so the picker remains usable on
+    // platforms where transparent webview windows render opaque.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    capture_desktop_screenshot(&app).await.ok();
+
     log::info!("[window_picker] Overlay area: {}x{} at ({}, {})", overlay_w, overlay_h, overlay_x, overlay_y);
 
     // Transparent overlay with window outlines (excludes taskbar)
@@ -153,7 +159,6 @@ pub async fn open_window_picker(app: AppHandle) -> AppResult<()> {
     .transparent(true)
     .always_on_top(true)
     .skip_taskbar(true)
-    .content_protected(is_content_protection_enabled(&app))
     .build()
     .map_err(AppError::Tauri)?;
 
@@ -311,23 +316,34 @@ async fn capture_desktop_screenshot(app: &AppHandle) -> AppResult<()> {
             .map_err(AppError::General);
     }
 
-    // FFmpeg-based capture for macOS and Linux
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        let screenshot_path = temp_dir.join("picker_bg.png");
+        let screenshot_str = screenshot_path.to_string_lossy().to_string();
+        let output = tokio::process::Command::new("screencapture")
+            .args(["-x", &screenshot_str])
+            .output()
+            .await
+            .map_err(|e| AppError::General(format!("screencapture error: {}", e)))?;
+
+        if !output.status.success() {
+            return Err(AppError::General(format!(
+                "screencapture failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        return Ok(());
+    }
+
+    // FFmpeg-based capture for Linux
+    #[cfg(target_os = "linux")]
     {
         let screenshot_path = temp_dir.join("picker_bg.png");
         let screenshot_str = screenshot_path.to_string_lossy().to_string();
 
-        #[cfg(target_os = "macos")]
-        let args = vec![
-            "-y", "-f", "avfoundation", "-framerate", "1", "-capture_cursor", "0",
-            "-i", "0:none", "-frames:v", "1", "-update", "true", &screenshot_str,
-        ];
-
-        #[cfg(target_os = "linux")]
         let display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
-        #[cfg(target_os = "linux")]
         let display_input = format!("{}+0,0", display);
-        #[cfg(target_os = "linux")]
         let args = vec![
             "-y", "-f", "x11grab", "-framerate", "1", "-draw_mouse", "0",
             "-i", &display_input, "-frames:v", "1", "-update", "true", &screenshot_str,
@@ -354,19 +370,22 @@ pub async fn get_picker_screenshot(app: AppHandle) -> AppResult<String> {
         s.temp_dir.clone()
     };
 
-    // Return file path for asset protocol loading (BMP on Windows, PNG elsewhere)
+    // Return a data URL so picker overlays do not depend on asset-protocol
+    // image loading while their custom CSP and transparent windows are active.
     let bmp_path = temp_dir.join("picker_bg.bmp");
     let png_path = temp_dir.join("picker_bg.png");
 
-    let screenshot_path = if bmp_path.exists() {
-        bmp_path
+    let (screenshot_path, mime_type) = if bmp_path.exists() {
+        (bmp_path, "image/bmp")
     } else if png_path.exists() {
-        png_path
+        (png_path, "image/png")
     } else {
         return Err(AppError::General("No picker screenshot available".into()));
     };
 
-    Ok(screenshot_path.to_string_lossy().to_string())
+    let bytes = std::fs::read(&screenshot_path)?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(format!("data:{};base64,{}", mime_type, encoded))
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary
- Reduce launch-time memory pressure by avoiding FFmpeg encoder discovery unless explicitly forced.
- Restore usable Area and Window picker overlays with robust screenshot loading and unprotected picker windows.
- Fix frontend runtime imports and keep capturer/encoder lists stable after selection.

## Issues
- Fixes #36
- Fixes #53
- Fixes #54

## Commits
- 1b54f72eec7a9514926b2b73d8081846dbeb6893 - Fix frontend setup
- 6d7f75aa0b64eaaf5edb932b7f5821d29c6932c7 - Reduce launch encoder load
- d210ecc6ba3c42ab5c8a400bdd901fb02a072e7c - Fix picker overlays

## Verification
- npm run lint (0 errors, existing warnings only)
- npm run build:frontend
- cargo check --manifest-path src-tauri/Cargo.toml
- git diff --check
- Computer Use smoke test: main recording, Area picker, Settings, Projects