### PR TITLE
Keep macOS cursor visible while recording

### DIFF
--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -1141,8 +1141,6 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
                 }
                 Err(e) => {
                     log::error!("Failed to spawn FFmpeg: {}", e);
-                    #[cfg(target_os = "macos")]
-                    crate::mouse_tracker::restore_macos_cursor();
                     app.emit("recording-error", "CaptureError").ok();
                     if let Some(win) = app.get_webview_window("recorder") {
                         win.close().ok();
@@ -1223,10 +1221,6 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
         state.is_recording = false;
 
         state.mouse_tracker.stop();
-
-        // Defensive: ensure macOS system cursor is restored even if the Drop guard didn't fire
-        #[cfg(target_os = "macos")]
-        crate::mouse_tracker::restore_macos_cursor();
 
         let start_ts = state.recording_start_timestamp.unwrap_or(stop_timestamp);
         let events = state.mouse_tracker.get_events(start_ts);
@@ -1777,9 +1771,6 @@ fn kill_ffmpeg(app: &AppHandle) {
         let pid_val = pid.unwrap_or(0);
 
         if !is_window_capture {
-            #[cfg(target_os = "macos")]
-            crate::mouse_tracker::restore_macos_cursor();
-
             use std::io::Write;
             // Send "q\n" to FFmpeg stdin for graceful shutdown
             if let Some(ref mut stdin) = process.stdin.take() {

--- a/src-tauri/src/mouse_tracker.rs
+++ b/src-tauri/src/mouse_tracker.rs
@@ -449,44 +449,6 @@ impl MouseTracker {
     }
 }
 
-// macOS: hide/show system cursor during recording so screencapture doesn't bake it into the video
-#[cfg(target_os = "macos")]
-extern "C" {
-    fn CGMainDisplayID() -> u32;
-    fn CGDisplayHideCursor(display: u32) -> i32;
-    fn CGDisplayShowCursor(display: u32) -> i32;
-}
-
-#[cfg(target_os = "macos")]
-struct CursorHider {
-    hidden: bool,
-}
-
-#[cfg(target_os = "macos")]
-impl CursorHider {
-    fn hide() -> Self {
-        unsafe { CGDisplayHideCursor(CGMainDisplayID()); }
-        log::info!("[CursorHider] System cursor hidden");
-        Self { hidden: true }
-    }
-}
-
-#[cfg(target_os = "macos")]
-impl Drop for CursorHider {
-    fn drop(&mut self) {
-        if self.hidden {
-            unsafe { CGDisplayShowCursor(CGMainDisplayID()); }
-            log::info!("[CursorHider] System cursor restored");
-        }
-    }
-}
-
-/// Restore the system cursor (defensive call for error paths)
-#[cfg(target_os = "macos")]
-pub fn restore_macos_cursor() {
-    unsafe { CGDisplayShowCursor(CGMainDisplayID()); }
-}
-
 /// Detect the current macOS cursor type via NSCursor
 #[cfg(target_os = "macos")]
 fn detect_macos_cursor_type() -> &'static str {
@@ -543,10 +505,6 @@ impl MouseTracker {
             "[MouseTracker] macOS mouse tracking started (offset: {}, {}, scale: {})",
             offset_x, offset_y, scale_factor
         );
-
-        // Hide system cursor so screencapture records without it.
-        // The Drop impl restores cursor when this loop exits (including panics).
-        let _cursor_hider = CursorHider::hide();
 
         let poll_interval = std::time::Duration::from_millis(16); // ~60Hz polling
         let mut last_x: i32 = -1;
@@ -642,7 +600,6 @@ impl MouseTracker {
         }
 
         log::info!("[MouseTracker] macOS mouse tracking stopped");
-        // _cursor_hider drops here, restoring system cursor
     }
 }
 


### PR DESCRIPTION
Closes #74

## Summary
- Remove the macOS `CGDisplayHideCursor`/`CGDisplayShowCursor` cursor-hider path from mouse tracking.
- Stop calling the old cursor restore helper from recording error/stop/kill paths.
- Keep FFmpeg's `-capture_cursor 0` behavior so the raw recording still excludes the system cursor while Flowtake continues collecting cursor metadata for editor effects.

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo build --manifest-path src-tauri/Cargo.toml`
- Ran the rebuilt macOS debug app from this branch, started a recording, and captured a `screencapture -C` screenshot while recording. The arrow cursor was visible over normal app content outside the Dock.
- Confirmed recording still used `h264_videotoolbox`, RAM stayed in the hundreds of MB, FFmpeg exited after the test, and the generated `screen.mp4` validated with FFmpeg.