### PR TITLE
Fix Mac preview worker init

### DIFF
--- a/app/shared/scene/Camera.js
+++ b/app/shared/scene/Camera.js
@@ -1,4 +1,4 @@
-import { DropShadowFilter } from "pixi-filters"
+import { DropShadowFilter } from "pixi-filters/drop-shadow"
 import {
     BlurFilter,
     CanvasSource,

--- a/app/shared/scene/Scene.js
+++ b/app/shared/scene/Scene.js
@@ -22,6 +22,7 @@ import {
     SCREEN_VIDEO
 } from "../constants"
 import Roboto from "../assets/fonts/Roboto-Regular.ttf"
+import { createPixiAppOptions } from "./pixiAppOptions"
 import {
     CREATE_CURSORS,
     postAsync
@@ -72,15 +73,7 @@ export default class Scene {
         console.log("[Scene] createApp: creating Application")
         this.app = new Application()
         console.log("[Scene] createApp: calling app.init (preference=webgl)", { hasCanvas: !!canvas, canvasType: canvas?.constructor?.name })
-        await this.app.init({
-            canvas,
-            background: '#000',
-            autoStart: false,
-            antialias: true,
-            accessibilityOptions: { activateOnTab: false },
-            preference: "webgl", // TODO: at the moment webgl is faster in web workers. Do benchmarking after electron updates
-            useBackBuffer: true
-        })
+        await this.app.init(createPixiAppOptions(canvas))
         console.log("[Scene] createApp: app.init resolved")
 
         this.app.stage.sortableChildren = true

--- a/app/shared/scene/Screen.js
+++ b/app/shared/scene/Screen.js
@@ -1,4 +1,4 @@
-import { DropShadowFilter } from "pixi-filters"
+import { DropShadowFilter } from "pixi-filters/drop-shadow"
 import { CanvasSource, Container, Graphics, Sprite, Texture } from "pixi.js"
 import { shallowEqual } from "react-redux"
 import CanvasWrapper from "./CanvasWrapper"

--- a/app/shared/scene/pixiAppOptions.js
+++ b/app/shared/scene/pixiAppOptions.js
@@ -1,0 +1,12 @@
+export function createPixiAppOptions(canvas = null) {
+    return {
+        canvas,
+        background: "#000",
+        autoStart: false,
+        antialias: true,
+        accessibilityOptions: { activateOnTab: false },
+        preference: "webgl", // WebGL is currently faster in workers; benchmark again after runtime upgrades.
+        useBackBuffer: true,
+        manageImports: false
+    }
+}

--- a/app/shared/workers/PreviewWorkerManager.js
+++ b/app/shared/workers/PreviewWorkerManager.js
@@ -56,31 +56,47 @@ export default class PreviewWorkerManager extends WorkerManager {
     }
 
     async init(canvas, duration, args) {
-        const screenVideoDims = await this.getDimensions(PROJECT_SCREEN_VIDEO, args.projectId)
+        let phase = "read screen video dimensions"
 
-        let cameraVideoDims
-        if (args.hasCameraVideo) {
-            cameraVideoDims = await this.getDimensions(PROJECT_CAMERA_VIDEO, args.projectId)
-            await this.createSegmenter(cameraVideoDims)
+        try {
+            const screenVideoDims = await this.getDimensions(PROJECT_SCREEN_VIDEO, args.projectId)
+
+            let cameraVideoDims
+            if (args.hasCameraVideo) {
+                phase = "read camera video dimensions"
+                cameraVideoDims = await this.getDimensions(PROJECT_CAMERA_VIDEO, args.projectId)
+                phase = "create camera segmenter"
+                await this.createSegmenter(cameraVideoDims)
+            }
+            phase = "transfer preview canvas"
+            const offscreenCanvas = canvas.transferControlToOffscreen()
+
+            phase = "create initial screen frame"
+            const screenFrame = new VideoFrame(this.screenVideo)
+
+            let cameraFrame = null
+            if (args.hasCameraVideo) {
+                phase = "create initial camera frame"
+                cameraFrame = new VideoFrame(this.cameraVideo)
+            }
+
+            const transferList = [offscreenCanvas, screenFrame]
+            if (cameraFrame) transferList.push(cameraFrame)
+
+            phase = "initialize preview worker"
+            await this.postAsync(
+                INIT_PREVIEW,
+                { args, canvas: offscreenCanvas, duration, screenFrame, screenVideoDims, cameraFrame, cameraVideoDims },
+                undefined,
+                transferList
+            )
+
+            phase = "setup preview frame callbacks"
+            this.setupVideoFrameCallbacks(args.hasCameraVideo)
+        } catch (e) {
+            e.message = `${e?.message || String(e)} (during ${phase})`
+            throw e
         }
-        const offscreenCanvas = canvas.transferControlToOffscreen()
-
-        const screenFrame = new VideoFrame(this.screenVideo)
-
-        let cameraFrame = null
-        if (args.hasCameraVideo) cameraFrame = new VideoFrame(this.cameraVideo)
-
-        const transferList = [offscreenCanvas, screenFrame]
-        if (cameraFrame) transferList.push(cameraFrame)
-
-        await this.postAsync(
-            INIT_PREVIEW,
-            { args, canvas: offscreenCanvas, duration, screenFrame, screenVideoDims, cameraFrame, cameraVideoDims },
-            undefined,
-            transferList
-        )
-
-        this.setupVideoFrameCallbacks(args.hasCameraVideo)
     }
 
     setupVideoFrameCallbacks(hasCameraVideo) {

--- a/app/shared/workers/helpers.js
+++ b/app/shared/workers/helpers.js
@@ -35,6 +35,7 @@ export const postAsync = (recipient, type, payload, id = crypto.randomUUID(), tr
                 else {
                     const e = new Error(error.message)
                     e.name = error.name
+                    e.stack = error.stack
                     e.isCaptured = true
                     reject(e)
                 }

--- a/app/shared/workers/previewWorker.js
+++ b/app/shared/workers/previewWorker.js
@@ -1,4 +1,7 @@
 import "pixi.js/webworker"
+import "pixi.js/graphics"
+import "pixi.js/mesh"
+import "pixi.js/text"
 
 import PreviewScene from "../scene/PreviewScene"
 import {
@@ -11,7 +14,6 @@ import {
     workerConsole
 } from "./helpers"
 
-// eslint-disable-next-line no-console
 console.log("[previewWorker:boot] deps imported, replacing console")
 
 // Replace console methods with worker console
@@ -34,26 +36,36 @@ class PreviewRenderer {
     async init({ canvas, args, duration, screenFrame, screenVideoDims, cameraFrame, cameraVideoDims }) {
 
         console.log("[previewWorker] PreviewRenderer.init start", { screenVideoDims, hasCameraVideo: args.hasCameraVideo, duration })
+        let phase = "construct scene"
 
-        this.scene = new PreviewScene()
-        console.log("[previewWorker] PreviewScene constructed, calling createApp")
+        try {
+            this.scene = new PreviewScene()
+            console.log("[previewWorker] PreviewScene constructed, calling createApp")
 
-        await this.scene.createApp(canvas)
-        console.log("[previewWorker] createApp resolved")
+            phase = "create Pixi app"
+            await this.scene.createApp(canvas)
+            console.log("[previewWorker] createApp resolved")
 
-        this.scene.initScreenVideo(screenVideoDims, screenFrame)
-        console.log("[previewWorker] initScreenVideo done")
+            phase = "initialize screen video"
+            this.scene.initScreenVideo(screenVideoDims, screenFrame)
+            console.log("[previewWorker] initScreenVideo done")
 
-        if (args.hasCameraVideo) {
-            this.scene.initCameraVideo(cameraVideoDims, cameraFrame)
-            console.log("[previewWorker] initCameraVideo done")
+            if (args.hasCameraVideo) {
+                phase = "initialize camera video"
+                this.scene.initCameraVideo(cameraVideoDims, cameraFrame)
+                console.log("[previewWorker] initCameraVideo done")
+            }
+
+            phase = "initialize scene animators"
+            await this.scene.init(args, duration)
+            console.log("[previewWorker] scene.init resolved")
+
+            this.isInitialized = true
+            console.log("[previewWorker] PreviewRenderer.init DONE")
+        } catch (e) {
+            e.message = `${e?.message || String(e)} (during ${phase})`
+            throw e
         }
-
-        await this.scene.init(args, duration)
-        console.log("[previewWorker] scene.init resolved")
-
-        this.isInitialized = true
-        console.log("[previewWorker] PreviewRenderer.init DONE")
     }
 
     async setVideoFrame({ type, frame, mask, landmarks }) {
@@ -135,7 +147,11 @@ self.addEventListener('message', async (event) => {
         // via workerConsole, then propagate it back through the response so
         // postAsync rejects instead of hanging forever.
         console.error('[previewWorker] handler threw for type=' + type, e?.stack || e?.message || String(e))
-        error = { name: e?.name || 'Error', message: e?.message || String(e) }
+        error = {
+            name: e?.name || 'Error',
+            message: e?.message || String(e),
+            stack: e?.stack
+        }
     }
 
     if (expectsResponse) {

--- a/app/shared/workers/renderWorker.js
+++ b/app/shared/workers/renderWorker.js
@@ -1,3 +1,8 @@
+import "pixi.js/webworker"
+import "pixi.js/graphics"
+import "pixi.js/mesh"
+import "pixi.js/text"
+
 import { Mp4OutputFormat } from "mediabunny"
 import throttle from "throttleit"
 import {

--- a/app/windows/main/components/Preview.jsx
+++ b/app/windows/main/components/Preview.jsx
@@ -237,9 +237,11 @@ export default function Preview() {
 
     const createManager = useCallback(async () => {
         console.log("[Preview] createManager start", { duration, hasCameraVideo, projectId: id })
+        let phase = "construct preview worker manager"
         try {
             const manager = new PreviewWorkerManager(screenVideoRef.current, cameraVideoRef.current)
             console.log("[Preview] awaiting manager.init()")
+            phase = "initialize preview worker manager"
             await manager.init(
                 canvasRef.current,
                 duration,
@@ -249,6 +251,7 @@ export default function Preview() {
             setManager(manager)
             dispatch(setIsInitialized(true))
         } catch (e) {
+            e.message = `${e?.message || String(e)} (during ${phase})`
             console.error("[Preview] createManager failed:", e?.stack || e?.message || String(e))
             dispatch(addErrorToast("Failed to initialize preview: " + (e?.message || String(e))))
             // Allow re-entry so a retry (project reopen) can run createManager again.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "lint": "eslint --cache .",
+    "test": "node --test",
     "dev:frontend": "vite --config vite.config.mjs",
     "build:frontend": "vite build --config vite.config.mjs",
     "dev": "tauri dev",

--- a/test/pixiAppOptions.test.js
+++ b/test/pixiAppOptions.test.js
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { createPixiAppOptions } from "../app/shared/scene/pixiAppOptions.js"
+
+test("Pixi app options are safe for worker rendering", () => {
+    const canvas = { kind: "offscreen-canvas" }
+    const options = createPixiAppOptions(canvas)
+
+    assert.equal(options.canvas, canvas)
+    assert.equal(options.manageImports, false)
+    assert.equal(options.preference, "webgl")
+    assert.equal(options.useBackBuffer, true)
+    assert.deepEqual(options.accessibilityOptions, { activateOnTab: false })
+})

--- a/test/pixiWorkerImports.test.js
+++ b/test/pixiWorkerImports.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const rootDir = path.resolve(fileURLToPath(import.meta.url), "../..")
+const workerFiles = [
+    "app/shared/workers/previewWorker.js",
+    "app/shared/workers/renderWorker.js"
+]
+const requiredPixiImports = [
+    "pixi.js/webworker",
+    "pixi.js/graphics",
+    "pixi.js/mesh",
+    "pixi.js/text"
+]
+
+test("Pixi workers import the worker-safe rendering modules", async () => {
+    for (const workerFile of workerFiles) {
+        const source = await readFile(path.join(rootDir, workerFile), "utf8")
+
+        for (const specifier of requiredPixiImports) {
+            assert.match(source, new RegExp(`import "${specifier}"`), `${workerFile} should import ${specifier}`)
+        }
+    }
+})
+
+test("worker-rendered scene modules avoid browser-only Pixi filter barrels", async () => {
+    const sceneFiles = [
+        "app/shared/scene/Scene.js",
+        "app/shared/scene/Screen.js",
+        "app/shared/scene/Camera.js"
+    ]
+
+    for (const sceneFile of sceneFiles) {
+        const source = await readFile(path.join(rootDir, sceneFile), "utf8")
+
+        assert.doesNotMatch(
+            source,
+            /from ["']pixi-filters["']/,
+            `${sceneFile} should import concrete pixi-filters submodules`
+        )
+    }
+})


### PR DESCRIPTION
Fixes #76

## Summary
- Share Pixi app options between main-thread preview and worker rendering.
- Avoid browser-only Pixi/filter imports in preview/render workers.
- Make preview worker startup and cleanup safer after opening a saved recording.

## Verification
- Real macOS screen recording opened the editor preview successfully.
- Edited Breathe preset settings.
- Exported and verified a 480p MP4 with `ffprobe`.
- `npm test`
- `npm run lint -- --no-cache`
- `npm run build:frontend`
- `git diff --check`