### PR TITLE
Fix Mac window recording stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "lint": "eslint --cache .",
+    "test": "node --test",
     "dev:frontend": "vite --config vite.config.mjs",
     "build:frontend": "vite build --config vite.config.mjs",
     "dev": "tauri dev",

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -1742,8 +1742,9 @@ fn kill_ffmpeg(app: &AppHandle) {
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
     };
+    let uses_stdin_pipe = is_window_capture && cfg!(target_os = "windows");
 
-    if is_window_capture {
+    if uses_stdin_pipe {
         // Signal the capture thread to stop
         {
             let s = state.lock().unwrap();
@@ -1770,7 +1771,7 @@ fn kill_ffmpeg(app: &AppHandle) {
     if let Some(ref mut process) = process {
         let pid_val = pid.unwrap_or(0);
 
-        if !is_window_capture {
+        if !uses_stdin_pipe {
             use std::io::Write;
             // Send "q\n" to FFmpeg stdin for graceful shutdown
             if let Some(ref mut stdin) = process.stdin.take() {

--- a/test/recordingStop.test.js
+++ b/test/recordingStop.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const rootDir = path.resolve(fileURLToPath(import.meta.url), "../..")
+
+test("macOS window capture uses FFmpeg's graceful shutdown path", async () => {
+    const source = await readFile(path.join(rootDir, "src-tauri/src/commands/recording.rs"), "utf8")
+
+    assert.match(
+        source,
+        /let uses_stdin_pipe = is_window_capture && cfg!\(target_os = "windows"\);/,
+        "only the Windows PrintWindow pipe should use the stdin-pipe shutdown branch"
+    )
+    assert.match(
+        source,
+        /if !uses_stdin_pipe \{[\s\S]*stdin\.write_all\(b"q\\n"\)/,
+        "macOS window capture should still send q to FFmpeg so MP4 files finalize"
+    )
+})


### PR DESCRIPTION
Fixes #77

## Summary
- Stop treating macOS window captures as Windows stdin-pipe captures.
- Send FFmpeg the normal quit signal for macOS window/area/screen recording stops.
- Add coverage for platform-specific stop behavior.

## Verification
- Real macOS window recording opened the editor and produced a valid MP4.
- Real macOS area recording opened the editor and produced a valid MP4.
- Confirmed no FFmpeg process remained after stop/save.
- `npm test`
- `npm run lint -- --no-cache`
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features`