### PR TITLE
Reduce Mac memory use

### DIFF
--- a/app/shared/redux/store.js
+++ b/app/shared/redux/store.js
@@ -110,6 +110,7 @@ const filterSlices = isAnyOf(
 // Set of excluded action types for O(1) lookup
 const EXCLUDED_ACTION_TYPES = new Set([
     projectSlice.actions.setVideoDetails.type,
+    projectSlice.actions.setMouseEvents.type,
     clipSlice.actions.setClips.type,
     zoomSlice.actions.setZooms.type,
     cameraSlice.actions.setCameraZooms.type,

--- a/app/shared/renderState.js
+++ b/app/shared/renderState.js
@@ -1,0 +1,19 @@
+const DEFAULT_PROJECT_NAME = "Recording"
+
+export const getRenderProjectName = state =>
+    state?.undoableState?.present?.project?.name || DEFAULT_PROJECT_NAME
+
+export const createRenderableProjectState = (state, rendererDims = null) => {
+    if (!state?.undoableState?.present) return null
+
+    return {
+        animator: {
+            ...(state.animator ?? {}),
+            ...(rendererDims ? { rendererDims } : {})
+        },
+        panCoords: state.panCoords,
+        undoableState: {
+            present: state.undoableState.present
+        }
+    }
+}

--- a/app/windows/exporter/components/form/NewRenderForm.jsx
+++ b/app/windows/exporter/components/form/NewRenderForm.jsx
@@ -30,6 +30,10 @@ import {
 import { buildGitHubIssueUrl } from "@shared/errorReporting"
 import { EXPORT_PRESETS } from "@shared/exportPresets"
 import {
+    createRenderableProjectState,
+    getRenderProjectName
+} from "@shared/renderState"
+import {
     addRender,
     addToast,
     selectProjectState,
@@ -171,16 +175,14 @@ export default function Form({ onAdd, onCancel, isVisible }) {
 
     const onAddClicked = async () => {
         setIsInitializing(true)
-        const state = structuredClone(projectState)
 
         const [x, y] = resolutionString.split("x")
         const resolution = { x: Number(x), y: Number(y) }
+        const state = createRenderableProjectState(projectState, resolution)
 
-        state.animator.rendererDims = resolution
-        delete state.undoableState.past
-        delete state.undoableState.future
         const render = {
             state,
+            projectName: getRenderProjectName(projectState),
             status: RENDER_PENDING,
             config: { resolution, fps, aspectRatio, quality },
             upload: { isRequested: useShareableUrl && !!presignedUrl, presignedUrl, objectId },

--- a/app/windows/exporter/components/queue/Row.jsx
+++ b/app/windows/exporter/components/queue/Row.jsx
@@ -8,11 +8,16 @@ import {
     XCircleIcon
 } from "@heroicons/react/24/outline"
 import { CloudArrowUpIcon } from "@heroicons/react/24/solid"
-import { useQuery } from "@tanstack/react-query"
+import {
+    useQuery,
+    useQueryClient
+} from "@tanstack/react-query"
 import PropTypes from "prop-types"
 import {
     useCallback,
     useEffect,
+    useMemo,
+    useRef,
     useState
 } from "react"
 import {
@@ -44,21 +49,30 @@ import UploadStatus from "./UploadStatus"
 
 export default function Row({ id, onProcessed, onPreview, onUpload }) {
     const dispatch = useDispatch()
+    const queryClient = useQueryClient()
 
     const render = useSelector(state => selectRenderById(state, id))
     const progress = useSelector(selectProgress)
 
     const [uploadProgress, setUploadProgress] = useState(0)
+    const onProcessedRef = useRef(onProcessed)
+    const managerQueryKey = useMemo(() => ['manager', render.id, onProcessedRef], [render.id, onProcessedRef])
+    const projectName = render.projectName ?? render.state?.undoableState?.present?.project?.name ?? "Recording"
+
+    useEffect(() => {
+        onProcessedRef.current = onProcessed
+    }, [onProcessed])
 
     const { data: manager } = useQuery({
-        queryKey: ['manager', render.id, onProcessed],
+        queryKey: managerQueryKey,
         queryFn: async () => {
             const manager = new RenderWorkerManager(render)
-            await manager.start(onProcessed)
+            await manager.start(() => onProcessedRef.current())
             return manager
         },
         staleTime: Infinity,
-        enabled: render.status !== RENDER_PENDING
+        gcTime: 0,
+        enabled: isRenderRendering(render) && !!render.state
     })
 
     const remove = useCallback(() => dispatch(removeRender(id)), [dispatch, id])
@@ -90,12 +104,16 @@ export default function Row({ id, onProcessed, onPreview, onUpload }) {
             case RENDER_COMPLETED:
             case RENDER_CANCELED:
                 manager?.terminate()
+                queryClient.removeQueries({ queryKey: managerQueryKey, exact: true })
+                if (render.state) {
+                    dispatch(updateRender({ id, changes: { state: null } }))
+                }
                 break
             case RENDER_CANCELING:
                 manager?.cancel()
                 break
         }
-    }, [render.status, manager])
+    }, [dispatch, id, manager, managerQueryKey, queryClient, render.state, render.status])
 
     useEffect(() => {
         window.electron.ipcRenderer.on('upload-progress', (_e, progress) => setUploadProgress(progress))
@@ -147,7 +165,7 @@ export default function Row({ id, onProcessed, onPreview, onUpload }) {
                 {/* Info */}
                 <div className="flex-1 min-w-0">
                     <div className="text-xs font-medium truncate">
-                        {render.state.undoableState.present.project.name}
+                        {projectName}
                     </div>
                     <div className="text-[11px] opacity-40 mt-0.5">
                         {render.config.resolution.x}x{render.config.resolution.y}
@@ -205,14 +223,14 @@ export default function Row({ id, onProcessed, onPreview, onUpload }) {
                 {render.status === RENDER_COMPLETED && (
                     <div className="flex items-center gap-0.5 w-full">
                         <button
-                            onClick={() => onPreview(id, render.state.undoableState.present.project.name)}
+                            onClick={() => onPreview(id, projectName)}
                             className="text-[11px] font-medium text-primary/70 hover:text-primary flex items-center gap-1 transition-all"
                         >
                             <EyeIcon className="size-3.5" /> Preview
                         </button>
                         <span className="opacity-20 mx-1">&middot;</span>
                         <button
-                            onClick={() => onUpload(id, render.state.undoableState.present.project.name)}
+                            onClick={() => onUpload(id, projectName)}
                             className="text-[11px] opacity-40 hover:opacity-70 flex items-center gap-1 transition-all"
                         >
                             <ArrowUpTrayIcon className="size-3.5" /> Upload

--- a/app/windows/main/App.jsx
+++ b/app/windows/main/App.jsx
@@ -20,6 +20,7 @@ import {
 } from "@shared/helpers"
 import { addErrorToast } from "@shared/errorToastHelper"
 import { initSystemInfo } from "@shared/errorReporting"
+import { withPreventUndo } from "@shared/redux/actionEnhancers"
 import {
     addToast,
     selectCapturers,
@@ -226,7 +227,7 @@ export default function App() {
                     zoomBlurStrength, cameraZoomtargetScale, playbackRate, maskBlurStrength, maskAlpha, maskBorderRadius,
                     maskFill, intro, outro, zoomTargetScale)
                 console.log("[Flowtake] openProject returned", actions.length, "actions")
-                actions.forEach(action => dispatch(action))
+                actions.forEach(action => dispatch(withPreventUndo(action)))
             } catch (e) {
                 console.error("[Flowtake] Project creation error:", e)
                 dispatch(addErrorToast("Failed to open recording: " + (e?.message || String(e))))

--- a/app/windows/main/components/ExportButton.jsx
+++ b/app/windows/main/components/ExportButton.jsx
@@ -17,9 +17,9 @@ import Button from "../../../components/Button"
 import {
     EXPORTER_SECTION_NEW_RENDER,
     EXPORTER_SECTION_QUEUE,
-    getProjectState,
     TOAST_EXPORT_COMPLETED
 } from "@shared/helpers"
+import { createRenderableProjectState } from "@shared/renderState"
 import {
     dismissToastsByType,
     selectHasExports,
@@ -50,7 +50,7 @@ export default function ExportButton() {
         try {
             await window.electron.ipcRenderer.invoke(
                 "open-export-window",
-                hasProject ? getProjectState(currentState) : null,
+                hasProject ? createRenderableProjectState(currentState) : null,
                 section
             )
         } catch (e) {

--- a/app/windows/main/components/newRecording/NewRecording.jsx
+++ b/app/windows/main/components/newRecording/NewRecording.jsx
@@ -12,7 +12,7 @@ import {
 } from "@heroicons/react/24/outline"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import PropTypes from "prop-types"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   useDispatch,
   useSelector
@@ -98,26 +98,57 @@ export default function NewRecording({ isOpen }) {
 
   const prevPreviewRef = useRef(null)
   const [screenPermissionDenied, setScreenPermissionDenied] = useState(false)
+  const [previewUnavailable, setPreviewUnavailable] = useState(false)
+
+  const previewSource = useMemo(() => source ? {
+    id: source.id,
+    type: source.type,
+    name: source.name,
+    x: source.x,
+    y: source.y,
+    width: source.width,
+    height: source.height,
+    monitorX: source.monitorX,
+    monitorY: source.monitorY,
+    monitorWidth: source.monitorWidth,
+    monitorHeight: source.monitorHeight,
+    monitorIndex: source.monitorIndex,
+    physicalX: source.physicalX,
+    physicalY: source.physicalY,
+    physicalWidth: source.physicalWidth,
+    physicalHeight: source.physicalHeight,
+    scaleFactor: source.scaleFactor,
+  } : null, [source])
+
+  useEffect(() => {
+    prevPreviewRef.current = null
+    setPreviewUnavailable(false)
+    setScreenPermissionDenied(false)
+  }, [previewSource])
 
   const { data: captureSourcePreview, isPending: isPendingCaptureSourcePreview, isError: isPreviewError } = useQuery({
-    queryKey: ['captureSourcePreview', source?.id, source?.type, source?.name, source],
+    queryKey: ['captureSourcePreview', previewSource],
     queryFn: async () => {
       try {
-        const result = await window.electron.ipcRenderer.invoke("get-source-screenshot", source)
+        const result = await window.electron.ipcRenderer.invoke("get-source-screenshot", previewSource)
         if (screenPermissionDenied) setScreenPermissionDenied(false)
+        if (previewUnavailable) setPreviewUnavailable(false)
         return result
       } catch (e) {
         const msg = typeof e === 'string' ? e : e?.message || String(e)
         if (msg.includes("ScreenPermissionDenied")) {
           setScreenPermissionDenied(true)
         }
+        setPreviewUnavailable(true)
         throw e
       }
     },
+    enabled: isOpen && !!previewSource && !screenPermissionDenied && !previewUnavailable,
     gcTime: 0,
-    retry: 1,
-    // Stop polling when screen permission is denied to avoid spamming OS dialogs
-    refetchInterval: screenPermissionDenied ? false : 500,
+    retry: false,
+    // Keep preview fresh without creating a screenshot retry storm on macOS.
+    refetchInterval: 2000,
+    refetchIntervalInBackground: false,
   })
 
   // Keep previous frame visible during transitions for smooth crossfade
@@ -310,9 +341,8 @@ export default function NewRecording({ isOpen }) {
                 />
               )}
               {/* Current frame crossfades on top */}
-              {!isPendingCaptureSourcePreview && captureSourcePreview && !isPreviewError && (
+              {!isPendingCaptureSourcePreview && captureSourcePreview && !isPreviewError && !previewUnavailable && (
                 <img
-                  key={captureSourcePreview}
                   src={captureSourcePreview}
                   className="absolute inset-0 w-full h-full object-contain animate-[fadeIn_150ms_ease-out]"
                   onError={(e) => { e.target.style.display = 'none' }}
@@ -325,7 +355,7 @@ export default function NewRecording({ isOpen }) {
                   <span className="text-xs text-base-content/30">Loading preview</span>
                 </div>
               )}
-              {!isPendingCaptureSourcePreview && isPreviewError && !prevPreviewRef.current && (
+              {!isPendingCaptureSourcePreview && (isPreviewError || previewUnavailable) && !prevPreviewRef.current && (
                 <div className="flex flex-col items-center gap-2 z-10">
                   <ComputerDesktopIcon className="size-10 md:size-12 text-base-content/15" />
                   {screenPermissionDenied ? (

--- a/app/windows/main/components/projects/Projects.jsx
+++ b/app/windows/main/components/projects/Projects.jsx
@@ -15,6 +15,7 @@ import {
 } from "react-redux"
 import Button from "../../../../components/Button"
 import { openProject } from "@shared/helpers"
+import { withPreventUndo } from "@shared/redux/actionEnhancers"
 import { selectTargetScale as selectCameraZoomTargetScale } from "@shared/redux/cameraZoomSlice"
 import {
     selectLayout,
@@ -69,7 +70,7 @@ export default function Projects({ isOpen }) {
             const actions = await openProject(id, false, layout, microphoneAudioVolume, systemAudioVolume,
                 zoomBlurStrength, cameraZoomTargetScale, playbackRate, maskBlurStrength, maskAlpha, maskBorderRadius,
                 maskFill, intro, outro, zoomTargetScale)
-            actions.forEach(action => dispatch(action))
+            actions.forEach(action => dispatch(withPreventUndo(action)))
         }
         setIsOpening(false)
     }, [layout, microphoneAudioVolume, systemAudioVolume, zoomBlurStrength, cameraZoomTargetScale, playbackRate,

--- a/app/windows/main/components/projects/Row.jsx
+++ b/app/windows/main/components/projects/Row.jsx
@@ -18,6 +18,7 @@ import {
 import Button from "../../../../components/Button"
 import { openProject } from "@shared/helpers"
 import { addErrorToast } from "@shared/errorToastHelper"
+import { withPreventUndo } from "@shared/redux/actionEnhancers"
 import { setLoaderMessage } from "@shared/redux/appSlice"
 import { selectTargetScale as selectCameraZoomTargetScale } from "@shared/redux/cameraZoomSlice"
 import {
@@ -76,7 +77,7 @@ export default function ProjectRow({ project, refetch }) {
         const actions = await openProject(project.id, false, layout, microphoneAudioVolume, systemAudioVolume,
             zoomBlurStrength, cameraZoomTargetScale, playbackRate, maskBlurStrength, maskAlpha, maskBorderRadius,
             maskFill, intro, outro, zoomTargetScale, refetch)
-        actions.forEach(action => dispatch(action))
+        actions.forEach(action => dispatch(withPreventUndo(action)))
         setIsOpenProcessing(false)
     }, [dispatch, project.id, layout, microphoneAudioVolume, systemAudioVolume, zoomBlurStrength, cameraZoomTargetScale,
         playbackRate, maskBlurStrength, maskAlpha, maskBorderRadius, maskFill, intro, outro, zoomTargetScale, refetch])

--- a/app/windows/main/components/toasts/ExportCompletedToast.jsx
+++ b/app/windows/main/components/toasts/ExportCompletedToast.jsx
@@ -8,9 +8,9 @@ import {
 import Toast from "../../../../components/toasts/Toast"
 import {
     EXPORTER_SECTION_QUEUE,
-    getProjectState,
     TOAST_EXPORT_COMPLETED
 } from "@shared/helpers"
+import { createRenderableProjectState } from "@shared/renderState"
 import {
     dismissToastsByType,
     selectHasProject
@@ -25,7 +25,7 @@ export default function ExportCompletedToast({ text, id, dismiss }) {
     const handleShowQueue = useCallback(async () => {
         await window.electron.ipcRenderer.invoke(
             "open-export-window",
-            hasProject ? getProjectState(entireState) : null,
+            hasProject ? createRenderableProjectState(entireState) : null,
             EXPORTER_SECTION_QUEUE
         )
         dispatch(dismissToastsByType(TOAST_EXPORT_COMPLETED))

--- a/test/newRecordingPreview.test.js
+++ b/test/newRecordingPreview.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+    new URL("../app/windows/main/components/newRecording/NewRecording.jsx", import.meta.url),
+    "utf8"
+)
+
+test("source preview polling avoids screenshot retry storms", () => {
+    assert.match(source, /retry:\s*false/)
+    assert.match(source, /refetchInterval:\s*2000/)
+    assert.match(source, /refetchIntervalInBackground:\s*false/)
+    assert.match(source, /previewUnavailable/)
+    assert.doesNotMatch(source, /key=\{captureSourcePreview\}/)
+    assert.doesNotMatch(source, /queryKey:\s*\[[^\n]*source\?\.[^\n]*source\]/)
+})

--- a/test/renderState.test.js
+++ b/test/renderState.test.js
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+import {
+    createRenderableProjectState,
+    getRenderProjectName
+} from "../app/shared/renderState.js"
+
+test("renderable project state omits app state and undo history", () => {
+    const present = {
+        project: {
+            name: "Memory test",
+            mouseEvents: [{ x: 10, y: 20, timestamp: 30 }]
+        },
+        cursorCoords: { inertia: 0.5 }
+    }
+    const panCoords = { points: [{ x: 1, y: 2 }] }
+    const state = {
+        animator: {
+            rendererDims: { x: 1920, y: 1080 },
+            backgroundAlpha: 1
+        },
+        app: { toasts: ["unused"] },
+        editor: { isPlaying: false },
+        recorder: { isRecording: false },
+        timeline: { zoom: 1 },
+        panCoords,
+        undoableState: {
+            past: [{ project: { mouseEvents: new Array(100).fill({ x: 1 }) } }],
+            present,
+            future: [{ project: { mouseEvents: new Array(100).fill({ x: 2 }) } }]
+        }
+    }
+
+    const renderState = createRenderableProjectState(state, { x: 854, y: 480 })
+
+    assert.deepEqual(Object.keys(renderState).sort(), ["animator", "panCoords", "undoableState"])
+    assert.equal(renderState.undoableState.present, present)
+    assert.equal(renderState.panCoords, panCoords)
+    assert.deepEqual(renderState.animator.rendererDims, { x: 854, y: 480 })
+    assert.equal(renderState.animator.backgroundAlpha, 1)
+    assert.equal("past" in renderState.undoableState, false)
+    assert.equal("future" in renderState.undoableState, false)
+    assert.equal("app" in renderState, false)
+    assert.equal("editor" in renderState, false)
+    assert.equal("recorder" in renderState, false)
+    assert.equal("timeline" in renderState, false)
+})
+
+test("render project name falls back when state has already been released", () => {
+    assert.equal(getRenderProjectName({
+        undoableState: { present: { project: { name: "Launch clip" } } }
+    }), "Launch clip")
+    assert.equal(getRenderProjectName(null), "Recording")
+})
+
+test("large recording data is kept out of undo history on load", async () => {
+    const storeSource = await readFile(new URL("../app/shared/redux/store.js", import.meta.url), "utf8")
+    assert.match(storeSource, /projectSlice\.actions\.setMouseEvents\.type/)
+
+    const loadProjectFiles = [
+        "../app/windows/main/App.jsx",
+        "../app/windows/main/components/projects/Projects.jsx",
+        "../app/windows/main/components/projects/Row.jsx"
+    ]
+
+    await Promise.all(loadProjectFiles.map(async file => {
+        const source = await readFile(new URL(file, import.meta.url), "utf8")
+        assert.match(source, /withPreventUndo/)
+        assert.match(source, /actions\.forEach\(action => dispatch\(withPreventUndo\(action\)\)\)/)
+    }))
+})


### PR DESCRIPTION
Fixes #78

## Summary
- Slow and stabilize the recording source preview polling on macOS.
- Stop retry storms after screenshot failures and avoid using base64 screenshots as React keys.
- Send compact render-only state to exporter instead of cloning full Redux/undo history.
- Release completed render state and cached worker managers.
- Keep imported recording mouse events out of undo history.

## Verification
- Reproduced the dev app becoming non-responsive at about 6.48 GB before the fix.
- Relaunched the dev app after the fix and idled on the recording screen around 100-180 MB RSS, with repeated `screencapture` spam gone.
- `npm test`
- `npm run lint -- --no-cache`
- `npm run build:frontend`
- `git diff --check`

## Note
This PR is stacked on `Macbook-Preview` so it only shows the RAM-specific commit and avoids duplicating the preview fix.