### PR TITLE
feat(version): bump app to v1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowtake",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowtake",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@bmunozg/react-image-area": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flowtake",
   "productName": "Flowtake",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Screen recorder with automatic zoom animations",
   "type": "module",
   "author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "flowtake"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowtake"
-version = "1.4.2"
+version = "1.4.3"
 description = "Screen recorder with automatic zoom animations"
 authors = ["Jnx03 <jn03official@gmail.com>"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Flowtake",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "identifier": "com.flowtake.desktop",
   "build": {
     "beforeDevCommand": "npm run dev:frontend",

--- a/test/newRecordingPreview.test.js
+++ b/test/newRecordingPreview.test.js
@@ -9,9 +9,10 @@ const source = await readFile(
 
 test("source preview polling avoids screenshot retry storms", () => {
     assert.match(source, /retry:\s*false/)
-    assert.match(source, /refetchInterval:\s*2000/)
+    assert.match(source, /refetchInterval:\s*screenPermissionDenied \|\| previewUnavailable \? 5000 : 2000/)
     assert.match(source, /refetchIntervalInBackground:\s*false/)
     assert.match(source, /previewUnavailable/)
+    assert.match(source, /refetch:\s*refetchCaptureSourcePreview/)
     assert.doesNotMatch(source, /key=\{captureSourcePreview\}/)
     assert.doesNotMatch(source, /queryKey:\s*\[[^\n]*source\?\.[^\n]*source\]/)
 })

--- a/test/pixiWorkerImports.test.js
+++ b/test/pixiWorkerImports.test.js
@@ -21,7 +21,11 @@ test("Pixi workers import the worker-safe rendering modules", async () => {
         const source = await readFile(path.join(rootDir, workerFile), "utf8")
 
         for (const specifier of requiredPixiImports) {
-            assert.match(source, new RegExp(`import "${specifier}"`), `${workerFile} should import ${specifier}`)
+            assert.match(
+                source,
+                new RegExp(`import(?:\\(|\\s+)["']${specifier}["']`),
+                `${workerFile} should import ${specifier}`
+            )
         }
     }
 })

--- a/test/versionConsistency.test.js
+++ b/test/versionConsistency.test.js
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import test from "node:test"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+const readRepoFile = file => readFile(path.join(repoRoot, file), "utf8")
+
+function readCargoPackageVersion(source, packageName) {
+    const packageMatch = source.match(new RegExp(`\\[\\[package\\]\\]\\nname = "${packageName}"\\nversion = "([^"]+)"`))
+    assert.ok(packageMatch, `Expected ${packageName} package version in Cargo.lock`)
+    return packageMatch[1]
+}
+
+test("release manifests share the same app version", async () => {
+    const [
+        packageJson,
+        packageLockJson,
+        tauriConfig,
+        cargoToml,
+        cargoLock
+    ] = await Promise.all([
+        readRepoFile("package.json").then(JSON.parse),
+        readRepoFile("package-lock.json").then(JSON.parse),
+        readRepoFile("src-tauri/tauri.conf.json").then(JSON.parse),
+        readRepoFile("src-tauri/Cargo.toml"),
+        readRepoFile("src-tauri/Cargo.lock")
+    ])
+
+    const releaseVersion = packageJson.version
+
+    assert.match(releaseVersion, /^\d+\.\d+\.\d+$/)
+    assert.equal(packageLockJson.version, releaseVersion)
+    assert.equal(packageLockJson.packages[""].version, releaseVersion)
+    assert.equal(tauriConfig.version, releaseVersion)
+    assert.match(cargoToml, new RegExp(`^version = "${releaseVersion}"$`, "m"))
+    assert.equal(readCargoPackageVersion(cargoLock, "flowtake"), releaseVersion)
+})


### PR DESCRIPTION
## Summary

- Bump Flowtake app metadata from 1.4.2 to 1.4.3 across npm, Tauri, and Cargo manifests.
- Add a version consistency regression test so release manifests stay aligned.
- Refresh stale regression assertions for current preview polling and worker import behavior.

## Validation

- `npm test` passed, 23/23.
- `npm run build:frontend` passed.
- `cargo check --manifest-path src-tauri/Cargo.toml` passed.
- `npm run lint` passed with existing warnings.
- Dev frontend smoke check served the Flowtake shell from `http://127.0.0.1:5173/`.