### PR TITLE
Add cursor spotlight and harden recording permissions

### DIFF
--- a/app/shared/redux/cursorCoordsSlice.js
+++ b/app/shared/redux/cursorCoordsSlice.js
@@ -5,7 +5,11 @@ const initialState = {
     cutOff: 0,
     isLoop: false,
     blurStrength: .3,
-    showClickRing: true
+    showClickRing: true,
+    showSpotlight: false,
+    spotlightRadius: 160,
+    spotlightOpacity: .55,
+    spotlightFeather: 80
 }
 
 export const cursorCoordsSlice = createSlice({
@@ -20,7 +24,11 @@ export const cursorCoordsSlice = createSlice({
         setCutOff: (state, action) => { state.cutOff = action.payload },
         setIsLoop: (state, action) => { state.isLoop = action.payload },
         setBlurStrength: (state, action) => { state.blurStrength = action.payload },
-        setShowClickRing: (state, action) => { state.showClickRing = action.payload }
+        setShowClickRing: (state, action) => { state.showClickRing = action.payload },
+        setShowSpotlight: (state, action) => { state.showSpotlight = action.payload },
+        setSpotlightRadius: (state, action) => { state.spotlightRadius = action.payload },
+        setSpotlightOpacity: (state, action) => { state.spotlightOpacity = action.payload },
+        setSpotlightFeather: (state, action) => { state.spotlightFeather = action.payload }
     },
 })
 
@@ -32,7 +40,11 @@ export const {
     setCutOff,
     setIsLoop,
     setBlurStrength,
-    setShowClickRing
+    setShowClickRing,
+    setShowSpotlight,
+    setSpotlightRadius,
+    setSpotlightOpacity,
+    setSpotlightFeather
 } = cursorCoordsSlice.actions
 
 export const selectInertia = state => state.undoableState.present.cursorCoords.inertia
@@ -40,5 +52,9 @@ export const selectCutOff = state => state.undoableState.present.cursorCoords.cu
 export const selectIsLoop = state => state.undoableState.present.cursorCoords.isLoop
 export const selectBlurStrength = state => state.undoableState.present.cursorCoords.blurStrength
 export const selectShowClickRing = state => state.undoableState.present.cursorCoords.showClickRing
+export const selectShowSpotlight = state => state.undoableState.present.cursorCoords.showSpotlight
+export const selectSpotlightRadius = state => state.undoableState.present.cursorCoords.spotlightRadius
+export const selectSpotlightOpacity = state => state.undoableState.present.cursorCoords.spotlightOpacity
+export const selectSpotlightFeather = state => state.undoableState.present.cursorCoords.spotlightFeather
 
 export default cursorCoordsSlice.reducer

--- a/app/shared/scene/PreviewScene.js
+++ b/app/shared/scene/PreviewScene.js
@@ -73,24 +73,29 @@ export default class PreviewScene extends Scene {
                 this.screen.setState({ leftTrim: payload })
                 this.zoomAnimator.setState({ leftTrim: payload })
                 this.panAnimator.setState({ leftTrim: payload })
+                this.spotlightAnimator.setState({ leftTrim: payload })
                 break
             case 'project.rightTrim':
                 this.screen.setState({ rightTrim: payload })
                 this.zoomAnimator.setState({ rightTrim: payload })
                 this.panAnimator.setState({ rightTrim: payload })
+                this.spotlightAnimator.setState({ rightTrim: payload })
                 break
             case 'project.topTrim':
                 this.screen.setState({ topTrim: payload })
                 this.zoomAnimator.setState({ topTrim: payload })
                 this.panAnimator.setState({ topTrim: payload })
+                this.spotlightAnimator.setState({ topTrim: payload })
                 break
             case 'project.bottomTrim':
                 this.screen.setState({ bottomTrim: payload })
                 this.zoomAnimator.setState({ bottomTrim: payload })
                 this.panAnimator.setState({ bottomTrim: payload })
+                this.spotlightAnimator.setState({ bottomTrim: payload })
                 break
             case 'project.borderRadius':
                 this.screen.setState({ borderRadius: payload })
+                this.spotlightAnimator.setState({ borderRadius: payload })
                 break
             case 'cursorCoords.inertia':
                 this.cursorAnimator.setState({ inertia: payload })
@@ -107,6 +112,18 @@ export default class PreviewScene extends Scene {
                 break
             case 'cursorCoords.showClickRing':
                 this.clickAnimator.setState({ showClickRing: payload })
+                break
+            case 'cursorCoords.showSpotlight':
+                this.spotlightAnimator.setState({ showSpotlight: payload })
+                break
+            case 'cursorCoords.spotlightRadius':
+                this.spotlightAnimator.setState({ radius: payload })
+                break
+            case 'cursorCoords.spotlightOpacity':
+                this.spotlightAnimator.setState({ opacity: payload })
+                break
+            case 'cursorCoords.spotlightFeather':
+                this.spotlightAnimator.setState({ feather: payload })
                 break
             case 'project.cursorMovementRotation':
                 this.cursorAnimator.setState({ rotationStrength: payload })

--- a/app/shared/scene/RenderScene.js
+++ b/app/shared/scene/RenderScene.js
@@ -45,6 +45,10 @@ export default class RenderScene extends Scene {
             cursorBlurStrength,
             cursorMovementRotation,
             cursorScale,
+            showSpotlight,
+            spotlightRadius,
+            spotlightOpacity,
+            spotlightFeather,
             padding,
             shadowAlpha,
             cameraVideoShadowAlpha,
@@ -65,6 +69,18 @@ export default class RenderScene extends Scene {
             blurStrength: cursorBlurStrength,
             rotationStrength: cursorMovementRotation,
             isLoop: cursorIsLoop
+        })
+
+        this.spotlightAnimator.setState({
+            showSpotlight,
+            radius: spotlightRadius,
+            opacity: spotlightOpacity,
+            feather: spotlightFeather,
+            leftTrim: trim.left,
+            rightTrim: trim.right,
+            topTrim: trim.top,
+            bottomTrim: trim.bottom,
+            borderRadius
         })
 
         this.panAnimator.setState({

--- a/app/shared/scene/Scene.js
+++ b/app/shared/scene/Scene.js
@@ -40,6 +40,7 @@ import OverlayAnimator from "./overlay/OverlayAnimator"
 import PanAnimator from "./pan/PanAnimator"
 import Screen from "./Screen"
 import SpatialAnimator from "./spatial/SpatialAnimator"
+import SpotlightAnimator from "./spotlight/SpotlightAnimator"
 import SubtitleAnimator from "./subtitle/SubtitleAnimator"
 import TransitionAnimator from "./transition/TransitionAnimator"
 import ZoomAnimator from "./zoom/ZoomAnimator"
@@ -115,6 +116,8 @@ export default class Scene {
         this.clickAnimator = new ClickAnimator(this.cursorImageContainer, this.cursorContainer)
 
         this.cursorAnimator = new CursorAnimator(this.cursorContainer, this.motionBlur, mouseEvents, this.screen.dims, duration)
+
+        this.spotlightAnimator = new SpotlightAnimator(this.screen.spotlightContainer, this.cursorContainer, this.screen.dims)
 
         this.panAnimator = new PanAnimator(this.screen.container, this.zoomBlur, this.screen.dims, duration)
 
@@ -240,6 +243,7 @@ export default class Scene {
 
         this.clickAnimator?.update(this.time)
         this.cursorAnimator?.update(this.time)
+        this.spotlightAnimator?.update()
         this.subtitleAnimator?.update(this.time)
         this.cursorTypeAnimator?.update(this.time)
         const clipFrame = this.clipAnimator?.update(this.time)

--- a/app/shared/scene/Screen.js
+++ b/app/shared/scene/Screen.js
@@ -30,9 +30,11 @@ export default class Screen extends CanvasWrapper {
         this.container.filters = [this.shadow]
         
         this.maskContainer = new Container()
+        this.spotlightContainer = new Container()
 
         this.container.addChild(this.fg)
         this.container.addChild(this.maskContainer)
+        this.container.addChild(this.spotlightContainer)
         this.container.addChild(cursorContainer)
         this.container.addChild(this.fg.mask)
     }

--- a/app/shared/scene/spotlight/SpotlightAnimator.js
+++ b/app/shared/scene/spotlight/SpotlightAnimator.js
@@ -1,0 +1,135 @@
+import {
+    Container,
+    Graphics
+} from "pixi.js"
+import {
+    DEFAULT_SPOTLIGHT_FEATHER,
+    DEFAULT_SPOTLIGHT_OPACITY,
+    DEFAULT_SPOTLIGHT_RADIUS,
+    getSpotlightFeatherBands,
+    normalizeSpotlightConfig
+} from "./spotlightMath"
+
+export default class SpotlightAnimator {
+    constructor(container, cursor, screenVideoDimensions) {
+        this.cursor = cursor
+        this.screenVideoDimensions = screenVideoDimensions
+
+        this.wrapper = new Container()
+        this.wrapper.label = "spotlight-effect"
+        this.wrapper.visible = false
+
+        this.graphic = new Graphics()
+        this.clipMask = new Graphics()
+
+        this.wrapper.addChild(this.graphic)
+        this.wrapper.mask = this.clipMask
+
+        container.addChild(this.wrapper)
+        container.addChild(this.clipMask)
+
+        this.showSpotlight = false
+        this.radius = DEFAULT_SPOTLIGHT_RADIUS
+        this.opacity = DEFAULT_SPOTLIGHT_OPACITY
+        this.feather = DEFAULT_SPOTLIGHT_FEATHER
+        this.borderRadius = 0
+        this.trim = {
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0
+        }
+    }
+
+    update() {
+        if (!this.showSpotlight || !this.cursor.visible || this.opacity <= 0) {
+            this.wrapper.visible = false
+            return
+        }
+
+        const rect = this.getVisibleRect()
+        if (rect.width <= 0 || rect.height <= 0) {
+            this.wrapper.visible = false
+            return
+        }
+
+        this.drawClipMask(rect)
+        this.drawSpotlight(rect)
+        this.wrapper.visible = true
+    }
+
+    setState({
+        showSpotlight,
+        radius,
+        opacity,
+        feather,
+        leftTrim,
+        rightTrim,
+        topTrim,
+        bottomTrim,
+        borderRadius
+    }) {
+        if (showSpotlight !== undefined) this.showSpotlight = showSpotlight
+        if (radius !== undefined || opacity !== undefined || feather !== undefined) {
+            const config = normalizeSpotlightConfig({
+                radius: radius ?? this.radius,
+                opacity: opacity ?? this.opacity,
+                feather: feather ?? this.feather
+            })
+            this.radius = config.radius
+            this.opacity = config.opacity
+            this.feather = config.feather
+        }
+
+        if (leftTrim !== undefined) this.trim.left = leftTrim
+        if (rightTrim !== undefined) this.trim.right = rightTrim
+        if (topTrim !== undefined) this.trim.top = topTrim
+        if (bottomTrim !== undefined) this.trim.bottom = bottomTrim
+        if (borderRadius !== undefined) this.borderRadius = borderRadius
+    }
+
+    getVisibleRect() {
+        return {
+            x: this.trim.left,
+            y: this.trim.top,
+            width: Math.max(0, this.screenVideoDimensions.x - this.trim.left - this.trim.right),
+            height: Math.max(0, this.screenVideoDimensions.y - this.trim.top - this.trim.bottom)
+        }
+    }
+
+    drawClipMask(rect) {
+        const radius = Math.min(this.borderRadius, rect.width * .5, rect.height * .5)
+
+        this.clipMask.clear()
+        this.clipMask.roundRect(rect.x, rect.y, rect.width, rect.height, radius)
+        this.clipMask.fill({ color: 0x000000 })
+    }
+
+    drawSpotlight(rect) {
+        const x = this.cursor.position.x
+        const y = this.cursor.position.y
+        const outerRadius = this.radius + this.feather
+        const borderRadius = Math.min(this.borderRadius, rect.width * .5, rect.height * .5)
+
+        this.graphic.clear()
+        this.graphic.roundRect(rect.x, rect.y, rect.width, rect.height, borderRadius)
+        this.graphic.fill({ color: 0x000000, alpha: this.opacity })
+
+        this.graphic.circle(x, y, outerRadius)
+        this.graphic.cut()
+
+        getSpotlightFeatherBands(this.radius, this.feather, this.opacity).forEach(({ innerRadius, outerRadius, alpha }) => {
+            this.graphic.circle(x, y, outerRadius)
+            this.graphic.fill({ color: 0x000000, alpha })
+            this.graphic.circle(x, y, innerRadius)
+            this.graphic.cut()
+        })
+    }
+
+    destroy() {
+        this.wrapper.removeFromParent()
+        this.clipMask.removeFromParent()
+        this.wrapper.destroy({ children: true })
+        this.clipMask.destroy()
+    }
+}

--- a/app/shared/scene/spotlight/spotlightMath.js
+++ b/app/shared/scene/spotlight/spotlightMath.js
@@ -1,0 +1,33 @@
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max)
+
+export const DEFAULT_SPOTLIGHT_RADIUS = 160
+export const DEFAULT_SPOTLIGHT_OPACITY = .55
+export const DEFAULT_SPOTLIGHT_FEATHER = 80
+
+export const normalizeSpotlightConfig = ({
+    radius = DEFAULT_SPOTLIGHT_RADIUS,
+    opacity = DEFAULT_SPOTLIGHT_OPACITY,
+    feather = DEFAULT_SPOTLIGHT_FEATHER
+} = {}) => ({
+    radius: clamp(Number.isFinite(radius) ? radius : DEFAULT_SPOTLIGHT_RADIUS, 1, 2000),
+    opacity: clamp(Number.isFinite(opacity) ? opacity : DEFAULT_SPOTLIGHT_OPACITY, 0, .95),
+    feather: clamp(Number.isFinite(feather) ? feather : DEFAULT_SPOTLIGHT_FEATHER, 0, 1000)
+})
+
+export const getSpotlightFeatherBands = (radius, feather, opacity) => {
+    const config = normalizeSpotlightConfig({ radius, feather, opacity })
+    if (config.feather <= 0 || config.opacity <= 0) return []
+
+    const steps = Math.min(10, Math.max(4, Math.ceil(config.feather / 18)))
+
+    return Array.from({ length: steps }, (_, index) => {
+        const innerT = index / steps
+        const outerT = (index + 1) / steps
+
+        return {
+            innerRadius: config.radius + config.feather * innerT,
+            outerRadius: config.radius + config.feather * outerT,
+            alpha: config.opacity * Math.pow(outerT, 1.7)
+        }
+    })
+}

--- a/app/shared/workers/renderWorker.js
+++ b/app/shared/workers/renderWorker.js
@@ -25,7 +25,11 @@ import {
     selectCutOff,
     selectInertia,
     selectIsLoop,
-    selectShowClickRing
+    selectShowClickRing,
+    selectShowSpotlight,
+    selectSpotlightFeather,
+    selectSpotlightOpacity,
+    selectSpotlightRadius
 } from "../redux/cursorCoordsSlice"
 import {
     selectAllCursorTypes,
@@ -165,6 +169,10 @@ class WorkerRenderer {
                 cursorBlurStrength: selectBlurStrength(this.render.state),
                 cursorMovementRotation: selectCursorMovementRotation(this.render.state),
                 cursorScale: selectCursorScale(this.render.state),
+                showSpotlight: selectShowSpotlight(this.render.state),
+                spotlightRadius: selectSpotlightRadius(this.render.state),
+                spotlightOpacity: selectSpotlightOpacity(this.render.state),
+                spotlightFeather: selectSpotlightFeather(this.render.state),
                 padding: selectPadding(this.render.state),
                 shadowAlpha: selectShadowAlpha(this.render.state),
                 cameraVideoShadowAlpha: selectCameraVideoShadowAlpha(this.render.state),

--- a/app/windows/main/components/Preview.jsx
+++ b/app/windows/main/components/Preview.jsx
@@ -45,7 +45,11 @@ import {
     selectCutOff,
     selectInertia,
     selectIsLoop,
-    selectShowClickRing
+    selectShowClickRing,
+    selectShowSpotlight,
+    selectSpotlightFeather,
+    selectSpotlightOpacity,
+    selectSpotlightRadius
 } from "@shared/redux/cursorCoordsSlice"
 import {
     selectAllCursorTypes,
@@ -195,6 +199,10 @@ export default function Preview() {
     const cursorIsLoop = useSelector(selectIsLoop)
     const clickAnims = useSelector(selectAllClicks)
     const showClickRing = useSelector(selectShowClickRing)
+    const showSpotlight = useSelector(selectShowSpotlight)
+    const spotlightRadius = useSelector(selectSpotlightRadius)
+    const spotlightOpacity = useSelector(selectSpotlightOpacity)
+    const spotlightFeather = useSelector(selectSpotlightFeather)
     const cursorScale = useSelector(selectCursorScale)
     const hasCameraVideo = useSelector(selectHasCameraVideo)
     const padding = useSelector(selectPadding)
@@ -498,6 +506,22 @@ export default function Preview() {
     useEffect(() => {
         manager?.postUpdate({ type: 'cursorCoords.showClickRing', payload: showClickRing })
     }, [manager, showClickRing])
+
+    useEffect(() => {
+        manager?.postUpdate({ type: 'cursorCoords.showSpotlight', payload: showSpotlight })
+    }, [manager, showSpotlight])
+
+    useEffect(() => {
+        manager?.postUpdate({ type: 'cursorCoords.spotlightRadius', payload: spotlightRadius })
+    }, [manager, spotlightRadius])
+
+    useEffect(() => {
+        manager?.postUpdate({ type: 'cursorCoords.spotlightOpacity', payload: spotlightOpacity })
+    }, [manager, spotlightOpacity])
+
+    useEffect(() => {
+        manager?.postUpdate({ type: 'cursorCoords.spotlightFeather', payload: spotlightFeather })
+    }, [manager, spotlightFeather])
 
     useEffect(() => {
         manager?.postUpdate({ type: 'project.cursorMovementRotation', payload: cursorRotationStrength })

--- a/app/windows/main/components/properties/CursorSection.jsx
+++ b/app/windows/main/components/properties/CursorSection.jsx
@@ -7,7 +7,8 @@ import {
 import {
     formatFixed,
     formatMs,
-    formatPercent
+    formatPercent,
+    formatPx
 } from "@shared/helpers"
 import { withGroup } from "@shared/redux/actionEnhancers"
 import {
@@ -16,11 +17,19 @@ import {
     selectInertia,
     selectIsLoop,
     selectShowClickRing,
+    selectShowSpotlight,
+    selectSpotlightFeather,
+    selectSpotlightOpacity,
+    selectSpotlightRadius,
     setBlurStrength,
     setCutOff,
     setInertia,
     setIsLoop,
-    setShowClickRing
+    setShowClickRing,
+    setShowSpotlight,
+    setSpotlightFeather,
+    setSpotlightOpacity,
+    setSpotlightRadius
 } from "@shared/redux/cursorCoordsSlice"
 import { selectIsStatic, setIsStatic } from "@shared/redux/cursorTypeSlice"
 import {
@@ -53,6 +62,10 @@ export default function CursorSection() {
     const cursorShadowAlpha = useSelector(selectCursorShadowAlpha)
     const cursorMovementRotation = useSelector(selectCursorMovementRotation)
     const showClickRing = useSelector(selectShowClickRing)
+    const showSpotlight = useSelector(selectShowSpotlight)
+    const spotlightRadius = useSelector(selectSpotlightRadius)
+    const spotlightOpacity = useSelector(selectSpotlightOpacity)
+    const spotlightFeather = useSelector(selectSpotlightFeather)
 
     const onChangeCursorScale = useCallback((value, group) => dispatch(withGroup(setCursorScale(value), group)), [dispatch])
 
@@ -77,6 +90,14 @@ export default function CursorSection() {
 
     const onChangeShowClickRing = useCallback(event => dispatch(setShowClickRing(event.target.checked)), [dispatch])
 
+    const onChangeShowSpotlight = useCallback(event => dispatch(setShowSpotlight(event.target.checked)), [dispatch])
+
+    const onChangeSpotlightRadius = useCallback((value, group) => dispatch(withGroup(setSpotlightRadius(value), group)), [dispatch])
+
+    const onChangeSpotlightOpacity = useCallback((value, group) => dispatch(withGroup(setSpotlightOpacity(value), group)), [dispatch])
+
+    const onChangeSpotlightFeather = useCallback((value, group) => dispatch(withGroup(setSpotlightFeather(value), group)), [dispatch])
+
     return (
         <Card icon={<CursorArrowRippleIcon className="w-6 h-6" />} title="Cursor">
             <>
@@ -90,6 +111,18 @@ export default function CursorSection() {
 
                 <Fieldset legend="Click Ring" description="Show a yellow ring effect around the cursor on mouse clicks. Individual click rings can be further customized in the timeline.">
                     <Toggle leftLabel="Click Ring" value={showClickRing} onChange={onChangeShowClickRing} />
+                </Fieldset>
+
+                <Fieldset legend="Spotlight Effect" description="Darkens the screen while keeping a circular area around the cursor visible.">
+                    <Toggle leftLabel="Spotlight" value={showSpotlight} onChange={onChangeShowSpotlight} />
+                    {showSpotlight && <>
+                        <Slider min={60} max={360} value={spotlightRadius} onChange={onChangeSpotlightRadius}
+                            label="Radius" format={formatPx} />
+                        <Slider value={spotlightOpacity} onChange={onChangeSpotlightOpacity}
+                            label="Opacity" format={formatPercent} />
+                        <Slider min={0} max={180} value={spotlightFeather} onChange={onChangeSpotlightFeather}
+                            label="Feather" format={formatPx} />
+                    </>}
                 </Fieldset>
 
                 <Fieldset legend="Smoothing" description="Cursor Smoothing removes jittery movements but can also remove some fidelity, e.g. near mouse clicks.">

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1614,17 +1614,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -1632,7 +1621,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2677,7 +2666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -3164,11 +3153,9 @@ dependencies = [
 [[package]]
 name = "phf_generator"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared 0.8.0",
- "rand 0.7.3",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3178,7 +3165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3188,7 +3175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3517,7 +3504,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3566,23 +3553,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3591,22 +3564,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3631,15 +3594,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -3654,24 +3608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4869,7 +4805,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5650,12 +5586,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -71,6 +71,11 @@ cocoa = "0.26"
 x11 = { version = "2.21", features = ["xlib", "xrandr", "xrecord", "xinput"] }
 libpulse-binding = "2.28"
 
+[patch.crates-io]
+# tauri-utils still pulls kuchikiki -> selectors -> phf_generator 0.8.
+# Keep that old PHF API but move its RNG dependency onto patched rand 0.8.6.
+phf_generator = { path = "vendor/phf_generator-0.8.0" }
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,11 +1,11 @@
-use crate::error::AppResult;
 #[cfg(not(target_os = "windows"))]
 use crate::error::AppError;
-use serde::{Serialize, Deserialize};
+use crate::error::AppResult;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::{AppHandle, Emitter};
-use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_autostart::ManagerExt;
+use tauri_plugin_dialog::DialogExt;
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateInfo {
@@ -61,13 +61,23 @@ pub struct SystemInfo {
 pub async fn get_system_info(app: AppHandle) -> AppResult<SystemInfo> {
     use sysinfo::System;
 
-    let version = app.config().version.clone().unwrap_or_else(|| "0.0.0".to_string());
+    let version = app
+        .config()
+        .version
+        .clone()
+        .unwrap_or_else(|| "0.0.0".to_string());
     let os = std::env::consts::OS.to_string();
     let arch = std::env::consts::ARCH.to_string();
     let os_version = System::os_version().unwrap_or_else(|| "unknown".to_string());
     let ram_gb = System::new_all().total_memory() as f64 / 1_073_741_824.0;
 
-    Ok(SystemInfo { version, os, os_version, arch, ram_gb })
+    Ok(SystemInfo {
+        version,
+        os,
+        os_version,
+        arch,
+        ram_gb,
+    })
 }
 
 #[tauri::command]
@@ -79,19 +89,7 @@ pub async fn get_is_sentry_enabled() -> AppResult<bool> {
 
 #[cfg(target_os = "macos")]
 pub fn macos_has_screen_recording_permission() -> bool {
-    use core_graphics::display::{CGDisplay, CGPoint, CGRect, CGSize};
-    use core_graphics::window::{
-        kCGNullWindowID, kCGWindowImageDefault, kCGWindowListOptionOnScreenOnly,
-    };
-
-    let rect = CGRect::new(&CGPoint::new(0.0, 0.0), &CGSize::new(1.0, 1.0));
-    CGDisplay::screenshot(
-        rect,
-        kCGWindowListOptionOnScreenOnly,
-        kCGNullWindowID,
-        kCGWindowImageDefault,
-    )
-    .is_some()
+    core_graphics::access::ScreenCaptureAccess::default().preflight()
 }
 
 #[tauri::command]
@@ -189,8 +187,12 @@ fn is_newer_version(latest: &str, current: &str) -> bool {
     for i in 0..l.len().max(c.len()) {
         let lv = l.get(i).copied().unwrap_or(0);
         let cv = c.get(i).copied().unwrap_or(0);
-        if lv > cv { return true; }
-        if lv < cv { return false; }
+        if lv > cv {
+            return true;
+        }
+        if lv < cv {
+            return false;
+        }
     }
     false
 }
@@ -207,7 +209,11 @@ fn platform_asset_patterns() -> Vec<&'static str> {
 
 #[tauri::command]
 pub async fn check_for_updates(app: AppHandle) -> AppResult<Value> {
-    let current_version = app.config().version.clone().unwrap_or_else(|| "0.0.0".to_string());
+    let current_version = app
+        .config()
+        .version
+        .clone()
+        .unwrap_or_else(|| "0.0.0".to_string());
 
     let client = reqwest::Client::new();
     let response = client
@@ -244,22 +250,44 @@ pub async fn check_for_updates(app: AppHandle) -> AppResult<Value> {
         }
     };
 
-    let tag = json.get("tag_name").and_then(|v| v.as_str()).unwrap_or("0.0.0");
+    let tag = json
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("0.0.0");
     let latest_version = tag.trim_start_matches('v').to_string();
-    let release_notes = json.get("body").and_then(|v| v.as_str()).unwrap_or("").to_string();
-    let published_at = json.get("published_at").and_then(|v| v.as_str()).unwrap_or("").to_string();
-    let html_url = json.get("html_url").and_then(|v| v.as_str()).unwrap_or("").to_string();
+    let release_notes = json
+        .get("body")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let published_at = json
+        .get("published_at")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let html_url = json
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
 
     // Find platform-specific download asset
     let patterns = platform_asset_patterns();
-    let download_url = json.get("assets")
+    let download_url = json
+        .get("assets")
         .and_then(|a| a.as_array())
         .and_then(|assets| {
             assets.iter().find_map(|asset| {
                 let name = asset.get("name").and_then(|n| n.as_str()).unwrap_or("");
                 let name_lower = name.to_lowercase();
-                if patterns.iter().any(|p| name_lower.ends_with(&p.to_lowercase())) {
-                    asset.get("browser_download_url").and_then(|u| u.as_str()).map(|s| s.to_string())
+                if patterns
+                    .iter()
+                    .any(|p| name_lower.ends_with(&p.to_lowercase()))
+                {
+                    asset
+                        .get("browser_download_url")
+                        .and_then(|u| u.as_str())
+                        .map(|s| s.to_string())
                 } else {
                     None
                 }
@@ -311,9 +339,10 @@ pub async fn download_update(app: AppHandle, download_url: String) -> AppResult<
         .map_err(|e| crate::error::AppError::General(format!("Download failed: {}", e)))?;
 
     if !response.status().is_success() {
-        return Err(crate::error::AppError::General(
-            format!("Download returned HTTP {}", response.status()),
-        ));
+        return Err(crate::error::AppError::General(format!(
+            "Download returned HTTP {}",
+            response.status()
+        )));
     }
 
     let total_bytes = response.content_length().unwrap_or(0);
@@ -323,12 +352,19 @@ pub async fn download_update(app: AppHandle, download_url: String) -> AppResult<
         .rsplit('/')
         .next()
         .and_then(|name| {
-            if name.to_lowercase().ends_with(".exe") { Some("exe") }
-            else if name.to_lowercase().ends_with(".msi") { Some("msi") }
-            else if name.to_lowercase().ends_with(".dmg") { Some("dmg") }
-            else if name.to_lowercase().ends_with(".appimage") { Some("AppImage") }
-            else if name.to_lowercase().ends_with(".deb") { Some("deb") }
-            else { None }
+            if name.to_lowercase().ends_with(".exe") {
+                Some("exe")
+            } else if name.to_lowercase().ends_with(".msi") {
+                Some("msi")
+            } else if name.to_lowercase().ends_with(".dmg") {
+                Some("dmg")
+            } else if name.to_lowercase().ends_with(".appimage") {
+                Some("AppImage")
+            } else if name.to_lowercase().ends_with(".deb") {
+                Some("deb")
+            } else {
+                None
+            }
         })
         .unwrap_or("bin");
 
@@ -366,11 +402,16 @@ pub async fn download_update(app: AppHandle, download_url: String) -> AppResult<
         // Emit progress every 1% to avoid flooding events
         if (percent - last_emitted_percent) >= 1.0 || bytes_downloaded == total_bytes {
             last_emitted_percent = percent;
-            app.emit_to("main", "update-download-progress", DownloadProgress {
-                bytes_downloaded,
-                total_bytes,
-                percent,
-            }).ok();
+            app.emit_to(
+                "main",
+                "update-download-progress",
+                DownloadProgress {
+                    bytes_downloaded,
+                    total_bytes,
+                    percent,
+                },
+            )
+            .ok();
         }
     }
 
@@ -409,7 +450,9 @@ pub async fn launch_installer(installer_path: String) -> AppResult<()> {
                 .arg("/S")
                 .creation_flags(0x08000000) // CREATE_NO_WINDOW
                 .spawn()
-                .map_err(|e| crate::error::AppError::General(format!("Failed to launch installer: {}", e)))?;
+                .map_err(|e| {
+                    crate::error::AppError::General(format!("Failed to launch installer: {}", e))
+                })?;
         }
         #[cfg(target_os = "windows")]
         "msi" => {
@@ -418,7 +461,9 @@ pub async fn launch_installer(installer_path: String) -> AppResult<()> {
                 .args(["/i", &installer_path, "/quiet", "/norestart"])
                 .creation_flags(0x08000000)
                 .spawn()
-                .map_err(|e| crate::error::AppError::General(format!("Failed to launch MSI: {}", e)))?;
+                .map_err(|e| {
+                    crate::error::AppError::General(format!("Failed to launch MSI: {}", e))
+                })?;
         }
         #[cfg(target_os = "macos")]
         "dmg" => {
@@ -430,21 +475,28 @@ pub async fn launch_installer(installer_path: String) -> AppResult<()> {
         "appimage" => {
             use std::os::unix::fs::PermissionsExt;
             let mut perms = std::fs::metadata(&installer_path)
-                .map_err(|e| crate::error::AppError::General(format!("Failed to get permissions: {}", e)))?
+                .map_err(|e| {
+                    crate::error::AppError::General(format!("Failed to get permissions: {}", e))
+                })?
                 .permissions();
             perms.set_mode(0o755);
-            std::fs::set_permissions(&installer_path, perms)
-                .map_err(|e| crate::error::AppError::General(format!("Failed to set permissions: {}", e)))?;
+            std::fs::set_permissions(&installer_path, perms).map_err(|e| {
+                crate::error::AppError::General(format!("Failed to set permissions: {}", e))
+            })?;
             std::process::Command::new(&installer_path)
                 .spawn()
-                .map_err(|e| crate::error::AppError::General(format!("Failed to launch AppImage: {}", e)))?;
+                .map_err(|e| {
+                    crate::error::AppError::General(format!("Failed to launch AppImage: {}", e))
+                })?;
         }
         #[cfg(target_os = "linux")]
         "deb" => {
             std::process::Command::new("pkexec")
                 .args(["dpkg", "-i", &installer_path])
                 .spawn()
-                .map_err(|e| crate::error::AppError::General(format!("Failed to install deb: {}", e)))?;
+                .map_err(|e| {
+                    crate::error::AppError::General(format!("Failed to install deb: {}", e))
+                })?;
         }
         _ => {
             // Fallback: open with default handler
@@ -476,15 +528,26 @@ pub async fn get_changelog() -> AppResult<Value> {
         Err(_) => return Ok(serde_json::json!([])),
     };
 
-    let entries: Vec<ChangelogEntry> = json.as_array()
+    let entries: Vec<ChangelogEntry> = json
+        .as_array()
         .unwrap_or(&vec![])
         .iter()
-        .map(|release| {
-            ChangelogEntry {
-                version: release.get("tag_name").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                release_notes: release.get("body").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-                published_at: release.get("published_at").and_then(|v| v.as_str()).unwrap_or("").to_string(),
-            }
+        .map(|release| ChangelogEntry {
+            version: release
+                .get("tag_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            release_notes: release
+                .get("body")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            published_at: release
+                .get("published_at")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
         })
         .collect();
 
@@ -554,15 +617,13 @@ pub async fn check_dependencies(app: AppHandle) -> AppResult<Value> {
     };
 
     #[allow(unused_mut)]
-    let mut deps = vec![
-        serde_json::json!({
-            "name": "FFmpeg",
-            "command": "ffmpeg",
-            "installed": has_ffmpeg,
-            "required": true,
-            "description": "Required for screen recording and video processing"
-        }),
-    ];
+    let mut deps = vec![serde_json::json!({
+        "name": "FFmpeg",
+        "command": "ffmpeg",
+        "installed": has_ffmpeg,
+        "required": true,
+        "description": "Required for screen recording and video processing"
+    })];
 
     #[cfg(target_os = "linux")]
     {
@@ -627,7 +688,8 @@ pub async fn check_dependencies(app: AppHandle) -> AppResult<Value> {
 
 /// Generate a platform-specific install command for missing dependencies
 fn get_install_command(deps: &[Value]) -> String {
-    let missing: Vec<&str> = deps.iter()
+    let missing: Vec<&str> = deps
+        .iter()
         .filter(|d| {
             let installed = d.get("installed").and_then(|v| v.as_bool()).unwrap_or(true);
             !installed
@@ -643,7 +705,7 @@ fn get_install_command(deps: &[Value]) -> String {
 
     #[cfg(target_os = "macos")]
     {
-        return format!("brew install {}", _packages);
+        format!("brew install {}", _packages)
     }
 
     #[cfg(target_os = "linux")]
@@ -678,7 +740,10 @@ fn get_install_command(deps: &[Value]) -> String {
 #[tauri::command]
 pub async fn install_dependencies(app: AppHandle) -> AppResult<Value> {
     let deps = check_dependencies(app.clone()).await?;
-    let all_installed = deps.get("allInstalled").and_then(|v| v.as_bool()).unwrap_or(true);
+    let all_installed = deps
+        .get("allInstalled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
 
     if all_installed {
         return Ok(serde_json::json!({
@@ -687,7 +752,8 @@ pub async fn install_dependencies(app: AppHandle) -> AppResult<Value> {
         }));
     }
 
-    let install_cmd = deps.get("installCommand")
+    let install_cmd = deps
+        .get("installCommand")
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
@@ -711,7 +777,7 @@ pub async fn install_dependencies(app: AppHandle) -> AppResult<Value> {
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-        return Ok(serde_json::json!({
+        Ok(serde_json::json!({
             "success": output.status.success(),
             "message": if output.status.success() {
                 "Dependencies installed successfully. Please restart Flowtake."
@@ -721,7 +787,7 @@ pub async fn install_dependencies(app: AppHandle) -> AppResult<Value> {
             "stdout": stdout,
             "stderr": stderr,
             "command": install_cmd
-        }));
+        }))
     }
 
     #[cfg(target_os = "linux")]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,11 +13,36 @@ pub mod windows;
 
 use tauri_plugin_shell::ShellExt;
 
+#[cfg(target_os = "macos")]
+pub async fn run_macos_screencapture(
+    args: &[&str],
+    timeout: std::time::Duration,
+) -> Result<std::process::Output, crate::error::AppError> {
+    let mut command = tokio::process::Command::new("screencapture");
+    command
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let child = command
+        .spawn()
+        .map_err(|e| crate::error::AppError::General(format!("screencapture error: {}", e)))?;
+
+    tokio::time::timeout(timeout, child.wait_with_output())
+        .await
+        .map_err(|_| crate::error::AppError::General("ScreenCaptureTimedOut".to_string()))?
+        .map_err(|e| crate::error::AppError::General(format!("screencapture error: {}", e)))
+}
+
 /// Helper to get FFmpeg command from an AppHandle.
 /// Tries the bundled sidecar first, then falls back to system-installed FFmpeg.
 /// This ensures the app works on macOS/Linux where FFmpeg may not be bundled as a sidecar
 /// but is installed system-wide (via Homebrew, apt, etc.).
-pub fn ffmpeg_from_app(app: &tauri::AppHandle) -> Result<tauri_plugin_shell::process::Command, crate::error::AppError> {
+pub fn ffmpeg_from_app(
+    app: &tauri::AppHandle,
+) -> Result<tauri_plugin_shell::process::Command, crate::error::AppError> {
     let shell = app.shell();
     match shell.sidecar("ffmpeg") {
         Ok(cmd) => Ok(cmd),

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -46,7 +46,11 @@ fn resolve_ffmpeg_path() -> Option<std::path::PathBuf> {
     }
 
     // Try plain name (with extension on Windows)
-    let plain_name = if cfg!(target_os = "windows") { "ffmpeg.exe" } else { "ffmpeg" };
+    let plain_name = if cfg!(target_os = "windows") {
+        "ffmpeg.exe"
+    } else {
+        "ffmpeg"
+    };
     let plain = dir.join(plain_name);
     if ffmpeg_binary_is_usable(&plain) {
         return Some(plain);
@@ -57,8 +61,8 @@ fn resolve_ffmpeg_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "macos")]
     {
         for path in [
-            "/opt/homebrew/bin/ffmpeg",    // Apple Silicon Homebrew
-            "/usr/local/bin/ffmpeg",       // Intel Homebrew
+            "/opt/homebrew/bin/ffmpeg", // Apple Silicon Homebrew
+            "/usr/local/bin/ffmpeg",    // Intel Homebrew
         ] {
             let p = std::path::PathBuf::from(path);
             if ffmpeg_binary_is_usable(&p) {
@@ -133,7 +137,11 @@ fn ffmpeg_binary_is_usable(path: &std::path::Path) -> bool {
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
             let reason = stderr.lines().next().unwrap_or("unknown error");
-            log::warn!("[ffmpeg] Skipping unusable candidate {:?}: {}", path, reason);
+            log::warn!(
+                "[ffmpeg] Skipping unusable candidate {:?}: {}",
+                path,
+                reason
+            );
             false
         }
         Err(err) => {
@@ -230,8 +238,7 @@ fn ffmpeg_encoder_available(encoder: &str) -> bool {
         .args(["-hide_banner", "-encoders"])
         .output()
         .map(|output| {
-            output.status.success()
-                && String::from_utf8_lossy(&output.stdout).contains(encoder)
+            output.status.success() && String::from_utf8_lossy(&output.stdout).contains(encoder)
         })
         .unwrap_or(false)
 }
@@ -315,7 +322,12 @@ fn macos_screen_device_index(monitor_index: i64) -> i64 {
                 } else {
                     screen_devices[0]
                 };
-                log::info!("[avfoundation] Screen device index {} for monitor {} (found {} screens)", idx, monitor_index, screen_devices.len());
+                log::info!(
+                    "[avfoundation] Screen device index {} for monitor {} (found {} screens)",
+                    idx,
+                    monitor_index,
+                    screen_devices.len()
+                );
                 return idx;
             }
         }
@@ -351,7 +363,17 @@ fn capture_window_frame(hwnd_raw: isize, width: i32, height: i32, buffer: &mut [
 
         if !success.as_bool() {
             // Fallback to BitBlt from window DC (works for most GDI windows)
-            let _ = BitBlt(hdc_mem, 0, 0, width, height, Some(hdc_window), 0, 0, SRCCOPY);
+            let _ = BitBlt(
+                hdc_mem,
+                0,
+                0,
+                width,
+                height,
+                Some(hdc_window),
+                0,
+                0,
+                SRCCOPY,
+            );
         }
 
         // Extract bitmap data as BGRA (top-down)
@@ -410,7 +432,9 @@ fn window_capture_loop(
 
     log::info!(
         "[capture_loop] Starting window capture: hwnd={} {}x{}",
-        hwnd, width, height
+        hwnd,
+        width,
+        height
     );
 
     while !stop_flag.load(Ordering::Relaxed) {
@@ -453,7 +477,17 @@ fn screenshot_window_printwindow(hwnd_raw: isize, width: i32, height: i32) -> Op
 
         let success = PrintWindow(hwnd, hdc_mem, PRINT_WINDOW_FLAGS(2));
         if !success.as_bool() {
-            let _ = BitBlt(hdc_mem, 0, 0, width, height, Some(hdc_window), 0, 0, SRCCOPY);
+            let _ = BitBlt(
+                hdc_mem,
+                0,
+                0,
+                width,
+                height,
+                Some(hdc_window),
+                0,
+                0,
+                SRCCOPY,
+            );
         }
 
         // Extract as BMP-style BGRA data (top-down)
@@ -574,7 +608,8 @@ pub async fn init_recording(
         let session_type = std::env::var("XDG_SESSION_TYPE").unwrap_or_default();
         if session_type == "wayland" && std::env::var("DISPLAY").is_err() {
             return Err(AppError::General(
-                "Screen recording requires X11 or XWayland. Pure Wayland is not yet supported.".into(),
+                "Screen recording requires X11 or XWayland. Pure Wayland is not yet supported."
+                    .into(),
             ));
         }
     }
@@ -586,7 +621,10 @@ pub async fn init_recording(
         let x = source.get("x").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
         let y = source.get("y").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
         let w = source.get("width").and_then(|v| v.as_i64()).unwrap_or(1920);
-        let h = source.get("height").and_then(|v| v.as_i64()).unwrap_or(1080);
+        let h = source
+            .get("height")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1080);
         let w = (w - (w % 2)).max(2);
         let h = (h - (h % 2)).max(2);
 
@@ -600,7 +638,11 @@ pub async fn init_recording(
 
             log::info!(
                 "[recording] window PrintWindow capture: hwnd={} x={} y={} w={} h={}",
-                hwnd_str, x, y, w, h
+                hwnd_str,
+                x,
+                y,
+                w,
+                h
             );
 
             // FFmpeg reads raw BGRA frames from stdin pipe (Windows PrintWindow API)
@@ -623,7 +665,10 @@ pub async fn init_recording(
         {
             log::info!(
                 "[recording] window capture via avfoundation+crop: x={} y={} w={} h={}",
-                x, y, w, h
+                x,
+                y,
+                w,
+                h
             );
 
             // Use avfoundation screen capture + crop to window region
@@ -651,7 +696,10 @@ pub async fn init_recording(
 
             log::info!(
                 "[recording] window capture via x11grab: x={} y={} w={} h={}",
-                x, y, w, h
+                x,
+                y,
+                w,
+                h
             );
 
             // Use x11grab with offset+video_size to capture window region
@@ -719,8 +767,14 @@ pub async fn init_recording(
             "area" => {
                 let x_pct = source.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
                 let y_pct = source.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                let w_pct = source.get("width").and_then(|v| v.as_f64()).unwrap_or(100.0);
-                let h_pct = source.get("height").and_then(|v| v.as_f64()).unwrap_or(100.0);
+                let w_pct = source
+                    .get("width")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(100.0);
+                let h_pct = source
+                    .get("height")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(100.0);
 
                 let x = (x_pct / 100.0 * screen_w) as i64;
                 let y = (y_pct / 100.0 * screen_h) as i64;
@@ -787,13 +841,23 @@ pub async fn init_recording(
                 // On Windows, use physical pixels for gdigrab; on other platforms use logical
                 #[cfg(target_os = "windows")]
                 let (monitor_x, monitor_y, monitor_w, monitor_h) = {
-                    let mx = source.get("physicalX").or_else(|| source.get("monitorX"))
-                        .and_then(|v| v.as_i64()).unwrap_or(0);
-                    let my = source.get("physicalY").or_else(|| source.get("monitorY"))
-                        .and_then(|v| v.as_i64()).unwrap_or(0);
-                    let mw = source.get("physicalWidth").or_else(|| source.get("monitorWidth"))
+                    let mx = source
+                        .get("physicalX")
+                        .or_else(|| source.get("monitorX"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let my = source
+                        .get("physicalY")
+                        .or_else(|| source.get("monitorY"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let mw = source
+                        .get("physicalWidth")
+                        .or_else(|| source.get("monitorWidth"))
                         .and_then(|v| v.as_i64());
-                    let mh = source.get("physicalHeight").or_else(|| source.get("monitorHeight"))
+                    let mh = source
+                        .get("physicalHeight")
+                        .or_else(|| source.get("monitorHeight"))
                         .and_then(|v| v.as_i64());
                     (mx, my, mw, mh)
                 };
@@ -825,7 +889,9 @@ pub async fn init_recording(
                         let h = (h - (h % 2)).max(2);
                         log::info!(
                             "[recording] monitor capture (ddagrab): idx={} w={} h={}",
-                            monitor_idx, w, h
+                            monitor_idx,
+                            w,
+                            h
                         );
                         filter.push_str(&format!(":video_size={}x{}", w, h));
                     } else {
@@ -887,12 +953,12 @@ pub async fn init_recording(
                         let h = (h - (h % 2)).max(2);
                         log::info!(
                             "[recording] monitor capture: x={} y={} w={} h={}",
-                            monitor_x, monitor_y, w, h
+                            monitor_x,
+                            monitor_y,
+                            w,
+                            h
                         );
-                        ffmpeg_args.extend([
-                            "-video_size".to_string(),
-                            format!("{}x{}", w, h),
-                        ]);
+                        ffmpeg_args.extend(["-video_size".to_string(), format!("{}x{}", w, h)]);
                     }
 
                     ffmpeg_args.extend([
@@ -958,18 +1024,14 @@ pub async fn init_recording(
 
         // Store window handle info for the capture thread
         if is_window_capture {
-            config["windowHwnd"] = serde_json::json!(
-                source
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("0")
-            );
-            config["windowWidth"] = serde_json::json!(
-                source.get("width").and_then(|v| v.as_i64()).unwrap_or(1920)
-            );
-            config["windowHeight"] = serde_json::json!(
-                source.get("height").and_then(|v| v.as_i64()).unwrap_or(1080)
-            );
+            config["windowHwnd"] =
+                serde_json::json!(source.get("id").and_then(|v| v.as_str()).unwrap_or("0"));
+            config["windowWidth"] =
+                serde_json::json!(source.get("width").and_then(|v| v.as_i64()).unwrap_or(1920));
+            config["windowHeight"] = serde_json::json!(source
+                .get("height")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(1080));
         }
 
         state.camera_mic_config = Some(config);
@@ -980,7 +1042,7 @@ pub async fn init_recording(
         main_win.minimize().ok();
     }
 
-// Create recorder overlay window (centered at top of screen)
+    // Create recorder overlay window (centered at top of screen)
     let monitor = app
         .get_webview_window("main")
         .and_then(|w| w.current_monitor().ok().flatten());
@@ -1096,9 +1158,8 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
 
         if use_stdin_pipe {
             // Window capture: spawn FFmpeg via std::process::Command for stdin pipe access
-            let ffmpeg_path = find_ffmpeg_path().ok_or_else(|| {
-                AppError::General("FFmpeg binary not found".to_string())
-            })?;
+            let ffmpeg_path = find_ffmpeg_path()
+                .ok_or_else(|| AppError::General("FFmpeg binary not found".to_string()))?;
 
             log::info!(
                 "[start_recording] Window capture mode, FFmpeg: {:?}",
@@ -1120,7 +1181,8 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
                 cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
             }
 
-            let mut process = cmd.spawn()
+            let mut process = cmd
+                .spawn()
                 .map_err(|e| AppError::General(format!("Failed to spawn FFmpeg: {}", e)))?;
 
             let pid = process.id();
@@ -1161,7 +1223,10 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
                 state.window_capture_thread = Some(capture_thread);
             }
 
-            log::info!("[start_recording] Window capture started, FFmpeg PID: {}", pid);
+            log::info!(
+                "[start_recording] Window capture started, FFmpeg PID: {}",
+                pid
+            );
         } else {
             // Screen/Area capture
             use std::process::{Command, Stdio};
@@ -1172,7 +1237,8 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
 
             log::info!(
                 "[start_recording] Screen/area capture, FFmpeg: {:?}, args: {:?}",
-                ffmpeg_path, args
+                ffmpeg_path,
+                args
             );
 
             let mut cmd = Command::new(&ffmpeg_path);
@@ -1208,7 +1274,9 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
                                             || msg.contains("not granted");
 
                                         if is_permission_error {
-                                            app_clone.emit("recording-error", "ScreenPermissionDenied").ok();
+                                            app_clone
+                                                .emit("recording-error", "ScreenPermissionDenied")
+                                                .ok();
                                         } else if ffmpeg_stderr_is_capture_error(&msg) {
                                             app_clone.emit("recording-error", "CaptureError").ok();
                                         }
@@ -1236,7 +1304,10 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
                     if let Some(main_win) = app.get_webview_window("main") {
                         main_win.unminimize().ok();
                     }
-                    return Err(AppError::General(format!("Failed to start recording: {}", e)));
+                    return Err(AppError::General(format!(
+                        "Failed to start recording: {}",
+                        e
+                    )));
                 }
             }
         }
@@ -1268,7 +1339,8 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
         // Scale mouse coordinates to match video resolution on Retina displays.
         #[cfg(target_os = "macos")]
         {
-            let scale = app.get_webview_window("main")
+            let scale = app
+                .get_webview_window("main")
                 .and_then(|w| w.current_monitor().ok().flatten())
                 .map(|m| m.scale_factor())
                 .unwrap_or(1.0);
@@ -1302,7 +1374,9 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
     tokio::task::spawn_blocking({
         let app = app.clone();
         move || kill_ffmpeg(&app)
-    }).await.ok();
+    })
+    .await
+    .ok();
 
     #[cfg(target_os = "macos")]
     crate::mouse_tracker::restore_macos_cursor();
@@ -1451,11 +1525,15 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
                     let state_lock = state.lock().unwrap();
                     state_lock.camera_video_file(rid)
                 };
-                if camera_src.exists() && camera_src.metadata().map(|m| m.len() > 0).unwrap_or(false) {
+                if camera_src.exists()
+                    && camera_src.metadata().map(|m| m.len() > 0).unwrap_or(false)
+                {
                     let camera_dest = project_temp.join("camera.webm");
                     log::info!(
                         "[stop_recording] Copying camera file: {:?} -> {:?} (size={})",
-                        camera_src, camera_dest, camera_src.metadata().map(|m| m.len()).unwrap_or(0)
+                        camera_src,
+                        camera_dest,
+                        camera_src.metadata().map(|m| m.len()).unwrap_or(0)
                     );
                     if std::fs::rename(&camera_src, &camera_dest).is_err() {
                         log::warn!("[stop_recording] camera rename failed, trying copy");
@@ -1470,7 +1548,10 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
                         true
                     }
                 } else {
-                    log::warn!("[stop_recording] Camera file not found or empty at {:?}", camera_src);
+                    log::warn!(
+                        "[stop_recording] Camera file not found or empty at {:?}",
+                        camera_src
+                    );
                     false
                 }
             } else {
@@ -1574,10 +1655,7 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
 
                 if let Ok(video_meta) = dest_video.metadata() {
                     let video_size = video_meta.len();
-                    log::info!(
-                        "[stop_recording] Adding video to zip, size={}",
-                        video_size
-                    );
+                    log::info!("[stop_recording] Adding video to zip, size={}", video_size);
                     if let Ok(mut video_file) = std::fs::File::open(&dest_video) {
                         zip.start_file("screen.mp4", options).ok();
                         std::io::copy(&mut video_file, &mut zip).ok();
@@ -1631,10 +1709,7 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
                     );
 
                     store.set("projects", Value::Object(projects));
-                    store.set(
-                        format!("projects.{}.path", pid),
-                        serde_json::json!(zip_str),
-                    );
+                    store.set(format!("projects.{}.path", pid), serde_json::json!(zip_str));
                     store.save().ok();
                     log::info!("[stop_recording] Project stored: {}", pid);
                 } else {
@@ -1719,7 +1794,9 @@ pub async fn reset_recording(app: AppHandle) -> AppResult<()> {
     tokio::task::spawn_blocking({
         let app = app.clone();
         move || kill_ffmpeg(&app)
-    }).await.ok();
+    })
+    .await
+    .ok();
 
     #[cfg(target_os = "macos")]
     crate::mouse_tracker::restore_macos_cursor();
@@ -1754,7 +1831,9 @@ pub async fn cancel_recording(app: AppHandle, error: Option<String>) -> AppResul
     tokio::task::spawn_blocking({
         let app = app.clone();
         move || kill_ffmpeg(&app)
-    }).await.ok();
+    })
+    .await
+    .ok();
 
     #[cfg(target_os = "macos")]
     crate::mouse_tracker::restore_macos_cursor();
@@ -1835,9 +1914,7 @@ async fn get_video_duration_ms(
 }
 
 /// Get video dimensions (width, height) using FFmpeg
-async fn get_video_dimensions(
-    video_path: &std::path::Path,
-) -> Result<(i64, i64), String> {
+async fn get_video_dimensions(video_path: &std::path::Path) -> Result<(i64, i64), String> {
     let path_str = video_path.to_string_lossy().to_string();
     let output = run_ffmpeg(&["-i", &path_str, "-f", "null", "-"])
         .await
@@ -1849,7 +1926,7 @@ async fn get_video_dimensions(
     for line in stderr.lines() {
         if line.contains("Video:") {
             // Look for WxH pattern like "1280x720" in the Video stream line
-            for part in line.split(|c: char| c == ',' || c == ' ') {
+            for part in line.split([',', ' ']) {
                 let part = part.trim();
                 if let Some(x_pos) = part.find('x') {
                     let w_str = &part[..x_pos];
@@ -1866,10 +1943,7 @@ async fn get_video_dimensions(
     Err("Could not parse video dimensions".to_string())
 }
 
-async fn recording_video_is_readable(
-    app: &AppHandle,
-    video_path: &std::path::Path,
-) -> bool {
+async fn recording_video_is_readable(app: &AppHandle, video_path: &std::path::Path) -> bool {
     get_video_duration_ms(app, video_path).await.is_ok()
         && get_video_dimensions(video_path).await.is_ok()
 }
@@ -1958,7 +2032,10 @@ fn kill_ffmpeg(app: &AppHandle) {
             }
         }
     } else if let Some(pid) = pid {
-        log::warn!("[kill_ffmpeg] No process handle, force killing PID: {}", pid);
+        log::warn!(
+            "[kill_ffmpeg] No process handle, force killing PID: {}",
+            pid
+        );
         force_kill_ffmpeg(pid);
     }
 }
@@ -2031,7 +2108,10 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
             let w = source.get("width").and_then(|v| v.as_i64()).unwrap_or(1920) as i32;
-            let h = source.get("height").and_then(|v| v.as_i64()).unwrap_or(1080) as i32;
+            let h = source
+                .get("height")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(1080) as i32;
 
             if hwnd != 0 {
                 if let Some(bmp_data) = screenshot_window_printwindow(hwnd, w, h) {
@@ -2055,8 +2135,7 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
                         let data = std::fs::read(&screenshot_path)?;
                         std::fs::remove_file(&screenshot_path).ok();
                         if !data.is_empty() {
-                            let b64 =
-                                base64::engine::general_purpose::STANDARD.encode(&data);
+                            let b64 = base64::engine::general_purpose::STANDARD.encode(&data);
                             return Ok(format!("data:image/png;base64,{}", b64));
                         }
                     }
@@ -2067,14 +2146,19 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
             let x = source.get("x").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
             let y = source.get("y").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
             let w64 = source.get("width").and_then(|v| v.as_i64()).unwrap_or(1920);
-            let h64 = source.get("height").and_then(|v| v.as_i64()).unwrap_or(1080);
+            let h64 = source
+                .get("height")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(1080);
             let w64 = w64.min(screen_w as i64 - x);
             let h64 = h64.min(screen_h as i64 - y);
             let w64 = (w64 - (w64 % 2)).max(2);
             let h64 = (h64 - (h64 % 2)).max(2);
 
             if let Some(main_win) = app.get_webview_window("main") {
-                main_win.set_content_protected(super::windows::is_content_protection_enabled(&app)).ok();
+                main_win
+                    .set_content_protected(super::windows::is_content_protection_enabled(&app))
+                    .ok();
             }
 
             let args = build_screenshot_args(x, y, w64, h64, &screenshot_str);
@@ -2100,7 +2184,10 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
             let x = source.get("x").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
             let y = source.get("y").and_then(|v| v.as_i64()).unwrap_or(0).max(0);
             let w64 = source.get("width").and_then(|v| v.as_i64()).unwrap_or(1920);
-            let h64 = source.get("height").and_then(|v| v.as_i64()).unwrap_or(1080);
+            let h64 = source
+                .get("height")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(1080);
 
             #[cfg(target_os = "macos")]
             {
@@ -2108,15 +2195,17 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
                     return Err(AppError::General("ScreenPermissionDenied".to_string()));
                 }
                 let region = format!("{},{},{},{}", x, y, w64, h64);
-                let screenshot_str_clone = screenshot_str.clone();
-                let _output = tokio::task::spawn_blocking(move || {
-                    std::process::Command::new("screencapture")
-                        .args(["-x", "-R", &region, &screenshot_str_clone])
-                        .output()
-                })
-                .await
-                .map_err(|e| AppError::General(format!("Screenshot task error: {}", e)))?
-                .map_err(|e| AppError::General(format!("Screenshot error: {}", e)))?;
+                let output = super::run_macos_screencapture(
+                    &["-x", "-R", &region, &screenshot_str],
+                    std::time::Duration::from_secs(5),
+                )
+                .await?;
+                if !output.status.success() {
+                    log::warn!(
+                        "[screenshot] screencapture stderr: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
             }
             #[cfg(not(target_os = "macos"))]
             {
@@ -2142,7 +2231,9 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
 
     // Screen/Area screenshot using platform-specific capture
     if let Some(main_win) = app.get_webview_window("main") {
-        main_win.set_content_protected(super::windows::is_content_protection_enabled(&app)).ok();
+        main_win
+            .set_content_protected(super::windows::is_content_protection_enabled(&app))
+            .ok();
     }
 
     // On macOS, check screen recording permission before calling screencapture
@@ -2156,8 +2247,14 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
             "area" => {
                 let x_pct = source.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
                 let y_pct = source.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                let w_pct = source.get("width").and_then(|v| v.as_f64()).unwrap_or(100.0);
-                let h_pct = source.get("height").and_then(|v| v.as_f64()).unwrap_or(100.0);
+                let w_pct = source
+                    .get("width")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(100.0);
+                let h_pct = source
+                    .get("height")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(100.0);
                 let x = (x_pct / 100.0 * screen_w) as i64;
                 let y = (y_pct / 100.0 * screen_h) as i64;
                 let w = ((w_pct / 100.0 * screen_w) as i64).max(2);
@@ -2178,18 +2275,17 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
         };
 
         let region = format!("{},{},{},{}", x, y, w, h);
-        let screenshot_str_clone = screenshot_str.clone();
-        let output = tokio::task::spawn_blocking(move || {
-            std::process::Command::new("screencapture")
-                .args(["-x", "-R", &region, &screenshot_str_clone])
-                .output()
-        })
-        .await
-        .map_err(|e| AppError::General(format!("Screenshot task error: {}", e)))?
-        .map_err(|e| AppError::General(format!("Screenshot error: {}", e)))?;
+        let output = super::run_macos_screencapture(
+            &["-x", "-R", &region, &screenshot_str],
+            std::time::Duration::from_secs(5),
+        )
+        .await?;
 
         if !output.status.success() {
-            log::warn!("[screenshot] screencapture stderr: {}", String::from_utf8_lossy(&output.stderr));
+            log::warn!(
+                "[screenshot] screencapture stderr: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         if screenshot_path.exists() {
@@ -2200,7 +2296,7 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
                 return Ok(format!("data:image/png;base64,{}", b64));
             }
         }
-        return Err(AppError::General("Screenshot capture failed".to_string()));
+        Err(AppError::General("Screenshot capture failed".to_string()))
     }
 
     // Windows/Linux: use FFmpeg for screenshots
@@ -2210,8 +2306,14 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
             "area" => {
                 let x_pct = source.get("x").and_then(|v| v.as_f64()).unwrap_or(0.0);
                 let y_pct = source.get("y").and_then(|v| v.as_f64()).unwrap_or(0.0);
-                let w_pct = source.get("width").and_then(|v| v.as_f64()).unwrap_or(100.0);
-                let h_pct = source.get("height").and_then(|v| v.as_f64()).unwrap_or(100.0);
+                let w_pct = source
+                    .get("width")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(100.0);
+                let h_pct = source
+                    .get("height")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(100.0);
                 let x = (x_pct / 100.0 * screen_w) as i64;
                 let y = (y_pct / 100.0 * screen_h) as i64;
                 let w = ((w_pct / 100.0 * screen_w) as i64).max(2);
@@ -2223,13 +2325,23 @@ pub async fn get_source_screenshot(app: AppHandle, source: Value) -> AppResult<S
             _ => {
                 #[cfg(target_os = "windows")]
                 let (monitor_x, monitor_y, monitor_w, monitor_h) = {
-                    let mx = source.get("physicalX").or_else(|| source.get("monitorX"))
-                        .and_then(|v| v.as_i64()).unwrap_or(0);
-                    let my = source.get("physicalY").or_else(|| source.get("monitorY"))
-                        .and_then(|v| v.as_i64()).unwrap_or(0);
-                    let mw = source.get("physicalWidth").or_else(|| source.get("monitorWidth"))
+                    let mx = source
+                        .get("physicalX")
+                        .or_else(|| source.get("monitorX"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let my = source
+                        .get("physicalY")
+                        .or_else(|| source.get("monitorY"))
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
+                    let mw = source
+                        .get("physicalWidth")
+                        .or_else(|| source.get("monitorWidth"))
                         .and_then(|v| v.as_i64());
-                    let mh = source.get("physicalHeight").or_else(|| source.get("monitorHeight"))
+                    let mh = source
+                        .get("physicalHeight")
+                        .or_else(|| source.get("monitorHeight"))
                         .and_then(|v| v.as_i64());
                     (mx, my, mw, mh)
                 };
@@ -2294,11 +2406,16 @@ pub async fn take_recording_screenshot(app: AppHandle) -> AppResult<String> {
         if let Ok(Some(monitor)) = main_win.current_monitor() {
             let size = monitor.size();
             #[cfg(target_os = "windows")]
-            { (size.width as i64, size.height as i64) }
+            {
+                (size.width as i64, size.height as i64)
+            }
             #[cfg(not(target_os = "windows"))]
             {
                 let scale = monitor.scale_factor();
-                ((size.width as f64 / scale) as i64, (size.height as f64 / scale) as i64)
+                (
+                    (size.width as f64 / scale) as i64,
+                    (size.height as f64 / scale) as i64,
+                )
             }
         } else {
             (1920i64, 1080i64)
@@ -2345,17 +2462,25 @@ pub async fn take_recording_screenshot(app: AppHandle) -> AppResult<String> {
 #[cfg(not(target_os = "windows"))]
 fn platform_capture_format() -> &'static str {
     #[cfg(target_os = "macos")]
-    { "avfoundation" }
+    {
+        "avfoundation"
+    }
     #[cfg(target_os = "linux")]
-    { "x11grab" }
+    {
+        "x11grab"
+    }
     #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    { "x11grab" }
+    {
+        "x11grab"
+    }
 }
 
 /// Get the platform default audio capture device name
 fn platform_default_audio_device() -> String {
     #[cfg(target_os = "windows")]
-    { "virtual-audio-capturer".to_string() }
+    {
+        "virtual-audio-capturer".to_string()
+    }
     #[cfg(target_os = "macos")]
     {
         // Try to detect available virtual audio devices via FFmpeg
@@ -2368,7 +2493,12 @@ fn platform_default_audio_device() -> String {
                 .output()
             {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                for name in ["BlackHole 2ch", "BlackHole 16ch", "Soundflower (2ch)", "Background Music"] {
+                for name in [
+                    "BlackHole 2ch",
+                    "BlackHole 16ch",
+                    "Soundflower (2ch)",
+                    "Background Music",
+                ] {
                     if stderr.contains(name) {
                         log::info!("[audio] Found macOS virtual audio device: {}", name);
                         return name.to_string();
@@ -2380,9 +2510,13 @@ fn platform_default_audio_device() -> String {
         "BlackHole 2ch".to_string()
     }
     #[cfg(target_os = "linux")]
-    { "default".to_string() }
+    {
+        "default".to_string()
+    }
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    { "default".to_string() }
+    {
+        "default".to_string()
+    }
 }
 
 /// Get platform-specific audio capture FFmpeg args (format, input)
@@ -2425,7 +2559,8 @@ async fn run_ffmpeg(args: &[&str]) -> AppResult<std::process::Output> {
             use std::os::windows::process::CommandExt;
             cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
         }
-        cmd.output().map_err(|e| AppError::General(format!("FFmpeg error: {}", e)))
+        cmd.output()
+            .map_err(|e| AppError::General(format!("FFmpeg error: {}", e)))
     })
     .await
     .map_err(|e| AppError::General(format!("FFmpeg task error: {}", e)))?
@@ -2436,12 +2571,25 @@ fn build_screenshot_args(x: i64, y: i64, w: i64, h: i64, output_path: &str) -> V
     #[cfg(target_os = "windows")]
     {
         vec![
-            "-y".into(), "-f".into(), "gdigrab".into(),
-            "-framerate".into(), "1".into(), "-draw_mouse".into(), "0".into(),
-            "-offset_x".into(), x.to_string(), "-offset_y".into(), y.to_string(),
-            "-video_size".into(), format!("{}x{}", w, h),
-            "-i".into(), "desktop".into(),
-            "-frames:v".into(), "1".into(), "-update".into(), "true".into(),
+            "-y".into(),
+            "-f".into(),
+            "gdigrab".into(),
+            "-framerate".into(),
+            "1".into(),
+            "-draw_mouse".into(),
+            "0".into(),
+            "-offset_x".into(),
+            x.to_string(),
+            "-offset_y".into(),
+            y.to_string(),
+            "-video_size".into(),
+            format!("{}x{}", w, h),
+            "-i".into(),
+            "desktop".into(),
+            "-frames:v".into(),
+            "1".into(),
+            "-update".into(),
+            "true".into(),
             output_path.into(),
         ]
     }
@@ -2449,11 +2597,19 @@ fn build_screenshot_args(x: i64, y: i64, w: i64, h: i64, output_path: &str) -> V
     {
         let screen_dev = macos_screen_device_index(0);
         let mut args: Vec<String> = vec![
-            "-y".into(), "-f".into(), "avfoundation".into(),
-            "-framerate".into(), "30".into(), "-pixel_format".into(), "nv12".into(),
-            "-capture_cursor".into(), "0".into(),
-            "-i".into(), format!("{}:none", screen_dev),
-            "-frames:v".into(), "1".into(),
+            "-y".into(),
+            "-f".into(),
+            "avfoundation".into(),
+            "-framerate".into(),
+            "30".into(),
+            "-pixel_format".into(),
+            "nv12".into(),
+            "-capture_cursor".into(),
+            "0".into(),
+            "-i".into(),
+            format!("{}:none", screen_dev),
+            "-frames:v".into(),
+            "1".into(),
         ];
         // Crop to the requested region (works for all cases including x=0,y=0)
         args.extend(["-vf".into(), format!("crop={}:{}:{}:{}", w, h, x, y)]);
@@ -2464,22 +2620,38 @@ fn build_screenshot_args(x: i64, y: i64, w: i64, h: i64, output_path: &str) -> V
     {
         let display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
         vec![
-            "-y".into(), "-f".into(), "x11grab".into(),
-            "-framerate".into(), "1".into(), "-draw_mouse".into(), "0".into(),
-            "-video_size".into(), format!("{}x{}", w, h),
-            "-i".into(), format!("{}+{},{}", display, x, y),
-            "-frames:v".into(), "1".into(), "-update".into(), "true".into(),
+            "-y".into(),
+            "-f".into(),
+            "x11grab".into(),
+            "-framerate".into(),
+            "1".into(),
+            "-draw_mouse".into(),
+            "0".into(),
+            "-video_size".into(),
+            format!("{}x{}", w, h),
+            "-i".into(),
+            format!("{}+{},{}", display, x, y),
+            "-frames:v".into(),
+            "1".into(),
+            "-update".into(),
+            "true".into(),
             output_path.into(),
         ]
     }
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
     {
         vec![
-            "-y".into(), "-f".into(), "x11grab".into(),
-            "-framerate".into(), "1".into(),
-            "-video_size".into(), format!("{}x{}", w, h),
-            "-i".into(), format!(":0+{},{}", x, y),
-            "-frames:v".into(), "1".into(),
+            "-y".into(),
+            "-f".into(),
+            "x11grab".into(),
+            "-framerate".into(),
+            "1".into(),
+            "-video_size".into(),
+            format!("{}x{}", w, h),
+            "-i".into(),
+            format!(":0+{},{}", x, y),
+            "-frames:v".into(),
+            "1".into(),
             output_path.into(),
         ]
     }

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -22,9 +22,7 @@ pub async fn set_content_protection(app: AppHandle, enabled: bool) -> AppResult<
         .store("store.json")
         .map_err(|e| AppError::General(e.to_string()))?;
     store.set("contentProtectionEnabled", Value::Bool(enabled));
-    store
-        .save()
-        .map_err(|e| AppError::General(e.to_string()))?;
+    store.save().map_err(|e| AppError::General(e.to_string()))?;
 
     // Apply to every existing window except drawingOverlay
     for (label, window) in app.webview_windows() {
@@ -38,17 +36,16 @@ pub async fn set_content_protection(app: AppHandle, enabled: bool) -> AppResult<
 }
 
 #[cfg(target_os = "windows")]
-use windows::Win32::Foundation::{HWND, LPARAM};
-#[cfg(target_os = "windows")]
 use windows::core::BOOL;
 #[cfg(target_os = "windows")]
-use windows::Win32::UI::WindowsAndMessaging::{
-    GetWindowTextW, GetWindowTextLengthW,
-    GetWindowThreadProcessId,
-    SystemParametersInfoW, SPI_GETWORKAREA,
-};
-#[cfg(target_os = "windows")]
 use windows::Win32::Foundation::RECT;
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::{HWND, LPARAM};
+#[cfg(target_os = "windows")]
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId, SystemParametersInfoW,
+    SPI_GETWORKAREA,
+};
 
 #[cfg(target_os = "macos")]
 use core_foundation::array::{CFArray, CFArrayRef};
@@ -120,7 +117,12 @@ pub async fn open_window_picker(app: AppHandle) -> AppResult<()> {
             } else {
                 if let Some(monitor) = monitors.first() {
                     let size = monitor.size();
-                    (0.0, 0.0, size.width as f64 / scale, size.height as f64 / scale)
+                    (
+                        0.0,
+                        0.0,
+                        size.width as f64 / scale,
+                        size.height as f64 / scale,
+                    )
                 } else {
                     (0.0, 0.0, 1920.0, 1080.0)
                 }
@@ -131,7 +133,12 @@ pub async fn open_window_picker(app: AppHandle) -> AppResult<()> {
         {
             if let Some(monitor) = monitors.first() {
                 let size = monitor.size();
-                (0.0, 0.0, size.width as f64 / scale, size.height as f64 / scale)
+                (
+                    0.0,
+                    0.0,
+                    size.width as f64 / scale,
+                    size.height as f64 / scale,
+                )
             } else {
                 (0.0, 0.0, 1920.0, 1080.0)
             }
@@ -143,7 +150,13 @@ pub async fn open_window_picker(app: AppHandle) -> AppResult<()> {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     capture_desktop_screenshot(&app).await.ok();
 
-    log::info!("[window_picker] Overlay area: {}x{} at ({}, {})", overlay_w, overlay_h, overlay_x, overlay_y);
+    log::info!(
+        "[window_picker] Overlay area: {}x{} at ({}, {})",
+        overlay_w,
+        overlay_h,
+        overlay_x,
+        overlay_y
+    );
 
     // Transparent overlay with window outlines (excludes taskbar)
     let _window = WebviewWindowBuilder::new(
@@ -230,7 +243,17 @@ fn capture_desktop_to_bmp(screenshot_path: &std::path::Path) -> Result<(), Strin
         let hbmp = CreateCompatibleBitmap(hdc_screen, width, height);
         let old_obj = SelectObject(hdc_mem, hbmp.into());
 
-        let _ = BitBlt(hdc_mem, 0, 0, width, height, Some(hdc_screen), 0, 0, SRCCOPY);
+        let _ = BitBlt(
+            hdc_mem,
+            0,
+            0,
+            width,
+            height,
+            Some(hdc_screen),
+            0,
+            0,
+            SRCCOPY,
+        );
 
         // Extract 24-bit BGR pixel data in bottom-up order (native BMP layout)
         let row_stride = ((width as usize * 3) + 3) & !3usize;
@@ -255,9 +278,13 @@ fn capture_desktop_to_bmp(screenshot_path: &std::path::Path) -> Result<(), Strin
         };
 
         GetDIBits(
-            hdc_mem, hbmp, 0, height as u32,
+            hdc_mem,
+            hbmp,
+            0,
+            height as u32,
             Some(pixels.as_mut_ptr() as *mut _),
-            &mut bmi, DIB_RGB_COLORS,
+            &mut bmi,
+            DIB_RGB_COLORS,
         );
 
         SelectObject(hdc_mem, old_obj);
@@ -291,8 +318,7 @@ fn capture_desktop_to_bmp(screenshot_path: &std::path::Path) -> Result<(), Strin
 
         bmp.extend_from_slice(&pixels);
 
-        std::fs::write(screenshot_path, &bmp)
-            .map_err(|e| format!("Write BMP failed: {e}"))?;
+        std::fs::write(screenshot_path, &bmp).map_err(|e| format!("Write BMP failed: {e}"))?;
 
         Ok(())
     }
@@ -320,11 +346,11 @@ async fn capture_desktop_screenshot(app: &AppHandle) -> AppResult<()> {
     {
         let screenshot_path = temp_dir.join("picker_bg.png");
         let screenshot_str = screenshot_path.to_string_lossy().to_string();
-        let output = tokio::process::Command::new("screencapture")
-            .args(["-x", &screenshot_str])
-            .output()
-            .await
-            .map_err(|e| AppError::General(format!("screencapture error: {}", e)))?;
+        let output = super::run_macos_screencapture(
+            &["-x", &screenshot_str],
+            std::time::Duration::from_secs(5),
+        )
+        .await?;
 
         if !output.status.success() {
             return Err(AppError::General(format!(
@@ -333,7 +359,7 @@ async fn capture_desktop_screenshot(app: &AppHandle) -> AppResult<()> {
             )));
         }
 
-        return Ok(());
+        Ok(())
     }
 
     // FFmpeg-based capture for Linux
@@ -345,8 +371,20 @@ async fn capture_desktop_screenshot(app: &AppHandle) -> AppResult<()> {
         let display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
         let display_input = format!("{}+0,0", display);
         let args = vec![
-            "-y", "-f", "x11grab", "-framerate", "1", "-draw_mouse", "0",
-            "-i", &display_input, "-frames:v", "1", "-update", "true", &screenshot_str,
+            "-y",
+            "-f",
+            "x11grab",
+            "-framerate",
+            "1",
+            "-draw_mouse",
+            "0",
+            "-i",
+            &display_input,
+            "-frames:v",
+            "1",
+            "-update",
+            "true",
+            &screenshot_str,
         ];
 
         let output = super::ffmpeg_from_app(app)?
@@ -356,7 +394,10 @@ async fn capture_desktop_screenshot(app: &AppHandle) -> AppResult<()> {
             .map_err(|e| AppError::General(format!("FFmpeg error: {}", e)))?;
 
         if !output.status.success() {
-            log::warn!("[FFmpeg picker bg] stderr: {}", String::from_utf8_lossy(&output.stderr));
+            log::warn!(
+                "[FFmpeg picker bg] stderr: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
         Ok(())
     }
@@ -445,11 +486,9 @@ pub async fn get_windows(app: AppHandle) -> AppResult<Value> {
     let our_pid = std::process::id();
 
     // Platform-specific window enumeration
-    let output = tauri::async_runtime::spawn(async move {
-        enumerate_windows_platform(our_pid)
-    })
-    .await
-    .unwrap_or(Value::Array(vec![]));
+    let output = tauri::async_runtime::spawn(async move { enumerate_windows_platform(our_pid) })
+        .await
+        .unwrap_or(Value::Array(vec![]));
 
     // Ensure it's always an array
     let windows = match output {
@@ -646,16 +685,19 @@ pub async fn get_monitors(app: AppHandle) -> AppResult<Value> {
 pub async fn get_window_at_point(_app: AppHandle, x: i32, y: i32) -> AppResult<Value> {
     #[cfg(target_os = "windows")]
     {
+        use std::sync::Mutex as StdMutex;
         use windows::Win32::UI::WindowsAndMessaging::{
             EnumWindows, GetWindowRect, IsWindowVisible as WinIsVisible,
         };
-        use std::sync::Mutex as StdMutex;
 
         let our_pid = std::process::id();
         let flowtake_titles: Vec<String> = vec![
-            "flowtake".into(), "select window - flowtake".into(),
-            "window picker - flowtake".into(), "recording - flowtake".into(),
-            "select area".into(), "select area - flowtake".into(),
+            "flowtake".into(),
+            "select window - flowtake".into(),
+            "window picker - flowtake".into(),
+            "recording - flowtake".into(),
+            "select area".into(),
+            "select area - flowtake".into(),
         ];
 
         // Shared result - first matching window found
@@ -671,7 +713,11 @@ pub async fn get_window_at_point(_app: AppHandle, x: i32, y: i32) -> AppResult<V
         }
 
         let data = Box::new(CallbackData {
-            x, y, our_pid, flowtake_titles, result: result.clone(),
+            x,
+            y,
+            our_pid,
+            flowtake_titles,
+            result: result.clone(),
         });
         let data_ptr = Box::into_raw(data);
 
@@ -697,7 +743,9 @@ pub async fn get_window_at_point(_app: AppHandle, x: i32, y: i32) -> AppResult<V
 
             // Get title
             let len = GetWindowTextLengthW(hwnd);
-            if len == 0 { return BOOL(1); }
+            if len == 0 {
+                return BOOL(1);
+            }
             let mut buf = vec![0u16; (len + 1) as usize];
             GetWindowTextW(hwnd, &mut buf);
             let title = String::from_utf16_lossy(&buf[..len as usize]);
@@ -716,11 +764,16 @@ pub async fn get_window_at_point(_app: AppHandle, x: i32, y: i32) -> AppResult<V
             let _ = GetWindowRect(hwnd, &mut rect);
             let w = rect.right - rect.left;
             let h = rect.bottom - rect.top;
-            if w <= 0 || h <= 0 { return BOOL(1); }
+            if w <= 0 || h <= 0 {
+                return BOOL(1);
+            }
 
             // Check if point is inside this window's rect
-            if data.x >= rect.left && data.x < rect.right &&
-               data.y >= rect.top && data.y < rect.bottom {
+            if data.x >= rect.left
+                && data.x < rect.right
+                && data.y >= rect.top
+                && data.y < rect.bottom
+            {
                 // Clamp to avoid negative coords (invisible window borders)
                 let cx = rect.left.max(0);
                 let cy = rect.top.max(0);
@@ -743,10 +796,7 @@ pub async fn get_window_at_point(_app: AppHandle, x: i32, y: i32) -> AppResult<V
         }
 
         unsafe {
-            let _ = EnumWindows(
-                Some(enum_callback),
-                LPARAM(data_ptr as isize),
-            );
+            let _ = EnumWindows(Some(enum_callback), LPARAM(data_ptr as isize));
             // Clean up
             drop(Box::from_raw(data_ptr));
         }
@@ -824,7 +874,10 @@ fn enumerate_windows_platform(our_pid: u32) -> Value {
 #[cfg(target_os = "windows")]
 fn enumerate_windows_windows(our_pid: u32) -> Value {
     let pid_line = format!("$appPid = [uint32]{}", our_pid);
-    let ps_script = format!("{}\n{}", pid_line, r#"
+    let ps_script = format!(
+        "{}\n{}",
+        pid_line,
+        r#"
 $allPids = New-Object 'System.Collections.Generic.HashSet[uint32]'
 [void]$allPids.Add($appPid)
 $procs = Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId 2>$null
@@ -908,7 +961,8 @@ public class WinEnum {
 $windows = [WinEnum]::GetVisibleWindows($pidArray)
 if ($windows -eq $null) { $windows = @() }
 ConvertTo-Json -InputObject @($windows) -Depth 3
-"#);
+"#
+    );
 
     use std::os::windows::process::CommandExt;
     let output = std::process::Command::new("powershell")
@@ -936,7 +990,10 @@ ConvertTo-Json -InputObject @($windows) -Depth 3
 }
 
 #[cfg(target_os = "macos")]
-fn cf_dict_raw_lookup(dict: CFDictionaryRef, key: &'static str) -> Option<*const core::ffi::c_void> {
+fn cf_dict_raw_lookup(
+    dict: CFDictionaryRef,
+    key: &'static str,
+) -> Option<*const core::ffi::c_void> {
     let cf_key = CFString::from_static_string(key);
     let mut value: *const core::ffi::c_void = core::ptr::null();
     let present = unsafe { CFDictionaryGetValueIfPresent(dict, cf_key.to_void(), &mut value) };
@@ -1119,9 +1176,7 @@ fn enumerate_windows_macos(our_pid: u32) -> Value {
 fn enumerate_windows_linux(our_pid: u32) -> Value {
     // Use wmctrl -lGp for window enumeration (widely available on X11)
     // Format: <wid> <desktop> <pid> <x> <y> <w> <h> <hostname> <title>
-    let output = std::process::Command::new("wmctrl")
-        .args(["-lGp"])
-        .output();
+    let output = std::process::Command::new("wmctrl").args(["-lGp"]).output();
 
     match output {
         Ok(out) => {
@@ -1170,7 +1225,10 @@ fn enumerate_windows_linux(our_pid: u32) -> Value {
             Value::Array(windows)
         }
         Err(e) => {
-            log::warn!("[get_windows] wmctrl not available: {}. Trying xdotool...", e);
+            log::warn!(
+                "[get_windows] wmctrl not available: {}. Trying xdotool...",
+                e
+            );
             // Fallback: try xdotool
             enumerate_windows_linux_xdotool(our_pid)
         }

--- a/src-tauri/vendor/phf_generator-0.8.0/Cargo.toml
+++ b/src-tauri/vendor/phf_generator-0.8.0/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition = "2018"
+name = "phf_generator"
+version = "0.8.0"
+authors = ["Steven Fackler <sfackler@gmail.com>"]
+description = "PHF generation logic"
+license = "MIT"
+repository = "https://github.com/sfackler/rust-phf"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+phf_shared = "0.8.0"
+rand = { version = "=0.8.6", features = ["small_rng"] }

--- a/src-tauri/vendor/phf_generator-0.8.0/src/lib.rs
+++ b/src-tauri/vendor/phf_generator-0.8.0/src/lib.rs
@@ -1,0 +1,90 @@
+#![doc(html_root_url = "https://docs.rs/phf_generator/0.8")]
+
+use phf_shared::{HashKey, PhfHash};
+use rand::distributions::Standard;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+const DEFAULT_LAMBDA: usize = 5;
+const FIXED_SEED: u64 = 1234567890;
+
+pub struct HashState {
+    pub key: HashKey,
+    pub disps: Vec<(u32, u32)>,
+    pub map: Vec<usize>,
+}
+
+pub fn generate_hash<H: PhfHash>(entries: &[H]) -> HashState {
+    SmallRng::seed_from_u64(FIXED_SEED)
+        .sample_iter(Standard)
+        .find_map(|key| try_generate_hash(entries, key))
+        .expect("failed to solve PHF")
+}
+
+fn try_generate_hash<H: PhfHash>(entries: &[H], key: HashKey) -> Option<HashState> {
+    struct Bucket {
+        idx: usize,
+        keys: Vec<usize>,
+    }
+
+    let hashes: Vec<_> = entries
+        .iter()
+        .map(|entry| phf_shared::hash(entry, &key))
+        .collect();
+
+    let buckets_len = (hashes.len() + DEFAULT_LAMBDA - 1) / DEFAULT_LAMBDA;
+    let mut buckets = (0..buckets_len)
+        .map(|i| Bucket {
+            idx: i,
+            keys: vec![],
+        })
+        .collect::<Vec<_>>();
+
+    for (i, hash) in hashes.iter().enumerate() {
+        buckets[(hash.g % (buckets_len as u32)) as usize]
+            .keys
+            .push(i);
+    }
+
+    buckets.sort_by(|a, b| a.keys.len().cmp(&b.keys.len()).reverse());
+
+    let table_len = hashes.len();
+    let mut map = vec![None; table_len];
+    let mut disps = vec![(0u32, 0u32); buckets_len];
+    let mut try_map = vec![0u64; table_len];
+    let mut generation = 0u64;
+    let mut values_to_add = vec![];
+
+    'buckets: for bucket in &buckets {
+        for d1 in 0..(table_len as u32) {
+            'disps: for d2 in 0..(table_len as u32) {
+                values_to_add.clear();
+                generation += 1;
+
+                for &key in &bucket.keys {
+                    let idx = (phf_shared::displace(hashes[key].f1, hashes[key].f2, d1, d2)
+                        % (table_len as u32)) as usize;
+                    if map[idx].is_some() || try_map[idx] == generation {
+                        continue 'disps;
+                    }
+                    try_map[idx] = generation;
+                    values_to_add.push((idx, key));
+                }
+
+                disps[bucket.idx] = (d1, d2);
+                for &(idx, key) in &values_to_add {
+                    map[idx] = Some(key);
+                }
+                continue 'buckets;
+            }
+        }
+
+        return None;
+    }
+
+    Some(HashState {
+        key,
+        disps,
+        map: map.into_iter().map(|i| i.unwrap()).collect(),
+    })
+}

--- a/tests/recording-preview-regression.test.mjs
+++ b/tests/recording-preview-regression.test.mjs
@@ -64,6 +64,8 @@ test("macOS recording errors only report permission denial after probing TCC", a
     const recording = await readRepoFile("src-tauri/src/commands/recording.rs")
 
     assert.match(appCommands, /pub fn macos_has_screen_recording_permission/)
+    assert.match(appCommands, /ScreenCaptureAccess::default\(\)\.preflight\(\)/)
+    assert.doesNotMatch(appCommands, /CGDisplay::screenshot/)
     assert.match(recording, /macos_ffmpeg_stderr_is_permission_error/)
     assert.match(recording, /macos_recording_error_code_for_empty_output/)
     assert.match(recording, /macos_has_screen_recording_permission\(\)/)
@@ -82,6 +84,21 @@ test("new recording preview retries after transient permission failures", async 
     assert.match(source, /refetchInterval:\s*screenPermissionDenied \|\| previewUnavailable \? 5000 : 2000/)
     assert.match(source, /Enable this exact Flowtake app/)
     assert.doesNotMatch(source, /enable this app, then restart/)
+})
+
+test("macOS screencapture previews time out instead of hanging permission checks", async () => {
+    const commands = await readRepoFile("src-tauri/src/commands/mod.rs")
+    const recording = await readRepoFile("src-tauri/src/commands/recording.rs")
+    const windows = await readRepoFile("src-tauri/src/commands/windows.rs")
+
+    assert.match(commands, /pub async fn run_macos_screencapture/)
+    assert.match(commands, /tokio::time::timeout\(timeout, child\.wait_with_output\(\)\)/)
+    assert.match(commands, /\.kill_on_drop\(true\)/)
+    assert.match(commands, /ScreenCaptureTimedOut/)
+    assert.match(recording, /super::run_macos_screencapture/)
+    assert.match(windows, /super::run_macos_screencapture/)
+    assert.doesNotMatch(recording, /Command::new\("screencapture"\)[\s\S]{0,200}\.output\(\)/)
+    assert.doesNotMatch(windows, /Command::new\("screencapture"\)[\s\S]{0,200}\.output\(\)/)
 })
 
 test("recording skips bundled ffmpeg binaries that fail to launch", async () => {

--- a/tests/spotlight-effect.test.mjs
+++ b/tests/spotlight-effect.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+import {
+    getSpotlightFeatherBands,
+    normalizeSpotlightConfig
+} from "../app/shared/scene/spotlight/spotlightMath.js"
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const readRepoFile = file => readFile(path.join(repoRoot, file), "utf8")
+
+test("spotlight config clamps unsafe values", () => {
+    assert.deepEqual(
+        normalizeSpotlightConfig({ radius: -10, opacity: 2, feather: -5 }),
+        { radius: 1, opacity: .95, feather: 0 }
+    )
+
+    assert.deepEqual(
+        normalizeSpotlightConfig({ radius: Number.NaN, opacity: Number.NaN, feather: Number.NaN }),
+        { radius: 160, opacity: .55, feather: 80 }
+    )
+})
+
+test("spotlight feather bands fade from the clear center to the dimmed screen", () => {
+    const bands = getSpotlightFeatherBands(120, 90, .6)
+
+    assert.ok(bands.length >= 4)
+    assert.ok(bands.length <= 10)
+    assert.equal(bands[0].innerRadius, 120)
+    assert.equal(bands.at(-1).outerRadius, 210)
+
+    for (let i = 1; i < bands.length; i++) {
+        assert.equal(bands[i].innerRadius, bands[i - 1].outerRadius)
+        assert.ok(bands[i].alpha > bands[i - 1].alpha)
+    }
+})
+
+test("spotlight settings are wired through preview and export renderers", async () => {
+    const cursorSlice = await readRepoFile("app/shared/redux/cursorCoordsSlice.js")
+    const preview = await readRepoFile("app/windows/main/components/Preview.jsx")
+    const previewScene = await readRepoFile("app/shared/scene/PreviewScene.js")
+    const renderWorker = await readRepoFile("app/shared/workers/renderWorker.js")
+    const renderScene = await readRepoFile("app/shared/scene/RenderScene.js")
+
+    assert.match(cursorSlice, /showSpotlight: false/)
+    assert.match(cursorSlice, /setShowSpotlight/)
+    assert.match(preview, /cursorCoords\.showSpotlight/)
+    assert.match(preview, /cursorCoords\.spotlightRadius/)
+    assert.match(preview, /cursorCoords\.spotlightOpacity/)
+    assert.match(preview, /cursorCoords\.spotlightFeather/)
+    assert.match(previewScene, /this\.spotlightAnimator\.setState\(\{ showSpotlight: payload \}\)/)
+    assert.match(renderWorker, /showSpotlight: selectShowSpotlight/)
+    assert.match(renderScene, /this\.spotlightAnimator\.setState\(\{/)
+})


### PR DESCRIPTION
## Summary

- Add the cursor spotlight effect from issue #62, with editor controls and preview/export rendering support.
- Harden macOS screen recording permission handling by using the native TCC preflight check and timing out stuck screencapture helpers.
- Patch the old phf_generator dependency path so the Rust graph no longer keeps vulnerable rand versions.

Closes #62

## Validation

- npm test
- cargo check --manifest-path src-tauri/Cargo.toml
- npm run build:frontend
- cargo tree --manifest-path src-tauri/Cargo.toml | rg "rand v|phf_generator v|getrandom v0\.1|rand v0\.7|rand v0\.9\.2"
- Manual dev app recording flow: preview loaded, recording started, stopped/saved, editor opened, saved screen.mp4 passed ffmpeg readability probe