### PR TITLE
feat: harden recording reliability and first-run UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
 
       - run: npm ci
 
+      - name: Lint JavaScript
+        run: npm run lint
+
+      - name: Run JavaScript tests
+        run: npm test
+
       - name: Build frontend
         run: npm run build:frontend
 
@@ -76,6 +82,10 @@ jobs:
 
       - name: Cargo check
         run: cargo check
+        working-directory: src-tauri
+
+      - name: Cargo unit tests
+        run: cargo test --lib --locked
         working-directory: src-tauri
 
       - name: Cargo clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,17 +69,30 @@ jobs:
       - name: Collect Windows installers and portable binary
         shell: bash
         run: |
+          set -euo pipefail
+          shopt -s nullglob
           mkdir -p installers
 
           # Installers
-          cp src-tauri/target/release/bundle/nsis/*.exe installers/ 2>/dev/null || true
-          cp src-tauri/target/release/bundle/msi/*.msi installers/ 2>/dev/null || true
+          nsis_installers=(src-tauri/target/release/bundle/nsis/*.exe)
+          msi_installers=(src-tauri/target/release/bundle/msi/*.msi)
+          if (( ${#nsis_installers[@]} == 0 )); then
+            echo "ERROR: Tauri produced no Windows NSIS installer" >&2
+            exit 1
+          fi
+          if (( ${#msi_installers[@]} == 0 )); then
+            echo "ERROR: Tauri produced no Windows MSI installer" >&2
+            exit 1
+          fi
+          cp "${nsis_installers[@]}" installers/
+          cp "${msi_installers[@]}" installers/
 
           # Portable standalone binary (zip with ffmpeg sidecar)
           mkdir -p _portable/Flowtake
           cp src-tauri/target/release/flowtake.exe _portable/Flowtake/Flowtake.exe
-          cp src-tauri/binaries/ffmpeg-x86_64-pc-windows-msvc.exe _portable/Flowtake/ffmpeg.exe 2>/dev/null || true
+          cp src-tauri/binaries/ffmpeg-x86_64-pc-windows-msvc.exe _portable/Flowtake/ffmpeg.exe
           cd _portable && 7z a -tzip ../installers/Flowtake-windows-x64-portable.zip Flowtake/ && cd ..
+          test -s installers/Flowtake-windows-x64-portable.zip
 
           echo "=== Collected files ==="
           ls -la installers/
@@ -89,6 +102,7 @@ jobs:
         with:
           name: windows-installers
           path: installers/*
+          if-no-files-found: error
 
   build-linux:
     name: Build (Linux x64)
@@ -157,20 +171,38 @@ jobs:
 
       - name: Collect Linux installers and portable binary
         run: |
+          set -euo pipefail
+          shopt -s nullglob
           mkdir -p installers
 
           # Installers
-          cp src-tauri/target/release/bundle/deb/*.deb installers/ 2>/dev/null || true
-          cp src-tauri/target/release/bundle/appimage/*.AppImage installers/ 2>/dev/null || true
-          cp src-tauri/target/release/bundle/rpm/*.rpm installers/ 2>/dev/null || true
+          deb_installers=(src-tauri/target/release/bundle/deb/*.deb)
+          appimages=(src-tauri/target/release/bundle/appimage/*.AppImage)
+          rpm_installers=(src-tauri/target/release/bundle/rpm/*.rpm)
+          if (( ${#deb_installers[@]} == 0 )); then
+            echo "ERROR: Tauri produced no Linux DEB package" >&2
+            exit 1
+          fi
+          if (( ${#appimages[@]} == 0 )); then
+            echo "ERROR: Tauri produced no Linux AppImage" >&2
+            exit 1
+          fi
+          if (( ${#rpm_installers[@]} == 0 )); then
+            echo "ERROR: Tauri produced no Linux RPM package" >&2
+            exit 1
+          fi
+          cp "${deb_installers[@]}" installers/
+          cp "${appimages[@]}" installers/
+          cp "${rpm_installers[@]}" installers/
 
           # Portable standalone binary (tar.gz with ffmpeg sidecar)
           mkdir -p _portable/Flowtake
           cp src-tauri/target/release/flowtake _portable/Flowtake/flowtake
           chmod +x _portable/Flowtake/flowtake
-          cp src-tauri/binaries/ffmpeg-x86_64-unknown-linux-gnu _portable/Flowtake/ffmpeg 2>/dev/null || true
-          chmod +x _portable/Flowtake/ffmpeg 2>/dev/null || true
+          cp src-tauri/binaries/ffmpeg-x86_64-unknown-linux-gnu _portable/Flowtake/ffmpeg
+          chmod +x _portable/Flowtake/ffmpeg
           tar -czf installers/Flowtake-linux-x64-portable.tar.gz -C _portable Flowtake
+          test -s installers/Flowtake-linux-x64-portable.tar.gz
 
           echo "=== Collected files ==="
           ls -la installers/
@@ -180,6 +212,7 @@ jobs:
         with:
           name: linux-installers
           path: installers/*
+          if-no-files-found: error
 
   build-macos:
     name: Build (macOS Universal)
@@ -248,21 +281,34 @@ jobs:
 
       - name: Collect macOS installers and portable app
         run: |
+          set -euo pipefail
+          shopt -s nullglob
           mkdir -p installers
 
           # Installers
-          cp src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg installers/ 2>/dev/null || true
+          dmg_installers=(src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg)
+          if (( ${#dmg_installers[@]} == 0 )); then
+            echo "ERROR: Tauri produced no macOS DMG" >&2
+            exit 1
+          fi
+          cp "${dmg_installers[@]}" installers/
 
           # Portable .app bundle (zip it for direct download)
           APP_PATH="src-tauri/target/universal-apple-darwin/release/bundle/macos/Flowtake.app"
-          if [ -d "$APP_PATH" ]; then
-            cd src-tauri/target/universal-apple-darwin/release/bundle/macos
-            zip -r -y ../../../../../../installers/Flowtake-macos-universal.zip Flowtake.app
-            cd ../../../../../../
+          if [ ! -d "$APP_PATH" ]; then
+            echo "ERROR: Tauri produced no macOS Flowtake.app bundle" >&2
+            exit 1
           fi
+          pushd "$(dirname "$APP_PATH")"
+          zip -r -y "$GITHUB_WORKSPACE/installers/Flowtake-macos-universal.zip" Flowtake.app
+          popd
+          test -s installers/Flowtake-macos-universal.zip
 
           # Also grab the .app.tar.gz if Tauri generated it
-          cp src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz installers/ 2>/dev/null || true
+          app_archives=(src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz)
+          if (( ${#app_archives[@]} > 0 )); then
+            cp "${app_archives[@]}" installers/
+          fi
 
           echo "=== Collected files ==="
           ls -la installers/
@@ -272,11 +318,12 @@ jobs:
         with:
           name: macos-installers
           path: installers/*
+          if-no-files-found: error
 
   release:
     name: Create Release
     needs: [build-windows, build-linux, build-macos]
-    if: always() && (needs.build-windows.result == 'success' || needs.build-linux.result == 'success' || needs.build-macos.result == 'success')
+    if: always() && needs.build-windows.result == 'success' && needs.build-linux.result == 'success' && needs.build-macos.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -327,6 +374,38 @@ jobs:
 
       - name: List all artifacts
         run: find artifacts -type f | sort
+
+      - name: Verify complete release payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          require_non_empty() {
+            local label="$1"
+            shift
+            local matches=("$@")
+            if (( ${#matches[@]} == 0 )); then
+              echo "ERROR: Missing required release artifact: $label" >&2
+              exit 1
+            fi
+            for file in "${matches[@]}"; do
+              if [ ! -s "$file" ]; then
+                echo "ERROR: Required release artifact is empty: $file" >&2
+                exit 1
+              fi
+            done
+          }
+
+          require_non_empty "Windows NSIS installer" artifacts/windows-installers/*.exe
+          require_non_empty "Windows MSI installer" artifacts/windows-installers/*.msi
+          require_non_empty "Windows portable ZIP" artifacts/windows-installers/Flowtake-windows-x64-portable.zip
+          require_non_empty "macOS DMG" artifacts/macos-installers/*.dmg
+          require_non_empty "macOS portable ZIP" artifacts/macos-installers/Flowtake-macos-universal.zip
+          require_non_empty "Linux DEB package" artifacts/linux-installers/*.deb
+          require_non_empty "Linux AppImage" artifacts/linux-installers/*.AppImage
+          require_non_empty "Linux RPM package" artifacts/linux-installers/*.rpm
+          require_non_empty "Linux portable archive" artifacts/linux-installers/Flowtake-linux-x64-portable.tar.gz
 
       - name: Build release body
         run: |
@@ -415,13 +494,14 @@ jobs:
           prerelease: false
           generate_release_notes: false
           body_path: /tmp/release_body.md
+          fail_on_unmatched_files: true
           files: |
-            artifacts/**/*.exe
-            artifacts/**/*.msi
-            artifacts/**/*.dmg
-            artifacts/**/*.zip
-            artifacts/**/*.app.tar.gz
-            artifacts/**/*.tar.gz
-            artifacts/**/*.deb
-            artifacts/**/*.AppImage
-            artifacts/**/*.rpm
+            artifacts/windows-installers/*.exe
+            artifacts/windows-installers/*.msi
+            artifacts/windows-installers/Flowtake-windows-x64-portable.zip
+            artifacts/macos-installers/*.dmg
+            artifacts/macos-installers/Flowtake-macos-universal.zip
+            artifacts/linux-installers/*.deb
+            artifacts/linux-installers/*.AppImage
+            artifacts/linux-installers/*.rpm
+            artifacts/linux-installers/Flowtake-linux-x64-portable.tar.gz

--- a/SUPPORT_AND_PERFORMANCE.md
+++ b/SUPPORT_AND_PERFORMANCE.md
@@ -1,0 +1,66 @@
+# Flowtake support and performance gates
+
+This document states the platforms Flowtake actually targets today and the measurements required before making performance claims. The numbers below are release gates, not achieved results.
+
+## Support matrix
+
+| Platform | Current recorder path | Support status |
+| --- | --- | --- |
+| Windows 10/11 x64 | Desktop capture through FFmpeg/DXGI (`ddagrab`) | Primary validation target. Release performance gates are not yet certified. |
+| Windows ARM64 | No ARM64 release artifact or validated capture path | Not supported. |
+| macOS 10.15+ on Intel or Apple Silicon | AVFoundation capture; VideoToolbox when available | Developer preview. Keyboard visualization is unavailable and the performance matrix must still be validated. |
+| Linux x64 with X11 or XWayland | `x11grab`; keyboard input through `xdotool` | Developer preview. Distribution packaging does not imply recorder certification. |
+| Linux with pure Wayland | No PipeWire/portal recorder path is wired | Recording is not supported. |
+| Linux ARM64 | No release artifact or validated capture path | Not supported. |
+| iOS, Android, and ChromeOS | No desktop recorder implementation | Not supported. |
+
+Flowtake is a desktop application. A hardware encoder should only be shown as available after a short encode probe succeeds on that machine. A failed probe must fall back to a tested software encoder and explain the downgrade; the UI setting must select the encoder used by the recorder.
+
+## Measurable release gates
+
+Run each recording case three times on a clean reboot and report the median and worst run. Keep the raw diagnostics, FFmpeg logs, source resolution, display scaling, codec, bitrate, and hardware identifiers.
+
+| Scenario | Required gate before release |
+| --- | --- |
+| 1080p60, 10 minutes, hardware encode | Dropped/duplicated frames <= 0.1%; A/V drift <= 50 ms; machine CPU <= 8%; Flowtake + FFmpeg working-set growth <= 150 MiB; stop-to-project-ready p95 <= 2 seconds. |
+| 4K60, 10 minutes, hardware encode | Dropped/duplicated frames <= 0.1%; A/V drift <= 80 ms; machine CPU <= 12%; working-set growth <= 300 MiB; unsupported hardware must downgrade without losing the recording. |
+| Two-hour soak | Memory slope < 5 MiB/hour after warm-up; zero orphan Flowtake FFmpeg processes; zero abandoned temporary recordings; final A/V drift <= 100 ms. |
+| Lifecycle stress | 20 pause/resume, cancel, stop, and restart cycles with zero process leaks, zero stuck overlays, and every output playable. |
+| Main menu and settings | Cold launch to responsive UI p95 <= 2 seconds; local interaction response p95 <= 100 ms; idle working set <= 120 MiB; every visible setting changes real runtime behavior or is removed. |
+
+GPU utilization varies by encoder and GPU generation, so capture engine-specific `Video Encode` utilization and publish the raw series instead of using a universal GPU percentage gate. The capture path must remain responsive while a hardware encoder is saturated and must surface a controlled quality downgrade rather than silently dropping content.
+
+## Device and layout validation
+
+Validate the recorder menu, settings, source picker, countdown, recording controls, and plugin controls at 760x520, 1000x600, 1366x768, 1920x1080, and 3840x2160. On Windows, also test 100%, 125%, 150%, and 200% display scaling plus mixed-DPI dual monitors. Acceptance requires no overlap, clipped controls, white gaps, focus traps, or keyboard-only dead ends.
+
+The macOS and Linux preview rows require equivalent real-device runs before promotion. Do not infer support from compilation or package generation alone.
+
+## Read-only Windows diagnostics
+
+While a recording is active, sample Flowtake and FFmpeg CPU, working set, private memory, threads, handles, and possible detached recorder processes:
+
+```powershell
+npm run diagnose:recording
+npm run diagnose:recording -- --sample-ms 5000 --json
+npm run diagnose:recording -- --fail-on-orphan
+```
+
+The command only reads Windows process telemetry. It does not launch or stop processes and does not read or change Flowtake settings. `orphanCandidates` are deliberately conservative: only detached FFmpeg commands with Flowtake-like paths or recording names are reported, so the output does not accuse unrelated FFmpeg workloads.
+
+## Comparison claim protocol
+
+Do not claim that Flowtake is faster than Screen Studio until both applications are tested on the same supported Mac, using the same display, source, resolution, frame rate, duration, codec class, and audio inputs. Run at least three trials per application and publish median plus worst-run CPU, memory, dropped frames, A/V drift, start latency, stop latency, and output quality. Cross-operating-system comparisons are not evidence for a product-level superiority claim.
+
+## Required automated checks
+
+Pull requests must pass:
+
+```powershell
+npm ci
+npm run lint
+npm test
+npm run build:frontend
+cargo check --manifest-path src-tauri/Cargo.toml --locked
+cargo clippy --manifest-path src-tauri/Cargo.toml --locked -- -D warnings --allow dead_code
+```

--- a/app/components/Button.jsx
+++ b/app/components/Button.jsx
@@ -8,7 +8,8 @@ export default function Button({
     children,
     size = "md",
     className,
-    tooltip
+    tooltip,
+    ...buttonProps
 }) {
 
     const getButtonSizeClass = size => {
@@ -50,6 +51,7 @@ export default function Button({
             onClick={onClick}
             disabled={disabled || isLoading}
             {...(tooltip ? { "data-tip": tooltip } : {})}
+            {...buttonProps}
         >
             {!isLoading && Icon && <Icon className={getIconSizeClass(size)} />}
             {isLoading && <span className={`loading loading-spinner ${getSpinnerSizeClass(size)}`} />}

--- a/app/components/PickerWrapper.jsx
+++ b/app/components/PickerWrapper.jsx
@@ -1,11 +1,12 @@
 import { XMarkIcon } from "@heroicons/react/20/solid"
 import PropTypes from "prop-types"
 
-export default function PickerWrapper({ children, onCancel }) {
+export default function PickerWrapper({ children, onCancel, instruction }) {
     return (<div className="h-full w-full relative overflow-hidden">
-        <div className="absolute z-10 w-full top-0 flex justify-center pt-1 pointer-events-none">
-            <div className="flex items-center px-3 py-2 bg-base-300 rounded-xl shadow-lg pointer-events-auto">
-                <button className="btn btn-sm btn-error" onClick={onCancel}>
+        <div className="absolute z-20 w-full top-0 flex justify-center pt-3 px-3 pointer-events-none">
+            <div className="flex items-center gap-3 px-3 py-2 bg-base-300/95 backdrop-blur rounded-xl shadow-lg pointer-events-auto border border-base-content/10">
+                {instruction && <p className="text-sm font-medium text-base-content/80">{instruction}</p>}
+                <button type="button" className="btn btn-sm btn-ghost text-error" onClick={onCancel}>
                     <XMarkIcon className="h-5 w-5" />Cancel
                 </button>
             </div>
@@ -16,5 +17,6 @@ export default function PickerWrapper({ children, onCancel }) {
 
 PickerWrapper.propTypes = {
     children: PropTypes.node.isRequired,
-    onCancel: PropTypes.func.isRequired
+    onCancel: PropTypes.func.isRequired,
+    instruction: PropTypes.string,
 }

--- a/app/shared/redux/pluginSlice.js
+++ b/app/shared/redux/pluginSlice.js
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSelector, createSlice } from '@reduxjs/toolkit'
 
 export const FEATURE_IDS = {
     APP_RECORDING: 'appRecording',
@@ -91,9 +91,9 @@ export const selectPluginsDir = state => state.plugin.pluginsDir
 export const selectIsHydrated = state => state.plugin.isHydrated
 export const selectIsDrawMouseModeActive = state => !!state.plugin.isDrawMouseModeActive
 
-export const selectPersistedShape = state => ({
-    enabled: state.plugin.enabled,
-    config: state.plugin.config,
-})
+export const selectPersistedShape = createSelector(
+    [selectAllEnabled, state => state.plugin.config],
+    (enabled, config) => ({ enabled, config })
+)
 
 export default pluginSlice.reducer

--- a/app/shared/systemAudio.js
+++ b/app/shared/systemAudio.js
@@ -1,0 +1,11 @@
+const LOOPBACK_DEVICE_PATTERN = /(?:stereo mix|what u hear|wave out mix|loopback|virtual[- ]audio[- ]capturer|blackhole|soundflower|monitor of|\.monitor\b|vb[- ]?audio|vb[- ]?cable|voicemeeter|cable (?:input|output))/i
+
+export function isLikelySystemAudioSource(label) {
+    return typeof label === "string" && LOOPBACK_DEVICE_PATTERN.test(label.trim())
+}
+
+export function getSystemAudioSources(devices = []) {
+    return [...new Set(devices
+        .filter(({ kind, label }) => kind === "audioinput" && isLikelySystemAudioSource(label))
+        .map(({ label }) => label.trim()))]
+}

--- a/app/windows/areaPicker/App.jsx
+++ b/app/windows/areaPicker/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { AreaSelector } from "@bmunozg/react-image-area"
 import { CursorArrowRaysIcon } from "@heroicons/react/24/outline"
 import PickerWrapper from "../../components/PickerWrapper"
@@ -11,46 +11,76 @@ export default function App() {
 
     const [areas, setAreas] = useState([])
     const [bgImage, setBgImage] = useState(null)
+    const [loadError, setLoadError] = useState(false)
+    const [loadAttempt, setLoadAttempt] = useState(0)
 
     // Fetch the pre-captured screenshot (captured by Rust before this window opened)
     useEffect(() => {
         let imageSrc
+        setLoadError(false)
         window.electron.ipcRenderer.invoke("get-picker-screenshot")
             .then(loadPickerImageSrc)
             .then(src => {
                 imageSrc = src
                 if (src) setBgImage(src)
             })
-            .catch(e => console.warn("[AreaPicker] Screenshot failed:", e))
+            .catch(e => {
+                console.warn("[AreaPicker] Screenshot failed:", e)
+                setLoadError(true)
+            })
 
         return () => releasePickerImageSrc(imageSrc)
-    }, [])
+    }, [loadAttempt])
 
-    const onCancel = () => window.electron.ipcRenderer.invoke("close-area-picker-window")
+    const onCancel = useCallback(() => window.electron.ipcRenderer.invoke("close-area-picker-window"), [])
 
-    const onSelect = () => window.electron.ipcRenderer.invoke("select-area", { ...areas[0], type: "area", name: "Area" })
+    const onSelect = useCallback(() => {
+        if (!areas[0]) return
+        window.electron.ipcRenderer.invoke("select-area", { ...areas[0], type: "area", name: "Area" })
+    }, [areas])
+
+    useEffect(() => {
+        const handleKeyDown = event => {
+            if (event.key === "Escape") onCancel()
+            if (event.key === "Enter" && areas[0]) onSelect()
+        }
+        window.addEventListener("keydown", handleKeyDown)
+        return () => window.removeEventListener("keydown", handleKeyDown)
+    }, [areas, onCancel, onSelect])
 
     const customRender = areaProps => {
-        if (!areaProps.isChanging) {
-            return (<div key={areaProps.areaNumber}
-                className="group w-full h-full flex items-center justify-center border-primary/50 bg-transparent border-4 hover:border-primary hover:bg-primary/10 transition-colors">
-                <button onClick={onSelect}
-                    className="btn btn-primary opacity-0 group-hover:opacity-100 transition-opacity shadow-lg" >
-                    <CursorArrowRaysIcon className="h-6 w-6" />
-                    Record area</button>
-            </div>)
-        }
+        return (<div key={areaProps.areaNumber}
+            className={`w-full h-full border-4 transition-colors ${areaProps.isChanging ? "border-primary/70" : "border-primary bg-primary/5"}`} />)
     }
 
-    return (<PickerWrapper onCancel={onCancel} >
+    const hasArea = !!areas[0]
+
+    return (<PickerWrapper
+        onCancel={onCancel}
+        instruction={hasArea ? "Selection ready - press Enter or confirm below" : "Drag anywhere to select the recording area"}>
         <AreaSelector areas={areas} maxAreas={1} minWidth={MIN_WIDTH} minHeight={MIN_HEIGHT}
             unit="percentage" onChange={setAreas}
             customAreaRenderer={customRender}>
-            {bgImage
+            {loadError
+                ? <div className="w-screen h-screen bg-base-300 flex flex-col items-center justify-center gap-3">
+                    <p className="text-sm text-base-content/70">The screen preview could not load.</p>
+                    <button type="button" className="btn btn-sm btn-primary" onClick={() => setLoadAttempt(value => value + 1)}>
+                        Try again
+                    </button>
+                </div>
+                : bgImage
                 ? <img src={bgImage} className="w-screen h-screen object-cover select-none" alt="" draggable={false} />
                 : <div className="w-screen h-screen bg-base-300 flex items-center justify-center">
                     <span className="loading loading-spinner loading-lg"></span>
                 </div>}
         </AreaSelector>
+        {hasArea && (
+            <div className="absolute inset-x-0 bottom-5 z-20 flex justify-center pointer-events-none">
+                <button type="button" onClick={onSelect} className="btn btn-primary shadow-xl pointer-events-auto min-h-12 px-6">
+                    <CursorArrowRaysIcon className="h-5 w-5" />
+                    Record this area
+                </button>
+            </div>
+        )}
     </PickerWrapper>)
 }

--- a/app/windows/main/App.jsx
+++ b/app/windows/main/App.jsx
@@ -16,8 +16,7 @@ import {
     TOAST_ERROR_CAPTURE,
     TOAST_EXPORT_COMPLETED,
     TOAST_UPDATE,
-    TOAST_UPDATE_READY,
-    TOAST_WARNING
+    TOAST_UPDATE_READY
 } from "@shared/helpers"
 import { addErrorToast } from "@shared/errorToastHelper"
 import { initSystemInfo } from "@shared/errorReporting"
@@ -120,6 +119,12 @@ export default function App() {
         setShowSetupWizard(false)
     }, [])
 
+    useEffect(() => {
+        const showSetup = () => setShowSetupWizard(true)
+        window.addEventListener("flowtake-run-setup", showSetup)
+        return () => window.removeEventListener("flowtake-run-setup", showSetup)
+    }, [])
+
     const getCapturersAndEncoders = useCallback(async () => {
         try {
             const c = await window.electron.ipcRenderer.invoke("get-capturers")
@@ -173,15 +178,29 @@ export default function App() {
         const consumeEarlyData = async () => {
             try {
                 if (window.__earlyData) {
-                    const [c, e, setupDone] = await Promise.all([
-                        window.__earlyData.capturers,
-                        window.__earlyData.encoders,
-                        window.__earlyData.setupCompleted
+                    const earlyData = window.__earlyData
+                    window.__earlyData = null
+
+                    // Capture-engine discovery and setup state are cheap. Show
+                    // the launcher as soon as those are ready while the real
+                    // hardware-encoder probes finish in the background. A cold
+                    // GPU driver can otherwise hold the splash for several
+                    // seconds even though the rest of the app is usable.
+                    const [c, setupDone] = await Promise.all([
+                        earlyData.capturers,
+                        earlyData.setupCompleted
                     ])
                     dispatch(setCapturers(Array.isArray(c) ? c : []))
-                    dispatch(setEncoders(Array.isArray(e) ? e : []))
                     setShowSetupWizard(setupDone !== true)
-                    window.__earlyData = null
+                    dismissSplash()
+
+                    try {
+                        const e = await earlyData.encoders
+                        dispatch(setEncoders(Array.isArray(e) ? e : []))
+                    } catch (encoderError) {
+                        console.error("[Flowtake] Failed to detect video encoders:", encoderError)
+                        dispatch(setEncoders([]))
+                    }
                 } else {
                     await getCapturersAndEncoders()
                     const setupDone = await window.electron.ipcRenderer.invoke("store-get", "hasCompletedSetup").catch(() => null)

--- a/app/windows/main/DeviceRecorder.js
+++ b/app/windows/main/DeviceRecorder.js
@@ -1,3 +1,54 @@
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value))
+
+const supportedMimeType = candidates => {
+    if (typeof MediaRecorder === "undefined" || typeof MediaRecorder.isTypeSupported !== "function") return ""
+    return candidates.find(candidate => MediaRecorder.isTypeSupported(candidate)) || ""
+}
+
+export function getRecorderOptions(stream) {
+    const hasVideo = stream.getVideoTracks().length > 0
+    const hasAudio = stream.getAudioTracks().length > 0
+
+    const mimeCandidates = hasVideo
+        ? (hasAudio
+            ? [
+                "video/webm;codecs=vp9,opus",
+                "video/webm;codecs=vp8,opus",
+                "video/webm",
+            ]
+            : [
+                "video/webm;codecs=vp9",
+                "video/webm;codecs=vp8",
+                "video/webm",
+            ])
+        : ["audio/webm;codecs=opus", "audio/webm"]
+
+    const options = {}
+    const mimeType = supportedMimeType(mimeCandidates)
+    if (mimeType) options.mimeType = mimeType
+
+    if (hasAudio) options.audioBitsPerSecond = 96_000
+
+    if (hasVideo) {
+        const settings = stream.getVideoTracks()[0].getSettings?.() || {}
+        const width = Number(settings.width) || 1280
+        const height = Number(settings.height) || 720
+        const frameRate = Number(settings.frameRate) || 30
+
+        // Scale camera bitrate with the actual negotiated stream instead of
+        // forcing every device into the old 1 Mbps ceiling. The cap keeps 4K
+        // camera streams bounded while leaving WebView hardware encoders room
+        // to produce a clean 1080p image.
+        options.videoBitsPerSecond = clamp(
+            Math.round(width * height * frameRate * 0.07),
+            1_500_000,
+            12_000_000
+        )
+    }
+
+    return options
+}
+
 export default class DeviceRecorder {
 
     constructor() {
@@ -5,6 +56,9 @@ export default class DeviceRecorder {
         this.enqueuePromise = Promise.resolve()
         this.enqueueError = null
         this.previewEl = null
+        this.stream = null
+        this.pendingChunks = 0
+        this.finalized = false
     }
 
     async init(cameraMicConfig, videoEl = null) {
@@ -28,12 +82,8 @@ export default class DeviceRecorder {
         }
 
         try {
-            // Create MediaRecorder
-            this.mediaRecorder = new MediaRecorder(stream, {
-                mimeType: 'video/webm;codecs=vp9,opus',
-                audioBitsPerSecond: 64000,
-                videoBitsPerSecond: 1000000
-            })
+            this.stream = stream
+            this.mediaRecorder = new MediaRecorder(stream, getRecorderOptions(stream))
 
             const enqueue = async data =>
                 window.electron.ipcRenderer.invoke("enqueue-camera-chunk", await data.arrayBuffer())
@@ -44,10 +94,14 @@ export default class DeviceRecorder {
                 // stop. enqueuePromise makes sure chunks are written in order. finalize-camera-file
                 // ensures the queue is completed.
                 if (data.size > 0) {
+                    this.pendingChunks += 1
                     this.enqueuePromise = this.enqueuePromise
                         .then(() => enqueue(data))
                         .catch(error => {
                             this.enqueueError = this.enqueueError || error
+                        })
+                        .finally(() => {
+                            this.pendingChunks = Math.max(0, this.pendingChunks - 1)
                         })
                 }
             })
@@ -58,32 +112,67 @@ export default class DeviceRecorder {
     }
 
     async initFile() {
+        this.enqueuePromise = Promise.resolve()
+        this.enqueueError = null
+        this.pendingChunks = 0
+        this.finalized = false
         await window.electron.ipcRenderer.invoke("init-camera-file")
     }
 
     async start() {
+        if (!this.mediaRecorder) throw new Error("Camera and microphone are not ready.")
+        if (this.mediaRecorder.state !== "inactive") return
         // Smaller chunks avoid large renderer/IPC spikes during longer recordings.
         this.mediaRecorder.start(1000)
     }
 
+    pause() {
+        if (this.mediaRecorder?.state === "recording") this.mediaRecorder.pause()
+    }
+
+    resume() {
+        if (this.mediaRecorder?.state === "paused") this.mediaRecorder.resume()
+    }
+
     async stop() {
-        // Request any remaining buffered data
-        if (this.mediaRecorder.state !== "inactive") {
-            await new Promise(resolve => {
-                this.mediaRecorder.addEventListener('dataavailable', resolve, { once: true })
+        if (this.finalized) return
+
+        // Wait for MediaRecorder's stop event, which is emitted after its final
+        // dataavailable event. Waiting on dataavailable alone can finalize the
+        // native file before the last chunk has joined the ordered IPC queue.
+        if (this.mediaRecorder?.state !== "inactive") {
+            await new Promise((resolve, reject) => {
+                const cleanup = () => {
+                    this.mediaRecorder.removeEventListener("stop", onStop)
+                    this.mediaRecorder.removeEventListener("error", onError)
+                }
+                const onStop = () => {
+                    cleanup()
+                    resolve()
+                }
+                const onError = event => {
+                    cleanup()
+                    reject(event?.error || new Error("Device recording failed."))
+                }
+                this.mediaRecorder.addEventListener("stop", onStop, { once: true })
+                this.mediaRecorder.addEventListener("error", onError, { once: true })
                 this.mediaRecorder.stop()
             })
-            await this.enqueuePromise
-            if (this.enqueueError) throw this.enqueueError
         }
 
+        await this.enqueuePromise
+        if (this.enqueueError) throw this.enqueueError
+
         await window.electron.ipcRenderer.invoke("finalize-camera-file")
+        this.finalized = true
     }
 
     destroy() {
-        this.mediaRecorder?.stream?.getTracks().forEach(track => track.stop())
+        this.stream?.getTracks().forEach(track => track.stop())
         if (this.previewEl) this.previewEl.srcObject = null
         this.mediaRecorder = null
+        this.stream = null
         this.previewEl = null
+        this.pendingChunks = 0
     }
 }

--- a/app/windows/main/components/Launcher.jsx
+++ b/app/windows/main/components/Launcher.jsx
@@ -2,86 +2,63 @@ import {
   Cog6ToothIcon,
   FolderOpenIcon,
   PuzzlePieceIcon,
-  SignalIcon,
   VideoCameraIcon,
 } from "@heroicons/react/24/outline"
 import {
   CodeBracketSquareIcon,
 } from "@heroicons/react/16/solid"
 import PropTypes from 'prop-types'
-import { useState } from "react"
-import { useDispatch } from "react-redux"
+import { lazy, Suspense, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
 import { useQuery } from "@tanstack/react-query"
 import logo from "@shared/assets/logo.svg"
 import TitleBar from "../../../components/TitleBar"
 import ExportButton from "./ExportButton"
-import Live from "./live/Live"
-import NewRecording from "./newRecording/NewRecording"
-import Plugins from "./plugins/Plugins"
-import Projects from "./projects/Projects"
-import { setOpenSettings } from "@shared/redux/appSlice"
+import {
+  selectCapturers,
+  selectEncoders,
+  setOpenSettings,
+} from "@shared/redux/appSlice"
 import { SETTINGS_GENERAL } from "./settings/constants"
+
+const NewRecording = lazy(() => import("./newRecording/NewRecording"))
+const Projects = lazy(() => import("./projects/Projects"))
+const Plugins = lazy(() => import("./plugins/Plugins"))
 
 const VIEW_RECORD = "record"
 const VIEW_PROJECTS = "projects"
 const VIEW_PLUGINS = "plugins"
-const VIEW_LIVE = "live"
 
-const VIEW_ORDER = [VIEW_RECORD, VIEW_PROJECTS, VIEW_LIVE, VIEW_PLUGINS]
+const VIEW_ORDER = [VIEW_RECORD, VIEW_PROJECTS]
+const EXPERIMENTAL_VIEW_ORDER = [VIEW_PLUGINS]
 
 const VIEW_META = {
-  [VIEW_RECORD]:   { num: "01", label: "Record",   icon: VideoCameraIcon },
-  [VIEW_PROJECTS]: { num: "02", label: "Library",  icon: FolderOpenIcon },
-  [VIEW_LIVE]:     { num: "03", label: "Live",     icon: SignalIcon },
-  [VIEW_PLUGINS]:  { num: "04", label: "Plugins",  icon: PuzzlePieceIcon },
-}
-
-function getGreeting() {
-  const h = new Date().getHours()
-  if (h < 5) return "Working late,"
-  if (h < 12) return "Good morning,"
-  if (h < 18) return "Good afternoon,"
-  return "Good evening,"
-}
-
-function getHeadline({ activeView, isFirstRun }) {
-  if (activeView === VIEW_RECORD) {
-    if (isFirstRun) return { line1: "Hello,", accent: "welcome." }
-    return { line1: getGreeting(), accent: "ready." }
-  }
-  if (activeView === VIEW_PROJECTS) return { line1: "Your", accent: "archive." }
-  if (activeView === VIEW_LIVE)     return { line1: "Go", accent: "live." }
-  if (activeView === VIEW_PLUGINS)  return { line1: "Extend the", accent: "runtime." }
-  return { line1: "", accent: "" }
-}
-
-function getDescription({ activeView, totalProjects }) {
-  if (activeView === VIEW_RECORD) {
-    return "Pick a source, set up audio, then hit record. Auto-zoom does the rest."
-  }
-  if (activeView === VIEW_PROJECTS) {
-    return totalProjects > 0
-      ? `${totalProjects} ${totalProjects === 1 ? "project" : "projects"} saved locally.`
-      : "Your recordings will appear here."
-  }
-  if (activeView === VIEW_LIVE) {
-    return "Pick a source, set up audio, then hit Go Live. Hold the zoom hotkey to zoom in mid-stream."
-  }
-  return "Toggle built-in extensions and drop in your own (research preview)."
+  [VIEW_RECORD]: {
+    label: "Record",
+    icon: VideoCameraIcon,
+    description: "Choose a source, confirm quality, and start a reliable local recording.",
+  },
+  [VIEW_PROJECTS]: {
+    label: "Library",
+    icon: FolderOpenIcon,
+    description: "Open a recording or continue a saved project.",
+  },
+  [VIEW_PLUGINS]: {
+    label: "Plugins",
+    icon: PuzzlePieceIcon,
+    description: "Enable built-in experimental recording tools.",
+  },
 }
 
 export default function Launcher() {
 
   const [activeView, setActiveView] = useState(VIEW_RECORD)
   const dispatch = useDispatch()
+  const capturers = useSelector(selectCapturers)
+  const encoders = useSelector(selectEncoders)
   const { data: version } = useQuery({
     queryKey: ['version'],
     queryFn: () => window.electron.ipcRenderer.invoke("get-version"),
-    staleTime: Infinity
-  })
-  const { data: launchCount } = useQuery({
-    queryKey: ['launchCount'],
-    queryFn: () => window.electron.ipcRenderer.invoke("store-get", "launchCount"),
     staleTime: Infinity
   })
   const { data: projectsMeta } = useQuery({
@@ -96,15 +73,11 @@ export default function Launcher() {
   })
 
   const totalProjects = projectsMeta?.count ?? 0
-  const isFirstRun = (launchCount ?? 0) <= 1
-  const headline = getHeadline({ activeView, isFirstRun })
-  const description = getDescription({ activeView, totalProjects })
-
-  const statusLabel = isFirstRun
-    ? "New session"
-    : totalProjects > 0
-      ? `${totalProjects} ${totalProjects === 1 ? "take" : "takes"} on disk`
-      : "Ready"
+  const activeMeta = VIEW_META[activeView]
+  const recorderReady = capturers.length > 0 && encoders.length > 0
+  const statusLabel = activeView === VIEW_RECORD
+    ? recorderReady ? "Ready" : "Setup needed"
+    : activeView === VIEW_PLUGINS ? "Experimental" : "Stored locally"
 
   return (<>
     <TitleBar>
@@ -112,15 +85,17 @@ export default function Launcher() {
     </TitleBar>
 
     <div className="flex h-full overflow-hidden">
-      {/* Sidebar */}
-      <aside className="flowtake-sidebar-rail relative w-[64px] flex-shrink-0 bg-base-200/30 border-r border-base-content/5 flex flex-col items-center py-4 gap-1.5">
-        <div className="size-9 rounded-xl flex items-center justify-center mb-2 overflow-hidden relative">
-          <span
-            aria-hidden="true"
-            className="absolute inset-0 rounded-xl"
-            style={{ boxShadow: "0 0 0 1px color-mix(in oklab, var(--color-primary) 35%, transparent), 0 0 18px color-mix(in oklab, var(--color-primary) 25%, transparent)" }}
-          />
-          <img src={logo} alt="Flowtake" className="size-7 relative" />
+      <aside className="flowtake-sidebar-rail relative w-14 sm:w-44 flex-shrink-0 bg-base-200/30 border-r border-base-content/5 flex flex-col items-center sm:items-stretch px-2 py-3 gap-1">
+        <div className="h-10 flex items-center justify-center sm:justify-start sm:px-2 gap-2 mb-2">
+          <div className="size-8 rounded-xl flex items-center justify-center overflow-hidden relative flex-shrink-0">
+            <span
+              aria-hidden="true"
+              className="absolute inset-0 rounded-xl"
+              style={{ boxShadow: "0 0 0 1px color-mix(in oklab, var(--color-primary) 35%, transparent), 0 0 18px color-mix(in oklab, var(--color-primary) 25%, transparent)" }}
+            />
+            <img src={logo} alt="" className="size-6 relative" />
+          </div>
+          <span className="hidden sm:block font-brand font-semibold text-sm">Flowtake</span>
         </div>
 
         {VIEW_ORDER.map(view => (
@@ -130,6 +105,21 @@ export default function Launcher() {
             label={VIEW_META[view].label}
             active={activeView === view}
             badge={view === VIEW_PROJECTS && totalProjects > 0 ? totalProjects : null}
+            onClick={() => setActiveView(view)}
+          />
+        ))}
+
+        <div className="hidden sm:block px-3 pt-3 pb-1 text-[9px] font-semibold uppercase tracking-[0.14em] text-base-content/30">
+          Experimental
+        </div>
+        <div className="sm:hidden my-1 border-t border-base-content/5" aria-hidden="true" />
+        {EXPERIMENTAL_VIEW_ORDER.map(view => (
+          <SidebarItem
+            key={view}
+            icon={VIEW_META[view].icon}
+            label={`${VIEW_META[view].label} (experimental)`}
+            visibleLabel={VIEW_META[view].label}
+            active={activeView === view}
             onClick={() => setActiveView(view)}
           />
         ))}
@@ -151,101 +141,38 @@ export default function Launcher() {
           label="Settings"
           onClick={() => dispatch(setOpenSettings(SETTINGS_GENERAL))}
         />
+        <div className="hidden sm:flex items-center justify-between px-3 pt-2 mt-1 border-t border-base-content/5 text-[10px] text-base-content/35">
+          <span>Local recorder</span>
+          <span>v{version || "—"}</span>
+        </div>
       </aside>
 
-      {/* Main stage */}
       <main className="flowtake-stage flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden">
         <div className="flowtake-grain" />
-
-        <div className="relative flex-1 min-h-0 w-full max-w-6xl mx-auto px-5 md:px-8 pt-2 pb-2 flex flex-col overflow-hidden">
-
-          {/* Eyebrow + status pill */}
-          <header className="flex-shrink-0 flex items-center justify-between gap-3 mb-1.5">
-            <p className="flowtake-eyebrow flowtake-rise flex items-center gap-2">
-              <span className="inline-block h-px w-4 bg-base-content/35" />
-              {isFirstRun ? "First take" : "Now playing"}
-              <span className="text-base-content/25">&middot;</span>
-              v{version || "—"}
-              <span className="text-base-content/25">&middot;</span>
-              MIT
-            </p>
-
-            <span className="flowtake-status-pill flowtake-rise" style={{ animationDelay: "0.05s" }}>
+        <div className="relative flex-1 min-h-0 w-full max-w-6xl mx-auto p-3 md:p-5 flex flex-col overflow-hidden">
+          <header className="flex-shrink-0 flex items-start justify-between gap-4 mb-3">
+            <div className="min-w-0">
+              <h1 className="font-brand font-semibold text-lg md:text-xl text-base-content/95">
+                {activeMeta.label}
+              </h1>
+              <p className="text-xs md:text-sm text-base-content/55 leading-snug truncate sm:whitespace-normal">
+                {activeView === VIEW_PROJECTS && totalProjects > 0
+                  ? `${totalProjects} ${totalProjects === 1 ? "project" : "projects"} saved locally.`
+                  : activeMeta.description}
+              </p>
+            </div>
+            <span className="flowtake-status-pill flex-shrink-0" aria-label={`Recorder status: ${statusLabel}`}>
               <span className="flowtake-status-pill__dot" />
               {statusLabel}
             </span>
           </header>
 
-          {/* Hero headline */}
-          <div className="flex-shrink-0">
-            <h1
-              key={`${activeView}-${isFirstRun}`}
-              className="flowtake-display flowtake-rise text-[26px] md:text-[34px] lg:text-[40px] text-base-content/95 whitespace-nowrap"
-              style={{ animationDelay: "0.08s" }}
-            >
-              {headline.line1}{" "}
-              <em className="flowtake-display--italic text-primary">
-                {headline.accent}
-              </em>
-            </h1>
-            <p
-              className="flowtake-rise mt-1 text-[12px] md:text-[13px] text-base-content/55 max-w-xl leading-snug"
-              style={{ animationDelay: "0.18s" }}
-            >
-              {description}
-            </p>
-          </div>
-
-          {/* First-run pull-quote */}
-          {isFirstRun && activeView === VIEW_RECORD && (
-            <div
-              className="flowtake-pullquote flowtake-pullquote--compact flowtake-rise flex-shrink-0 mt-2 max-w-xl"
-              style={{ animationDelay: "0.24s" }}
-            >
-              <p className="flowtake-pullquote__lead">
-                Enable system audio and a microphone for tutorials. Cursor zoom, masks, and click effects are choreographed automatically.
-              </p>
-            </div>
-          )}
-
-          {/* Numbered navigation */}
-          <nav
-            className="flowtake-rise flex-shrink-0 mt-2.5 flex items-baseline gap-5 md:gap-7 border-t border-base-content/10 pt-2"
-            style={{ animationDelay: "0.28s" }}
-            aria-label="Primary"
-          >
-            {VIEW_ORDER.map(view => {
-              const meta = VIEW_META[view]
-              const isActive = activeView === view
-              return (
-                <button
-                  key={view}
-                  type="button"
-                  onClick={() => setActiveView(view)}
-                  className="flowtake-nav-item"
-                  data-active={isActive ? "true" : "false"}
-                >
-                  <span className="flowtake-numeral">{meta.num}</span>
-                  <span>{meta.label}</span>
-                  {view === VIEW_PROJECTS && totalProjects > 0 && (
-                    <span className="ml-0.5 text-[10px] text-base-content/35 font-medium tabular-nums">
-                      ({totalProjects})
-                    </span>
-                  )}
-                </button>
-              )
-            })}
-          </nav>
-
-          {/* Content surface */}
-          <section
-            className="flowtake-rise flex-1 min-h-0 mt-2.5 overflow-hidden"
-            style={{ animationDelay: "0.34s" }}
-          >
-            <NewRecording isOpen={activeView === VIEW_RECORD} />
-            <Projects isOpen={activeView === VIEW_PROJECTS} />
-            <Live isOpen={activeView === VIEW_LIVE} />
-            <Plugins isOpen={activeView === VIEW_PLUGINS} />
+          <section className="flex-1 min-h-0 overflow-hidden" aria-label={`${activeMeta.label} workspace`}>
+            <Suspense fallback={<ViewLoading label={activeMeta.label} />}>
+              {activeView === VIEW_RECORD && <NewRecording isOpen />}
+              {activeView === VIEW_PROJECTS && <Projects isOpen />}
+              {activeView === VIEW_PLUGINS && <Plugins isOpen />}
+            </Suspense>
           </section>
         </div>
       </main>
@@ -265,18 +192,26 @@ GitHubIcon.propTypes = {
   className: PropTypes.string
 }
 
-function SidebarItem({ onClick, active, icon: Icon, label, badge }) {
+function SidebarItem({ onClick, active, icon: Icon, label, visibleLabel = label, badge }) {
   return (
     <button
+      type="button"
       onClick={onClick}
-      className="flowtake-sidebar-rail__item tooltip tooltip-right"
+      className={`tooltip tooltip-right sm:tooltip-none relative rounded-[0.6rem] w-10 sm:w-full h-10 sm:px-3 inline-flex items-center justify-center sm:justify-start sm:gap-3 transition-colors
+        ${active
+          ? "text-primary bg-primary/10"
+          : "text-base-content/50 hover:text-base-content/85 hover:bg-base-content/5"
+        }`}
       data-tip={label}
       data-active={active ? "true" : "false"}
+      aria-label={label}
+      aria-current={active ? "page" : undefined}
     >
       {active && (
         <span className="flowtake-sidebar-rail__accent" aria-hidden="true" />
       )}
       <Icon className="size-5" />
+      <span className="hidden sm:inline text-xs font-medium">{visibleLabel}</span>
       {badge != null && (
         <span className="absolute -top-0.5 -right-0.5 min-w-[16px] h-[16px] px-1 rounded-full bg-base-content/15 text-base-content/80 text-[9px] font-semibold flex items-center justify-center leading-none">
           {badge > 99 ? "99+" : badge}
@@ -286,10 +221,24 @@ function SidebarItem({ onClick, active, icon: Icon, label, badge }) {
   )
 }
 
+function ViewLoading({ label }) {
+  return (
+    <div className="h-full flex items-center justify-center gap-2 text-xs text-base-content/45" role="status">
+      <span className="loading loading-spinner loading-sm" />
+      Loading {label.toLowerCase()}…
+    </div>
+  )
+}
+
+ViewLoading.propTypes = {
+  label: PropTypes.string.isRequired,
+}
+
 SidebarItem.propTypes = {
   onClick: PropTypes.func.isRequired,
   active: PropTypes.bool,
   icon: PropTypes.elementType.isRequired,
   label: PropTypes.string.isRequired,
+  visibleLabel: PropTypes.string,
   badge: PropTypes.number,
 }

--- a/app/windows/main/components/SetupWizard.jsx
+++ b/app/windows/main/components/SetupWizard.jsx
@@ -3,16 +3,12 @@ import PropTypes from "prop-types"
 import TitleBar from "../../../components/TitleBar"
 import WelcomeStep from "./setup/WelcomeStep"
 import PermissionsStep from "./setup/PermissionsStep"
-import ExportPathStep from "./setup/ExportPathStep"
-import AppearanceStep from "./setup/AppearanceStep"
 import CompletionStep from "./setup/CompletionStep"
 
 const STEPS = [
     { id: "welcome", label: "Welcome" },
-    { id: "permissions", label: "Permissions" },
-    { id: "export", label: "Export" },
-    { id: "theme", label: "Theme" },
-    { id: "done", label: "Done" },
+    { id: "permissions", label: "Readiness" },
+    { id: "done", label: "Record" },
 ]
 
 export default function SetupWizard({ onComplete }) {
@@ -30,8 +26,6 @@ export default function SetupWizard({ onComplete }) {
         switch (STEPS[currentStep].id) {
             case "welcome": return <WelcomeStep />
             case "permissions": return <PermissionsStep />
-            case "export": return <ExportPathStep />
-            case "theme": return <AppearanceStep />
             case "done": return <CompletionStep onComplete={onComplete} />
             default: return null
         }
@@ -45,7 +39,7 @@ export default function SetupWizard({ onComplete }) {
 
         <div className="flex flex-col h-full pt-8">
             {/* Step indicator */}
-            <div className="px-8 pt-6 pb-2 flex-none">
+            <div className="px-4 sm:px-8 pt-5 pb-2 flex-none">
                 <ul className="steps steps-horizontal w-full">
                     {STEPS.map((step, i) => (
                         <li key={step.id} className={`step text-xs ${i <= currentStep ? "step-primary" : ""}`}>
@@ -56,28 +50,29 @@ export default function SetupWizard({ onComplete }) {
             </div>
 
             {/* Step content */}
-            <div className="flex-1 overflow-auto px-8 py-4">
+            <div className="flex-1 overflow-auto px-4 sm:px-8 py-4">
                 {renderStep()}
             </div>
 
             {/* Navigation */}
-            <div className="flex-none px-8 py-4 border-t border-base-content/10 flex items-center justify-between">
+            <div className="flex-none px-4 sm:px-8 py-4 border-t border-base-content/10 flex items-center justify-between">
                 <button
+                    type="button"
                     className="btn btn-ghost btn-sm"
                     onClick={onComplete}
                 >
-                    Skip setup
+                    Use defaults
                 </button>
 
                 <div className="flex gap-2">
                     {!isFirst && (
-                        <button className="btn btn-ghost btn-sm" onClick={prev}>
+                        <button type="button" className="btn btn-ghost btn-sm" onClick={prev}>
                             Back
                         </button>
                     )}
                     {!isLast && (
-                        <button className="btn btn-primary btn-sm" onClick={next}>
-                            Next
+                        <button type="button" className="btn btn-primary btn-sm" onClick={next}>
+                            {currentStep === 0 ? "Check readiness" : "Continue"}
                         </button>
                     )}
                 </div>

--- a/app/windows/main/components/newRecording/AppAudioControl.jsx
+++ b/app/windows/main/components/newRecording/AppAudioControl.jsx
@@ -35,6 +35,8 @@ export default function AppAudioControl({ onExcludedAppsChange }) {
       <div className="flex items-center justify-between mb-1.5">
         <span className="text-[10px] font-medium text-base-content/30 uppercase tracking-wider">App Audio</span>
         <button
+          type="button"
+          aria-label="Refresh app audio sessions"
           onClick={() => refetch()}
           disabled={isPending}
           className="btn btn-ghost btn-xs size-5 min-h-0 p-0"
@@ -64,6 +66,7 @@ export default function AppAudioControl({ onExcludedAppsChange }) {
                   value={!excludedPids.has(pid)}
                   onChange={() => toggleApp(pid)}
                   justifyBetween={false}
+                  rightLabel={<span className="sr-only">Include {name} audio</span>}
                 />
               </div>
             </div>

--- a/app/windows/main/components/newRecording/CameraMicrophoneSelect.jsx
+++ b/app/windows/main/components/newRecording/CameraMicrophoneSelect.jsx
@@ -10,113 +10,63 @@ import {
 } from "@tanstack/react-query"
 import {
   useCallback,
-  useEffect,
-  useRef,
   useState
 } from "react"
+import PropTypes from "prop-types"
 import {
-  CONSTRAINTS_AUDIO,
-  CONSTRAINTS_VIDEO
+  CONSTRAINTS_AUDIO
 } from "@shared/helpers"
-import useAudioMeter from "@shared/hooks/useAudioMeter"
-import VolumeMeter from "../../../../components/VolumeMeter"
 
-export default function CameraMicrophoneSelect() {
+const canonicalMediaDevices = (devices, excludedLabel = null) => (devices || [])
+  .filter(device => device.kind === "videoinput" || device.kind === "audioinput")
+  .filter(device => device.deviceId !== "default" && device.deviceId !== "communications")
+  .filter(device => !excludedLabel || device.label !== excludedLabel)
+
+const DETECT_CAMERA_VALUE = "__detect-camera__"
+const DETECT_MICROPHONE_VALUE = "__detect-microphone__"
+
+export default function CameraMicrophoneSelect({ audioProcessingSettings }) {
 
   const queryClient = useQueryClient()
   const [permissionDenied, setPermissionDenied] = useState({ video: false, audio: false })
-  const [meterStream, setMeterStream] = useState(null)
-  const meterStreamRef = useRef(null)
-  const { level, peak } = useAudioMeter(meterStream)
 
-  const detect = useCallback(async (type, mediaDevices) => {
-    const devices = (mediaDevices || []).filter(({ kind }) => kind === `${type}input`)
-
-    const configs = []
-
+  const detect = useCallback(async (type, excludedLabel = null) => {
     try {
-      for (const device of devices) {
-        const constraints = {
-          video: type === "video" ? { ...CONSTRAINTS_VIDEO, deviceId: device.deviceId } : false,
-          audio: type === "audio" ? { ...CONSTRAINTS_AUDIO, deviceId: device.deviceId } : false
-        }
+      // One lightweight permission probe unlocks labels for every device. Opening
+      // every camera and microphone serially made the launcher slow and glitchy.
+      const permissionStream = await navigator.mediaDevices.getUserMedia({
+        video: type === "video",
+        audio: type === "audio" ? { ...CONSTRAINTS_AUDIO, ...audioProcessingSettings } : false,
+      })
+      permissionStream.getTracks().forEach(track => track.stop())
 
-        const stream = await navigator.mediaDevices.getUserMedia(constraints)
-        if (!stream) continue
+      const refreshedDevices = await navigator.mediaDevices.enumerateDevices()
+      const configs = canonicalMediaDevices(refreshedDevices, excludedLabel)
+        .filter(device => device.kind === `${type}input`)
+        .map(device => ({
+          id: `mediaSource-${device.deviceId || device.groupId || device.label}`,
+          track: { label: device.label },
+          deviceId: device.deviceId,
+          label: device.label || `${type === "video" ? "Camera" : "Microphone"} ${device.deviceId.slice(0, 6)}`,
+        }))
 
-        let tracks
-
-        switch (type) {
-          case "video":
-            tracks = stream.getVideoTracks()
-            break
-          case "audio":
-            tracks = stream.getAudioTracks()
-            break
-        }
-
-        for (const track of tracks) {
-          configs.push({
-            id: `mediaSource-${self.crypto.randomUUID()}`,
-            track,
-            deviceId: device.deviceId,
-            label:
-              tracks.length > 1
-                ? `${device.label} (${track.label})`
-                : device.label,
-          })
-        }
-        stream.getTracks().forEach(track => track.stop())
-      }
+      setPermissionDenied(prev => ({ ...prev, [type]: false }))
+      return configs
     } catch (e) {
       // If permission was denied or device not available, mark it and stop retrying
       if (e.name === "NotAllowedError" || e.name === "PermissionDeniedError") {
         setPermissionDenied(prev => ({ ...prev, [type]: true }))
-        return configs
+        return []
       }
       console.log(e)
+      return []
     }
-
-    // Clear denied state on success
-    if (configs.length > 0) {
-      setPermissionDenied(prev => ({ ...prev, [type]: false }))
-    }
-
-    return configs
-      .filter(({ track }) => track.kind === type)
-      .map(({ id, track, deviceId, label }) => ({
-        id,
-        track: { label: track.label },
-        deviceId,
-        label,
-      }))
-  }, [])
-
-  const areDevicesEqual = useCallback((a, b) => {
-    if (!a || !b || a.length !== b.length) return false
-    return a.every(deviceFromA =>
-      b.some(deviceFromB =>
-        deviceFromB.label === deviceFromA.label && deviceFromB.deviceId === deviceFromA.deviceId))
-  }, [])
+  }, [audioProcessingSettings])
 
   const { data: systemAudio, isPending: isPendingSystemAudio } = useQuery({
     queryKey: ['systemAudio'],
     queryFn: () => window.electron.ipcRenderer.invoke("store-get", "defaultSystemAudioSource"),
     staleTime: Infinity
-  })
-
-  const { data: mediaDevices, isPending: isPendingMediaDevices } = useQuery({
-    queryKey: ['devices', systemAudio],
-    queryFn: async () => {
-      const devices = await navigator.mediaDevices.enumerateDevices()
-      return devices
-        .filter(({ kind }) => kind === "videoinput" || kind === "audioinput")
-        .filter(({ deviceId }) => deviceId !== "default" && deviceId !== "communications")
-        .filter(({ label }) => label !== systemAudio)
-    },
-    staleTime: 5000,
-    gcTime: 10000,
-    enabled: !isPendingSystemAudio
   })
 
   const { data: camera, isPending: isPendingCamera } = useQuery({
@@ -144,10 +94,13 @@ export default function CameraMicrophoneSelect() {
   })
 
   const { mutate: detectCameras, isPending: isPendingDetectCameras } = useMutation({
-    mutationFn: async () => {
-      const cameras = await detect("video", mediaDevices)
+    mutationFn: async ({ selectFirst = false } = {}) => {
+      const cameras = await detect("video")
       await window.electron.ipcRenderer.invoke("store-set", "videoSources", cameras)
-      await window.electron.ipcRenderer.invoke("store-set", "defaultVideoSource", null)
+      const nextSelection = cameras.some(device => device.id === camera)
+        ? camera
+        : selectFirst ? cameras[0]?.id ?? null : null
+      await window.electron.ipcRenderer.invoke("store-set", "defaultVideoSource", nextSelection)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['cameras'] })
@@ -156,10 +109,13 @@ export default function CameraMicrophoneSelect() {
   })
 
   const { mutate: detectMicrophones, isPending: isPendingDetectMicrophones } = useMutation({
-    mutationFn: async () => {
-      const microphones = await detect("audio", mediaDevices)
+    mutationFn: async ({ selectFirst = false } = {}) => {
+      const microphones = await detect("audio", systemAudio)
       await window.electron.ipcRenderer.invoke("store-set", "audioSources", microphones)
-      await window.electron.ipcRenderer.invoke("store-set", "defaultAudioSource", null)
+      const nextSelection = microphones.some(device => device.id === microphone)
+        ? microphone
+        : selectFirst ? microphones[0]?.id ?? null : null
+      await window.electron.ipcRenderer.invoke("store-set", "defaultAudioSource", nextSelection)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['microphones'] })
@@ -181,95 +137,39 @@ export default function CameraMicrophoneSelect() {
     },
   })
 
-  const { mutate: setCameras, isPending: isPendingSetCameras } = useMutation({
-    mutationFn: cameras => window.electron.ipcRenderer.invoke("store-set", "videoSources", cameras),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['cameras'] })
-    },
-  })
-
-  const { mutate: setMicrophones, isPending: isPendingSetMicrophones } = useMutation({
-    mutationFn: microphones => window.electron.ipcRenderer.invoke("store-set", "audioSources", microphones),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['microphones'] })
-    },
-  })
-
-  const clearCache = () => {
+  const refreshDevices = () => {
     setPermissionDenied({ video: false, audio: false })
-    setCameras(null)
-    setMicrophones(null)
-    queryClient.invalidateQueries({ queryKey: ['devices'] })
+    detectCameras()
+    detectMicrophones()
   }
 
-  useEffect(() => {
-    if (!isPendingMediaDevices &&
-      !isPendingCameras &&
-      !isPendingDetectCameras &&
-      !permissionDenied.video &&
-      mediaDevices &&
-      !areDevicesEqual(mediaDevices.filter(({ kind }) => kind === "videoinput"), cameras))
-      detectCameras()
-  }, [mediaDevices, detectCameras, isPendingDetectCameras, isPendingMediaDevices, cameras, isPendingCameras, areDevicesEqual, permissionDenied.video])
-
-  useEffect(() => {
-    if (!isPendingMediaDevices &&
-      !isPendingMicrophones &&
-      !isPendingDetectMicrophones &&
-      !permissionDenied.audio &&
-      mediaDevices &&
-      !areDevicesEqual(mediaDevices.filter(({ kind }) => kind === "audioinput"), microphones))
-      detectMicrophones()
-  }, [mediaDevices, microphones, detectMicrophones, isPendingDetectMicrophones, isPendingMediaDevices, isPendingMicrophones, areDevicesEqual, permissionDenied.audio])
-
-  // Acquire a metering-only audio stream when a microphone is selected
-  useEffect(() => {
-    if (!microphone || !microphones || permissionDenied.audio) {
-      if (meterStreamRef.current) {
-        meterStreamRef.current.getTracks().forEach(t => t.stop())
-        meterStreamRef.current = null
-      }
-      setMeterStream(null)
-      return
-    }
-    const selected = microphones.find(({ id }) => id === microphone)
-    if (!selected) return
-
-    let cancelled = false
-    navigator.mediaDevices.getUserMedia({
-      video: false,
-      audio: { ...CONSTRAINTS_AUDIO, deviceId: selected.deviceId }
-    }).then(stream => {
-      if (cancelled) { stream.getTracks().forEach(t => t.stop()); return }
-      if (meterStreamRef.current) meterStreamRef.current.getTracks().forEach(t => t.stop())
-      meterStreamRef.current = stream
-      setMeterStream(stream)
-    }).catch(() => {})
-
-    return () => {
-      cancelled = true
-      if (meterStreamRef.current) {
-        meterStreamRef.current.getTracks().forEach(t => t.stop())
-        meterStreamRef.current = null
-      }
-      setMeterStream(null)
-    }
-  }, [microphone, microphones, permissionDenied.audio])
-
-  const options = (sources, defaultValue) => {
+  const options = (sources, defaultValue, detectValue, detectLabel) => {
     const options = [<option value="-1" key={0}>{defaultValue}</option>]
     sources?.forEach(
-      ({ id, track, label }, i) => options.push(<option value={id} key={i + 1}>{label ?? track.label}</option>))
+      ({ id, track, label }, i) => options.push(<option value={id} key={i + 1}>{label || track?.label}</option>))
+    options.push(<option value={detectValue} key={detectValue}>{detectLabel}</option>)
     return options
   }
 
-  const onSelectCamera = e => setCamera((cameras ?? []).find(({ id }) => id === e.target.value)?.id ?? null)
+  const onSelectCamera = e => {
+    if (e.target.value === DETECT_CAMERA_VALUE) {
+      detectCameras({ selectFirst: true })
+      return
+    }
+    setCamera((cameras ?? []).find(({ id }) => id === e.target.value)?.id ?? null)
+  }
 
-  const onSelectMicrophone = e => setMicrophone((microphones ?? []).find(({ id }) => id === e.target.value)?.id ?? null)
+  const onSelectMicrophone = e => {
+    if (e.target.value === DETECT_MICROPHONE_VALUE) {
+      detectMicrophones({ selectFirst: true })
+      return
+    }
+    setMicrophone((microphones ?? []).find(({ id }) => id === e.target.value)?.id ?? null)
+  }
 
-  const isPending = isPendingMediaDevices || isPendingCameras || isPendingDetectCameras || isPendingMicrophones ||
+  const isPending = isPendingSystemAudio || isPendingCameras || isPendingDetectCameras || isPendingMicrophones ||
     isPendingDetectMicrophones || isPendingCamera || isPendingMicrophone || isPendingSetCamera ||
-    isPendingSetMicrophone || isPendingSetCameras || isPendingSetMicrophones
+    isPendingSetMicrophone
 
   const hasAnyDenied = permissionDenied.video || permissionDenied.audio
 
@@ -281,6 +181,7 @@ export default function CameraMicrophoneSelect() {
           <VideoCameraIcon className="size-3.5" />
         </div>
         <select
+          aria-label="Camera"
           onChange={onSelectCamera}
           disabled={isPending || permissionDenied.video}
           value={camera ?? "-1"}
@@ -288,7 +189,7 @@ export default function CameraMicrophoneSelect() {
         >
           {permissionDenied.video
             ? <option value="-1">Camera not available</option>
-            : options(cameras, "No camera")}
+            : options(cameras, "Camera off", DETECT_CAMERA_VALUE, "Turn on a camera...")}
         </select>
       </div>
 
@@ -302,6 +203,7 @@ export default function CameraMicrophoneSelect() {
         </div>
         <div className="flex-1 min-w-0 flex flex-col gap-1">
           <select
+            aria-label="Microphone"
             onChange={onSelectMicrophone}
             disabled={isPending || permissionDenied.audio}
             value={microphone ?? "-1"}
@@ -309,31 +211,35 @@ export default function CameraMicrophoneSelect() {
           >
             {permissionDenied.audio
               ? <option value="-1">Mic not available</option>
-              : options(microphones, "No microphone")}
+              : options(microphones, "Microphone off", DETECT_MICROPHONE_VALUE, "Turn on a microphone...")}
           </select>
-          {microphone && !permissionDenied.audio && (
-            <VolumeMeter level={level} peak={peak} showPeak />
-          )}
         </div>
       </div>
 
-      {/* Refresh / Permission denied */}
-      {(hasAnyDenied || isPending) && (
-        <div className="flex items-center gap-2 mt-0.5">
-          <div className="size-7 flex-shrink-0" />
-          {hasAnyDenied && (
-            <p className="text-[11px] text-warning flex-1">Permission denied</p>
-          )}
-          <button
-            onClick={clearCache}
-            disabled={isPending}
-            className="btn btn-ghost btn-xs gap-1 text-base-content/40 hover:text-base-content/70"
-          >
-            <ArrowPathIcon className={`size-3 ${isPending ? "animate-spin" : ""}`} />
-            <span className="text-[11px]">{hasAnyDenied ? "Retry" : "Refresh"}</span>
-          </button>
-        </div>
-      )}
+      <div className="flex items-center gap-2 mt-0.5">
+        <div className="size-7 flex-shrink-0" />
+        <p className={`text-[11px] flex-1 ${hasAnyDenied ? "text-warning" : "text-base-content/40"}`}>
+          {hasAnyDenied ? "Permission denied" : "Camera and mic stay off until you choose one."}
+        </p>
+        <button
+          type="button"
+          aria-label={hasAnyDenied ? "Retry device detection" : "Refresh cameras and microphones"}
+          onClick={refreshDevices}
+          disabled={isPending}
+          className="btn btn-ghost btn-xs gap-1 text-base-content/40 hover:text-base-content/70 ml-auto"
+        >
+          <ArrowPathIcon className={`size-3 ${isPending ? "animate-spin" : ""}`} />
+          <span className="text-[11px]">{hasAnyDenied ? "Retry" : "Refresh"}</span>
+        </button>
+      </div>
     </div>
   )
+}
+
+CameraMicrophoneSelect.propTypes = {
+  audioProcessingSettings: PropTypes.shape({
+    noiseSuppression: PropTypes.bool,
+    echoCancellation: PropTypes.bool,
+    autoGainControl: PropTypes.bool,
+  }).isRequired,
 }

--- a/app/windows/main/components/newRecording/CameraPreview.jsx
+++ b/app/windows/main/components/newRecording/CameraPreview.jsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useRef
 } from "react"
+import PropTypes from "prop-types"
 import { useSelector } from "react-redux"
 import {
   CONSTRAINTS_AUDIO,
@@ -10,7 +11,7 @@ import {
 } from "@shared/helpers"
 import { selectIsCloseRequested } from "@shared/redux/appSlice"
 
-export default function CameraPreview() {
+export default function CameraPreview({ audioProcessingSettings }) {
 
   const previewVideoRef = useRef(null)
 
@@ -41,14 +42,14 @@ export default function CameraPreview() {
   })
 
   const { data: stream, isPending: isPendingStream } = useQuery({
-    queryKey: ['stream', camera, microphone, cameras, microphones],
+    queryKey: ['stream', camera, microphone, cameras, microphones, audioProcessingSettings],
     queryFn: async () => {
       let video = false
       let videoSource = null
       if (camera) {
         videoSource = (cameras ?? []).find(({ id }) => id === camera)
         if (!videoSource) return null
-        video = { ...CONSTRAINTS_VIDEO, deviceId: videoSource.deviceId }
+        video = { ...CONSTRAINTS_VIDEO, deviceId: { exact: videoSource.deviceId } }
       }
 
       let audio = false
@@ -56,7 +57,7 @@ export default function CameraPreview() {
       if (microphone) {
         audioSource = (microphones ?? []).find(({ id }) => id === microphone)
         if (!audioSource) return null
-        audio = { ...CONSTRAINTS_AUDIO, deviceId: audioSource.deviceId }
+        audio = { ...CONSTRAINTS_AUDIO, ...audioProcessingSettings, deviceId: { exact: audioSource.deviceId } }
       }
 
       try {
@@ -118,6 +119,7 @@ export default function CameraPreview() {
         <span className="loading loading-spinner"></span>
       </div>
       <video
+        aria-label="Camera preview"
         ref={previewVideoRef}
         autoPlay
         muted
@@ -126,4 +128,12 @@ export default function CameraPreview() {
       />
     </div>
   )
+}
+
+CameraPreview.propTypes = {
+  audioProcessingSettings: PropTypes.shape({
+    noiseSuppression: PropTypes.bool,
+    echoCancellation: PropTypes.bool,
+    autoGainControl: PropTypes.bool,
+  }).isRequired,
 }

--- a/app/windows/main/components/newRecording/NewRecording.jsx
+++ b/app/windows/main/components/newRecording/NewRecording.jsx
@@ -5,7 +5,6 @@ import {
   WindowIcon,
   ChevronDownIcon,
   SpeakerWaveIcon,
-  VideoCameraIcon,
   MicrophoneIcon,
   ChevronUpIcon,
   AdjustmentsHorizontalIcon,
@@ -23,11 +22,16 @@ import {
   SOURCE_TYPE_SCREEN,
   SOURCE_TYPE_WINDOW,
 } from "@shared/constants"
-import { setOpenSettings } from "@shared/redux/appSlice"
+import {
+  selectCapturers,
+  selectEncoders,
+  setOpenSettings,
+} from "@shared/redux/appSlice"
 import {
   selectSource,
   setSource
 } from "@shared/redux/recorderSlice"
+import { isLikelySystemAudioSource } from "@shared/systemAudio"
 import Toggle from "../properties/Toggle"
 import { SETTINGS_RECORDER } from "../settings/constants"
 import CameraMicrophoneSelect from "./CameraMicrophoneSelect"
@@ -40,10 +44,13 @@ export default function NewRecording({ isOpen }) {
   const dispatch = useDispatch()
   const queryClient = useQueryClient()
   const source = useSelector(selectSource)
+  const capturers = useSelector(selectCapturers)
+  const encoders = useSelector(selectEncoders)
   const [isRecordingSystemAudio, setIsRecordingSystemAudio] = useState(false)
   const [excludedAudioPids, setExcludedAudioPids] = useState([])
   const [showMonitorPicker, setShowMonitorPicker] = useState(false)
   const [showAudioSettings, setShowAudioSettings] = useState(false)
+  const [pickerError, setPickerError] = useState(null)
   const monitorPickerRef = useRef(null)
 
   const { data: defaultSystemAudioSource, isPending } = useQuery({
@@ -84,10 +91,33 @@ export default function NewRecording({ isOpen }) {
     },
     staleTime: Infinity
   })
+  const { data: screenFps } = useQuery({
+    queryKey: ['screenFps'],
+    queryFn: () => window.electron.ipcRenderer.invoke("store-get", "screenFps"),
+    staleTime: Infinity,
+  })
+  const { data: recordingQuality } = useQuery({
+    queryKey: ['recordingQuality'],
+    queryFn: () => window.electron.ipcRenderer.invoke("store-get", "recordingQuality"),
+    staleTime: Infinity,
+  })
 
-  const setAudioSetting = useCallback((key, value) => {
-    window.electron.ipcRenderer.invoke("store-set", key, value)
-    queryClient.invalidateQueries({ queryKey: ['audioSetting', key] })
+  const audioProcessingSettings = useMemo(() => ({
+    noiseSuppression: noiseSuppression ?? true,
+    echoCancellation: echoCancellation ?? true,
+    autoGainControl: autoGainControl ?? true,
+  }), [noiseSuppression, echoCancellation, autoGainControl])
+
+  const selectedCapturer = capturers?.find(item => item.isSelected)
+  const selectedEncoder = encoders?.find(item => item.isSelected)
+  const captureLabel = selectedCapturer?.displayName || selectedCapturer?.name || selectedCapturer?.value || "Not selected"
+  const encoderLabel = selectedEncoder?.displayName || selectedEncoder?.name || selectedEncoder?.value || "Not selected"
+  const isEngineReady = (capturers?.length ?? 0) > 0 && (encoders?.length ?? 0) > 0
+  const hasConfiguredSystemAudio = isLikelySystemAudioSource(defaultSystemAudioSource)
+
+  const setAudioSetting = useCallback(async (key, value) => {
+    await window.electron.ipcRenderer.invoke("store-set", key, value)
+    await queryClient.invalidateQueries({ queryKey: ['audioSetting', key] })
   }, [queryClient])
 
   // Fetch available monitors
@@ -127,28 +157,35 @@ export default function NewRecording({ isOpen }) {
     setScreenPermissionDenied(false)
   }, [previewSource])
 
-  const { data: captureSourcePreview, isPending: isPendingCaptureSourcePreview, isError: isPreviewError, refetch: refetchCaptureSourcePreview } = useQuery({
+  const { data: captureSourcePreview, isPending: isPendingCaptureSourcePreview, isError: isPreviewError, error: previewError, refetch: refetchCaptureSourcePreview } = useQuery({
     queryKey: ['captureSourcePreview', previewSource],
-    queryFn: async () => {
-      try {
-        const result = await window.electron.ipcRenderer.invoke("get-source-screenshot", previewSource)
-        setScreenPermissionDenied(false)
-        setPreviewUnavailable(false)
-        return result
-      } catch (e) {
-        const msg = typeof e === 'string' ? e : e?.message || String(e)
-        setScreenPermissionDenied(msg.includes("ScreenPermissionDenied"))
-        setPreviewUnavailable(true)
-        throw e
-      }
-    },
+    queryFn: () => window.electron.ipcRenderer.invoke("get-source-screenshot", previewSource),
     enabled: isOpen && !!previewSource,
     gcTime: 0,
-    retry: false,
+    // Smooth over one transient native-capture startup failure. Permission errors
+    // still stop immediately so the UI can show the correct recovery action.
+    retry: (failureCount, error) => {
+      const message = typeof error === "string" ? error : error?.message || String(error)
+      return failureCount < 1 && !message.includes("ScreenPermissionDenied")
+    },
+    retryDelay: 500,
     // Keep preview fresh; permission failures use the cheap native permission probe before screencapture.
-    refetchInterval: screenPermissionDenied || previewUnavailable ? 5000 : 2000,
+    refetchInterval: screenPermissionDenied || previewUnavailable ? 10000 : 5000,
     refetchIntervalInBackground: false,
   })
+
+  useEffect(() => {
+    if (captureSourcePreview) {
+      setScreenPermissionDenied(false)
+      setPreviewUnavailable(false)
+      return
+    }
+    if (isPreviewError) {
+      const message = typeof previewError === "string" ? previewError : previewError?.message || String(previewError)
+      setScreenPermissionDenied(message.includes("ScreenPermissionDenied"))
+      setPreviewUnavailable(true)
+    }
+  }, [captureSourcePreview, isPreviewError, previewError])
 
   const retryPreview = useCallback(() => {
     setScreenPermissionDenied(false)
@@ -248,6 +285,7 @@ export default function NewRecording({ isOpen }) {
   const areaSelectedCbRef = useRef(null)
 
   const openWindowPicker = useCallback(async () => {
+    setPickerError(null)
     // Clean up any stale listener from a previous cancelled picker
     if (windowSelectedCbRef.current) {
       window.electron.ipcRenderer.removeListener("window-selected", windowSelectedCbRef.current)
@@ -255,6 +293,7 @@ export default function NewRecording({ isOpen }) {
 
     const cb = (_e, selectedWindow) => {
       windowSelectedCbRef.current = null
+      setPickerError(null)
       dispatch(setSource(selectedWindow))
     }
     windowSelectedCbRef.current = cb
@@ -266,16 +305,19 @@ export default function NewRecording({ isOpen }) {
       window.electron.ipcRenderer.removeListener("window-selected", cb)
       windowSelectedCbRef.current = null
       console.error("[Flowtake] Failed to open window picker:", err)
+      setPickerError("Window picker could not open. Try again or record the full screen.")
     }
   }, [dispatch])
 
   const openAreaPicker = useCallback(async () => {
+    setPickerError(null)
     if (areaSelectedCbRef.current) {
       window.electron.ipcRenderer.removeListener("area-selected", areaSelectedCbRef.current)
     }
 
     const cb = (_e, selectedArea) => {
       areaSelectedCbRef.current = null
+      setPickerError(null)
       dispatch(setSource(selectedArea))
     }
     areaSelectedCbRef.current = cb
@@ -287,6 +329,7 @@ export default function NewRecording({ isOpen }) {
       window.electron.ipcRenderer.removeListener("area-selected", cb)
       areaSelectedCbRef.current = null
       console.error("[Flowtake] Failed to open area picker:", err)
+      setPickerError("Area picker could not open. Try again or record the full screen.")
     }
   }, [dispatch])
 
@@ -303,7 +346,7 @@ export default function NewRecording({ isOpen }) {
   }, [])
 
   const onEnableSystemAudio = async () => {
-    if (defaultSystemAudioSource) {
+    if (hasConfiguredSystemAudio) {
       setIsRecordingSystemAudio(!isRecordingSystemAudio)
     } else if (!isRecordingSystemAudio) {
       dispatch(setOpenSettings(SETTINGS_RECORDER))
@@ -332,9 +375,9 @@ export default function NewRecording({ isOpen }) {
   return (
     <div className={`${isOpen ? "" : "hidden"} h-full min-h-0 flex flex-col`}>
       {/* Main content: always side-by-side */}
-      <div className="flex-1 min-h-0 flex gap-3 md:gap-4">
+      <div className="flex-1 min-h-0 flex flex-col md:flex-row gap-3 md:gap-4 overflow-y-auto md:overflow-hidden pr-1 md:pr-0">
         {/* Left: Preview */}
-        <div className="flex-1 min-w-0 min-h-0 flex flex-col">
+        <div className="flex-1 min-w-0 min-h-56 md:min-h-0 flex flex-col">
           <div className="relative rounded-xl overflow-hidden bg-base-200/50 border border-base-content/5 flex-1 min-h-0">
             <div className="w-full h-full flex items-center justify-center relative">
               {/* Previous frame as background for smooth crossfade */}
@@ -349,6 +392,7 @@ export default function NewRecording({ isOpen }) {
               {!isPendingCaptureSourcePreview && captureSourcePreview && !isPreviewError && !previewUnavailable && (
                 <img
                   src={captureSourcePreview}
+                  alt={`Preview of ${source.name || "selected recording source"}`}
                   className="absolute inset-0 w-full h-full object-contain animate-[fadeIn_150ms_ease-out]"
                   onError={(e) => { e.target.style.display = 'none' }}
                 />
@@ -375,7 +419,13 @@ export default function NewRecording({ isOpen }) {
                       </button>
                     </>
                   ) : (
-                    <span className="text-xs text-base-content/30">Preview unavailable</span>
+                    <>
+                      <span className="text-xs text-base-content/30">Preview unavailable</span>
+                      <button type="button" className="btn btn-xs btn-outline mt-1" onClick={retryPreview}>
+                        <ArrowPathIcon className="size-3.5" />
+                        Retry
+                      </button>
+                    </>
                   )}
                 </div>
               )}
@@ -386,7 +436,7 @@ export default function NewRecording({ isOpen }) {
                 </div>
               )}
             </div>
-            <CameraPreview />
+            <CameraPreview audioProcessingSettings={audioProcessingSettings} />
 
             {/* Bottom gradient overlay for badges */}
             {(captureSourcePreview || prevPreviewRef.current) && (
@@ -420,15 +470,16 @@ export default function NewRecording({ isOpen }) {
                 </span>
               )}
               <span className="badge badge-sm bg-black/50 backdrop-blur-md border-white/10 text-white/80 gap-1.5">
-                <span className="size-1.5 rounded-full bg-red-500 animate-pulse" />
-                Live
+                <span className="size-1.5 rounded-full bg-primary/70" />
+                Preview
               </span>
             </div>
           </div>
         </div>
 
-        {/* Right: Controls panel — flat, compact, always fits */}
-        <div className="w-60 lg:w-64 xl:w-72 flex-shrink-0 min-h-0 flex flex-col gap-2.5">
+        {/* Right: scrollable setup with the primary action always visible. */}
+        <div className="w-full md:w-64 xl:w-72 flex-shrink-0 min-h-0 flex flex-col">
+          <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-1 flex flex-col gap-2.5">
           {/* Source — horizontal segmented */}
           <div className="relative flex-shrink-0" ref={monitorPickerRef} data-tutorial="source-panel">
             <SectionLabel>Source</SectionLabel>
@@ -467,6 +518,7 @@ export default function NewRecording({ isOpen }) {
               <div className="absolute top-full left-0 right-0 mt-1 z-50 bg-base-200 border border-base-content/10 rounded-lg shadow-xl overflow-hidden">
                 {monitors.map((m, i) => (
                   <button
+                    type="button"
                     key={m.id}
                     onClick={() => selectMonitor(m)}
                     className={`w-full text-left px-2.5 py-2 text-xs hover:bg-base-300/60 flex items-center gap-2 transition-colors
@@ -485,10 +537,16 @@ export default function NewRecording({ isOpen }) {
             )}
           </div>
 
+          {pickerError && (
+            <div className="rounded-md border border-error/25 bg-error/10 px-2 py-1.5 text-[11px] leading-snug text-error" role="alert">
+              {pickerError}
+            </div>
+          )}
+
           {/* Devices */}
           <div className="flex-shrink-0">
             <SectionLabel>Devices</SectionLabel>
-            <CameraMicrophoneSelect />
+            <CameraMicrophoneSelect audioProcessingSettings={audioProcessingSettings} />
           </div>
 
           {/* Audio toggles — inline row */}
@@ -502,15 +560,18 @@ export default function NewRecording({ isOpen }) {
               <AppAudioControl onExcludedAppsChange={setExcludedAudioPids} />
             )}
             <button
+              type="button"
               onClick={() => setShowAudioSettings(v => !v)}
               className="flex items-center gap-2 w-full group text-left"
+              aria-expanded={showAudioSettings}
+              aria-controls="record-audio-processing"
             >
               <AdjustmentsHorizontalIcon className="size-3.5 text-base-content/40 flex-shrink-0" />
               <span className="text-xs text-base-content/70 flex-1">Audio processing</span>
               <ChevronUpIcon className={`size-3 text-base-content/30 transition-transform ${showAudioSettings ? "" : "rotate-180"}`} />
             </button>
             {showAudioSettings && (
-              <div className="ml-5 flex flex-col gap-1">
+              <div id="record-audio-processing" className="ml-5 flex flex-col gap-1">
                 <Toggle
                   rightLabel={<span className="text-[11px] text-base-content/60">Noise suppression</span>}
                   justifyBetween={false}
@@ -533,12 +594,39 @@ export default function NewRecording({ isOpen }) {
             )}
           </div>
 
-          {/* Actions — pinned to bottom */}
-          <div className="mt-auto flex gap-2 flex-shrink-0 pt-1">
-            <div className="flex-[4] min-w-0" data-tutorial="record-button">
-              <RecordButton isRecordingSystemAudio={isRecordingSystemAudio} excludedAudioPids={excludedAudioPids} />
+          <div className="rounded-lg border border-base-content/5 bg-base-200/30 p-2.5 flex-shrink-0" aria-label="Recording quality summary">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-base-content/35">Quality</span>
+              <span className={`text-[10px] font-medium ${isEngineReady ? "text-emerald-500" : "text-warning"}`}>
+                <span className="capitalize">{recordingQuality || "balanced"}</span> - {screenFps ?? 30} FPS
+              </span>
             </div>
-            <button onClick={addNote} className="flex-[1] btn btn-sm btn-ghost bg-base-200/30 border border-base-content/5 text-base-content/40 hover:text-base-content/60 h-auto" title="Teleprompter Notes">
+            <div className="mt-1 flex items-center gap-1.5 text-[11px] min-w-0">
+              <span className={`size-1.5 rounded-full flex-shrink-0 ${isEngineReady ? "bg-emerald-500" : "bg-warning"}`} />
+              <span className="truncate text-base-content/55" title={`${captureLabel} to ${encoderLabel}`}>
+                {isEngineReady ? `${captureLabel} to ${encoderLabel}` : "Choose a capture and encoder"}
+              </span>
+              <button
+                type="button"
+                className="ml-auto flex-shrink-0 text-[10px] font-medium text-primary hover:underline"
+                onClick={() => dispatch(setOpenSettings(SETTINGS_RECORDER))}
+              >
+                Adjust
+              </button>
+            </div>
+          </div>
+
+          </div>
+
+          <div className="flex gap-2 flex-shrink-0 pt-2 mt-1 border-t border-base-content/5 bg-base-100/20">
+            <div className="flex-[4] min-w-0" data-tutorial="record-button">
+              <RecordButton
+                isRecordingSystemAudio={isRecordingSystemAudio}
+                excludedAudioPids={excludedAudioPids}
+                audioProcessingSettings={audioProcessingSettings}
+              />
+            </div>
+            <button type="button" onClick={addNote} className="flex-[1] btn btn-sm btn-ghost bg-base-200/30 border border-base-content/5 text-base-content/40 hover:text-base-content/60 h-auto" title="Teleprompter Notes" aria-label="Open teleprompter notes">
               <DocumentIcon className="size-4" />
             </button>
           </div>
@@ -561,8 +649,11 @@ SectionLabel.propTypes = {
 function SourceSegment({ icon: Icon, label, active, onClick, iconFlip, hasDropdown }) {
   return (
     <button
+      type="button"
       onClick={onClick}
-      className={`flex flex-col items-center justify-center gap-0.5 py-1.5 rounded-md transition-all
+      aria-label={`${label} recording source`}
+      aria-pressed={active}
+      className={`min-h-11 flex flex-col items-center justify-center gap-0.5 py-1.5 rounded-md transition-all
         ${active
           ? "bg-primary/15 text-primary"
           : "text-base-content/50 hover:text-base-content/80 hover:bg-base-content/5"

--- a/app/windows/main/components/newRecording/RecordButton.jsx
+++ b/app/windows/main/components/newRecording/RecordButton.jsx
@@ -6,6 +6,7 @@ import PropTypes from "prop-types"
 import {
   useCallback,
   useEffect,
+  useRef,
   useState
 } from "react"
 import {
@@ -22,6 +23,7 @@ import {
   selectEncoders,
   selectIsProjectClosing,
   selectRenderQueueProgress,
+  setOpenSettings,
   setLoaderMessage
 } from "@shared/redux/appSlice"
 import {
@@ -30,12 +32,16 @@ import {
   setIsRecording
 } from "@shared/redux/recorderSlice"
 import RecordModal from "./RecordModal"
+import { SETTINGS_RECORDER } from "../settings/constants"
 
-export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids = [] }) {
+export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids = [], audioProcessingSettings }) {
 
   const dispatch = useDispatch()
 
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [startError, setStartError] = useState(null)
+  const [isStarting, setIsStarting] = useState(false)
+  const startInFlightRef = useRef(false)
 
   const source = useSelector(selectSource)
   const isRecording = useSelector(selectIsRecording)
@@ -79,6 +85,10 @@ export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids
   }, [dispatch, isRecording, isProjectClosing])
 
   const start = useCallback(async () => {
+    if (startInFlightRef.current || isRecording) return
+    startInFlightRef.current = true
+    setIsStarting(true)
+
     const video = (cameras ?? []).find(({ id }) => id === camera) ?? null
     const audio = (microphones ?? []).find(({ id }) => id === microphone) ?? null
 
@@ -87,15 +97,16 @@ export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids
       audioTrack: audio?.track.label,
       constraints: {
         video: video
-          ? { ...CONSTRAINTS_VIDEO, deviceId: video.deviceId }
+          ? { ...CONSTRAINTS_VIDEO, deviceId: { exact: video.deviceId } }
           : false,
         audio: audio
-          ? { ...CONSTRAINTS_AUDIO, deviceId: audio.deviceId }
+          ? { ...CONSTRAINTS_AUDIO, ...audioProcessingSettings, deviceId: { exact: audio.deviceId } }
           : false,
       },
     }
 
     try {
+      setStartError(null)
       await window.electron.ipcRenderer.invoke("init-recording", source, mediaSourceConfig, isRecordingSystemAudio ? systemAudio : null)
 
       // Mute excluded apps when recording with system audio
@@ -106,9 +117,13 @@ export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids
       dispatch(setIsRecording(true))
     } catch (err) {
       console.error("[Flowtake] init-recording failed:", err)
+      setStartError(err?.message || String(err) || "Recording could not start. Check your devices and try again.")
       dispatch(setIsRecording(false))
+    } finally {
+      startInFlightRef.current = false
+      setIsStarting(false)
     }
-  }, [cameras, microphones, source, isRecordingSystemAudio, systemAudio, dispatch, camera, microphone, excludedAudioPids])
+  }, [cameras, microphones, source, isRecordingSystemAudio, systemAudio, dispatch, camera, microphone, excludedAudioPids, audioProcessingSettings, isRecording])
 
   const onClick = useCallback(() => {
     if (renderQueueProgress === -1) start()
@@ -124,17 +139,31 @@ export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids
 
   const isPending = isPendingCamera || isPendingCameras || isPendingMicrophone || isPendingMicrophones ||
     isPendingSystemAudio
+  const hasRecorderEngine = (capturers?.length ?? 0) > 0 && (encoders?.length ?? 0) > 0
+  const primaryAction = hasRecorderEngine || isPending
+    ? onClick
+    : () => dispatch(setOpenSettings(SETTINGS_RECORDER))
 
   return (<>
     <Button
-      onClick={onClick}
-      isLoading={isPending || !capturers?.length || !encoders?.length}
-      disabled={isPending || !capturers?.length || !encoders?.length}
+      onClick={primaryAction}
+      isLoading={isStarting || isPending}
+      disabled={isStarting || isRecording || isPending}
       icon={ArrowRightIcon}
       className="btn-primary w-full"
     >
-      Record
+      {hasRecorderEngine ? "Record" : "Set up recorder"}
     </Button>
+    {!isPending && !hasRecorderEngine && (
+      <p className="mt-1 text-[11px] leading-snug text-warning" role="status">
+        Capture engine needs attention. Open Recorder settings to repair it.
+      </p>
+    )}
+    {startError && (
+      <p className="mt-1 text-[11px] leading-snug text-error" role="alert">
+        {startError}
+      </p>
+    )}
     <RecordModal
       isOpen={isModalOpen}
       onCancel={onModalCancel}
@@ -146,4 +175,9 @@ export default function RecordButton({ isRecordingSystemAudio, excludedAudioPids
 RecordButton.propTypes = {
   isRecordingSystemAudio: PropTypes.bool.isRequired,
   excludedAudioPids: PropTypes.arrayOf(PropTypes.number),
+  audioProcessingSettings: PropTypes.shape({
+    noiseSuppression: PropTypes.bool,
+    echoCancellation: PropTypes.bool,
+    autoGainControl: PropTypes.bool,
+  }).isRequired,
 }

--- a/app/windows/main/components/plugins/Plugins.jsx
+++ b/app/windows/main/components/plugins/Plugins.jsx
@@ -4,121 +4,83 @@ import {
     PuzzlePieceIcon,
     RectangleGroupIcon,
 } from "@heroicons/react/24/outline"
-import { ArrowPathIcon, ChevronDownIcon, FolderOpenIcon } from "@heroicons/react/20/solid"
+import { ChevronDownIcon } from "@heroicons/react/20/solid"
 import PropTypes from "prop-types"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useDispatch, useSelector } from "react-redux"
 import {
     FEATURE_IDS,
     selectAllEnabled,
-    selectDetectedPlugins,
-    selectPluginsDir,
-    setDetectedPlugins,
     setFeatureEnabled,
-    setPluginsDir,
 } from "@shared/redux/pluginSlice"
 import AppRecordingFeature from "../settings/plugin/features/AppRecordingFeature"
-import KeyboardOverlayFeature from "../settings/plugin/features/KeyboardOverlayFeature"
-import MouseStyleFeature from "../settings/plugin/features/MouseStyleFeature"
 
 const CONFIG_COMPONENTS = {
     [FEATURE_IDS.APP_RECORDING]: AppRecordingFeature,
-    [FEATURE_IDS.MOUSE_STYLE]: MouseStyleFeature,
-    [FEATURE_IDS.KEYBOARD_OVERLAY]: KeyboardOverlayFeature,
 }
 
 const BUILT_IN_PLUGINS = [
     {
         id: FEATURE_IDS.APP_RECORDING,
         icon: RectangleGroupIcon,
-        name: "Individual App Recording",
-        short: "Record multiple apps at once",
-        description:
-            "Capture each selected app to its own video layer in parallel. Choose which layers to show in the editor before export.",
+        name: "App layers",
+        short: "Record up to two extra app regions",
+        description: "Creates separate video layers from the selected app regions. Keep those windows open, visible, and in place while recording.",
+        overhead: "Higher overhead",
     },
     {
         id: FEATURE_IDS.MOUSE_STYLE,
         icon: CursorArrowRaysIcon,
-        name: "Mouse Coloring & Name Tag",
-        short: "Recolor cursor and pin a label",
-        description:
-            "Tints the rendered cursor and pins a floating label next to it during recording and playback. Great for AI-agent demos.",
+        name: "Enhanced Cursor",
+        short: "Render the configured cursor style",
+        description: "Applies Flowtake's cursor styling during preview and final rendering.",
+        overhead: "Low overhead",
     },
     {
         id: FEATURE_IDS.KEYBOARD_OVERLAY,
         icon: CommandLineIcon,
-        name: "Keyboard Typing Layout",
-        short: "Show keys being pressed",
-        description:
-            "Captures keystrokes during recording and overlays them. Two modes: full typing or keybinds-only (Ctrl/Alt/Fn/F1–F12, Backspace, Delete, arrows…).",
+        name: "Keyboard Overlay",
+        short: "Show captured shortcuts and typing",
+        description: "On Windows, captures keyboard events during recording and renders the configured overlay in the finished video.",
+        overhead: "Low overhead",
+        windowsOnly: true,
     },
 ]
 
 export default function Plugins({ isOpen }) {
     const dispatch = useDispatch()
     const enabled = useSelector(selectAllEnabled)
-    const detected = useSelector(selectDetectedPlugins)
-    const pluginsDir = useSelector(selectPluginsDir)
-    const [refreshing, setRefreshing] = useState(false)
-
-    const refresh = async () => {
-        setRefreshing(true)
-        try {
-            const path = await window.electron.ipcRenderer.invoke("ensure-plugins-dir")
-            dispatch(setPluginsDir(path))
-            const list = await window.electron.ipcRenderer.invoke("list-plugins")
-            dispatch(setDetectedPlugins(list || []))
-        } catch {
-            /* swallow */
-        } finally {
-            setRefreshing(false)
-        }
-    }
-
-    useEffect(() => {
-        if (!isOpen) return
-        refresh()
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isOpen])
+    const platform = window.electron?.process?.platform || (navigator.platform?.includes("Win") ? "win32" : "other")
+    const availablePlugins = BUILT_IN_PLUGINS.filter(plugin => !plugin.windowsOnly || platform === "win32")
 
     if (!isOpen) return null
 
-    const setEnabled = (id, val) => dispatch(setFeatureEnabled({ id, enabled: val }))
+    const setEnabled = (id, value) => dispatch(setFeatureEnabled({ id, enabled: value }))
 
     return (
         <div className="h-full flex flex-col min-h-0">
-            {/* Header — fixed */}
             <div className="flex items-center gap-2 mb-2 flex-shrink-0">
                 <PuzzlePieceIcon className="size-5 text-primary flex-shrink-0" />
-                <h2 className="font-brand font-semibold text-sm">Plugins & Extensions</h2>
-                <span className="px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-300 text-[9px] font-bold uppercase tracking-wider">
-                    Research Preview
+                <h2 className="font-brand font-semibold text-sm">Experimental features</h2>
+                <span className="px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400 text-[9px] font-bold uppercase tracking-wider">
+                    Built-in
                 </span>
             </div>
-            <p className="text-xs text-base-content/55 leading-relaxed mb-4 flex-shrink-0">
-                Built-in extensions can be toggled on or off. Third-party plugin files dropped into the folder
-                below are detected but not executed in this preview build.
+            <p className="text-xs text-base-content/55 leading-relaxed mb-4 flex-shrink-0 max-w-2xl">
+                These local features have real recording or rendering integrations, but may add resource use. Keep only the tools you need enabled.
             </p>
 
-            {/* Scrollable content */}
             <div className="flex-1 min-h-0 overflow-y-auto pr-1 -mr-1">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 mb-4">
-                    {BUILT_IN_PLUGINS.map((p) => (
+                <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                    {availablePlugins.map(plugin => (
                         <PluginCard
-                            key={p.id}
-                            plugin={p}
-                            enabled={!!enabled[p.id]}
-                            onToggle={(v) => setEnabled(p.id, v)}
+                            key={plugin.id}
+                            plugin={plugin}
+                            enabled={!!enabled[plugin.id]}
+                            onToggle={value => setEnabled(plugin.id, value)}
                         />
                     ))}
                 </div>
-
-                <DetectedPluginsCard
-                    pluginsDir={pluginsDir}
-                    detected={detected}
-                    refreshing={refreshing}
-                    onRefresh={refresh}
-                />
             </div>
         </div>
     )
@@ -131,7 +93,7 @@ Plugins.propTypes = {
 function PluginCard({ plugin, enabled, onToggle }) {
     const Icon = plugin.icon
     const ConfigComponent = CONFIG_COMPONENTS[plugin.id]
-    const [isOpen, setIsOpen] = useState(false)
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false)
 
     return (
         <article className={`rounded-xl border bg-base-100/60 transition-colors flex flex-col min-w-0
@@ -150,35 +112,35 @@ function PluginCard({ plugin, enabled, onToggle }) {
                         type="checkbox"
                         className="toggle toggle-sm toggle-primary flex-shrink-0 mt-0.5"
                         checked={enabled}
-                        onChange={(e) => onToggle(e.target.checked)}
+                        onChange={event => onToggle(event.target.checked)}
                         aria-label={`Enable ${plugin.name}`}
                     />
                 </header>
-                <p className="text-[11px] text-base-content/65 leading-relaxed">
-                    {plugin.description}
-                </p>
+                <p className="text-[11px] text-base-content/65 leading-relaxed">{plugin.description}</p>
                 <div className="mt-2 pt-2 border-t border-base-content/5 flex items-center gap-1.5">
-                    <span className="px-1 py-0.5 rounded bg-amber-500/15 text-amber-400 text-[8px] font-bold uppercase tracking-wider">
-                        Built-in
+                    <span className={`px-1 py-0.5 rounded text-[8px] font-bold uppercase tracking-wider
+                        ${plugin.overhead === "Low overhead"
+                            ? "bg-emerald-500/10 text-emerald-500"
+                            : "bg-amber-500/15 text-amber-400"}`}>
+                        {plugin.overhead}
                     </span>
-                    <span className="text-[10px] text-base-content/40">
-                        {enabled ? "Active" : "Disabled"}
-                    </span>
+                    <span className="text-[10px] text-base-content/40">{enabled ? "Active" : "Disabled"}</span>
                     {ConfigComponent && (
                         <button
                             type="button"
-                            onClick={() => setIsOpen(o => !o)}
+                            onClick={() => setIsSettingsOpen(open => !open)}
                             className="ml-auto inline-flex items-center gap-1 text-[10px] text-base-content/50 hover:text-base-content/80 px-1.5 py-0.5 rounded hover:bg-base-content/5 transition-colors"
-                            aria-label={isOpen ? "Hide settings" : "Show settings"}>
-                            {isOpen ? "Hide settings" : "Settings"}
-                            <ChevronDownIcon className={`size-3 transition-transform ${isOpen ? "rotate-180" : ""}`} />
+                            aria-label={isSettingsOpen ? `Hide ${plugin.name} settings` : `Show ${plugin.name} settings`}
+                            aria-expanded={isSettingsOpen}
+                        >
+                            {isSettingsOpen ? "Hide settings" : "Settings"}
+                            <ChevronDownIcon className={`size-3 transition-transform ${isSettingsOpen ? "rotate-180" : ""}`} />
                         </button>
                     )}
                 </div>
             </div>
-            {isOpen && ConfigComponent && (
-                <div className={`px-3 pb-3 pt-1 border-t border-base-content/5
-                    ${enabled ? "" : "opacity-40 pointer-events-none"}`}>
+            {isSettingsOpen && ConfigComponent && (
+                <div className={`px-3 pb-3 pt-1 border-t border-base-content/5 ${enabled ? "" : "opacity-40 pointer-events-none"}`}>
                     <ConfigComponent />
                 </div>
             )}
@@ -193,70 +155,9 @@ PluginCard.propTypes = {
         name: PropTypes.string.isRequired,
         short: PropTypes.string.isRequired,
         description: PropTypes.string.isRequired,
+        overhead: PropTypes.string.isRequired,
+        windowsOnly: PropTypes.bool,
     }).isRequired,
     enabled: PropTypes.bool.isRequired,
     onToggle: PropTypes.func.isRequired,
-}
-
-function DetectedPluginsCard({ pluginsDir, detected, refreshing, onRefresh }) {
-    return (
-        <article className="rounded-xl border border-base-content/10 bg-base-100/60 p-3">
-            <header className="flex items-center gap-2 mb-2">
-                <div className="flex-1 min-w-0">
-                    <h3 className="text-[13px] font-semibold">Drop-in plugins folder</h3>
-                    <p className="text-[10px] text-base-content/45 font-mono truncate" title={pluginsDir || ""}>
-                        {pluginsDir || "Loading folder…"}
-                    </p>
-                </div>
-                <button
-                    type="button"
-                    className="btn btn-xs btn-ghost btn-square"
-                    onClick={onRefresh}
-                    disabled={refreshing}
-                    title="Refresh">
-                    <ArrowPathIcon className={`size-3.5 ${refreshing ? "animate-spin" : ""}`} />
-                </button>
-                <button
-                    type="button"
-                    className="btn btn-xs btn-outline gap-1"
-                    onClick={() => window.electron.ipcRenderer.invoke("open-plugins-folder")}>
-                    <FolderOpenIcon className="size-3.5" />
-                    Open
-                </button>
-            </header>
-
-            {detected.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-base-content/10 px-3 py-4 text-center">
-                    <p className="text-xs text-base-content/40">
-                        No plugins detected. Drop files into the folder and refresh.
-                    </p>
-                </div>
-            ) : (
-                <ul className="divide-y divide-base-content/5 rounded-lg border border-base-content/10 overflow-hidden">
-                    {detected.map((p) => (
-                        <li key={p.name} className="flex items-center gap-3 px-3 py-1.5 min-w-0">
-                            <span className="size-6 flex items-center justify-center rounded bg-base-content/5 text-[9px] font-mono text-base-content/50 flex-shrink-0">
-                                {p.is_dir ? "DIR" : (p.kind || "?").toUpperCase().slice(0, 4)}
-                            </span>
-                            <span className="text-xs flex-1 min-w-0 truncate">{p.name}</span>
-                            <span className="px-1.5 py-0.5 rounded bg-base-content/5 text-[9px] font-bold uppercase tracking-wider text-base-content/45 flex-shrink-0">
-                                Detected
-                            </span>
-                        </li>
-                    ))}
-                </ul>
-            )}
-
-            <p className="text-[10px] text-base-content/35 mt-2 leading-snug">
-                Detection only — third-party plugin code is not executed in this preview build.
-            </p>
-        </article>
-    )
-}
-
-DetectedPluginsCard.propTypes = {
-    pluginsDir: PropTypes.string,
-    detected: PropTypes.array.isRequired,
-    refreshing: PropTypes.bool,
-    onRefresh: PropTypes.func.isRequired,
 }

--- a/app/windows/main/components/settings/GeneralSettings.jsx
+++ b/app/windows/main/components/settings/GeneralSettings.jsx
@@ -1,26 +1,12 @@
-import { FolderOpenIcon, ChatBubbleLeftRightIcon, LightBulbIcon, AcademicCapIcon } from "@heroicons/react/24/outline"
+import { FolderOpenIcon, ChatBubbleLeftRightIcon, LightBulbIcon, AcademicCapIcon, ArrowPathIcon } from "@heroicons/react/24/outline"
 import { useQuery } from "@tanstack/react-query"
 import { useCallback } from "react"
 import { useDispatch } from "react-redux"
 import Button from "../../../../components/Button"
+import { setOpenSettings } from "@shared/redux/appSlice"
 import { resetTutorial, startTutorial } from "@shared/redux/tutorialSlice"
 import Fieldset from "../properties/Fieldset"
 import Toggle from "../properties/Toggle"
-
-const RESOLUTIONS = [
-    { value: "1280x720", label: "720p (1280x720)" },
-    { value: "1920x1080", label: "1080p (1920x1080)" },
-    { value: "2560x1440", label: "1440p (2560x1440)" },
-    { value: "3840x2160", label: "4K (3840x2160)" },
-]
-
-const AUTO_SAVE_OPTIONS = [
-    { value: 0, label: "Disabled" },
-    { value: 60, label: "1 minute" },
-    { value: 120, label: "2 minutes" },
-    { value: 300, label: "5 minutes" },
-    { value: 600, label: "10 minutes" },
-]
 
 export default function GeneralSettings() {
 
@@ -28,37 +14,20 @@ export default function GeneralSettings() {
 
     const restartTutorial = useCallback(async () => {
         await window.electron.ipcRenderer.invoke("store-set", "hasCompletedTutorial", false)
+        dispatch(setOpenSettings(null))
         dispatch(resetTutorial())
         dispatch(startTutorial())
     }, [dispatch])
 
-    const { data: isIssueReportingEnabled, isPending, isError, refetch } = useQuery({
-        queryKey: ['isIssueReportingEnabled'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "isIssueReportingEnabled"),
-        staleTime: Infinity
-    })
+    const restartSetup = useCallback(async () => {
+        await window.electron.ipcRenderer.invoke("store-set", "hasCompletedSetup", false)
+        dispatch(setOpenSettings(null))
+        window.dispatchEvent(new Event("flowtake-run-setup"))
+    }, [dispatch])
 
     const { data: isAutoStartEnabled, isPending: isAutoStartPending, refetch: refetchAutoStart } = useQuery({
         queryKey: ['autostart'],
         queryFn: () => window.electron.ipcRenderer.invoke("get-autostart"),
-        staleTime: Infinity
-    })
-
-    const { data: defaultResolution, isPending: isResolutionPending, refetch: refetchResolution } = useQuery({
-        queryKey: ['defaultResolution'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "defaultResolution"),
-        staleTime: Infinity
-    })
-
-    const { data: autoSaveInterval, isPending: isAutoSavePending, refetch: refetchAutoSave } = useQuery({
-        queryKey: ['autoSaveInterval'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "autoSaveInterval"),
-        staleTime: Infinity
-    })
-
-    const { data: notificationsEnabled, isPending: isNotifPending, refetch: refetchNotif } = useQuery({
-        queryKey: ['notificationsEnabled'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "notificationsEnabled"),
         staleTime: Infinity
     })
 
@@ -68,29 +37,9 @@ export default function GeneralSettings() {
         staleTime: Infinity
     })
 
-    const onChangeIsIssueReportingEnabled = async (e) => {
-        await window.electron.ipcRenderer.invoke("store-set", "isIssueReportingEnabled", e.target.checked)
-        refetch()
-    }
-
     const onChangeAutoStart = async (e) => {
         await window.electron.ipcRenderer.invoke("set-autostart", e.target.checked)
         refetchAutoStart()
-    }
-
-    const onChangeResolution = async (e) => {
-        await window.electron.ipcRenderer.invoke("store-set", "defaultResolution", e.target.value)
-        refetchResolution()
-    }
-
-    const onChangeAutoSave = async (e) => {
-        await window.electron.ipcRenderer.invoke("store-set", "autoSaveInterval", Number(e.target.value))
-        refetchAutoSave()
-    }
-
-    const onChangeNotifications = async (e) => {
-        await window.electron.ipcRenderer.invoke("store-set", "notificationsEnabled", e.target.checked)
-        refetchNotif()
     }
 
     const onChangeContentProtection = async (e) => {
@@ -109,34 +58,6 @@ export default function GeneralSettings() {
                 isIndeterminate={isAutoStartPending} />
         </Fieldset>
 
-        <Fieldset legend="Default recording resolution" description="Set the default resolution for new recordings.">
-            <select className="select select-sm w-full"
-                value={isResolutionPending ? "1920x1080" : (defaultResolution || "1920x1080")}
-                onChange={onChangeResolution}
-                disabled={isResolutionPending}>
-                {RESOLUTIONS.map(({ value, label }) => (
-                    <option key={value} value={value}>{label}</option>
-                ))}
-            </select>
-        </Fieldset>
-
-        <Fieldset legend="Auto-save" description="Automatically save your project at a regular interval.">
-            <select className="select select-sm w-full"
-                value={isAutoSavePending ? 300 : (autoSaveInterval ?? 300)}
-                onChange={onChangeAutoSave}
-                disabled={isAutoSavePending}>
-                {AUTO_SAVE_OPTIONS.map(({ value, label }) => (
-                    <option key={value} value={value}>{label}</option>
-                ))}
-            </select>
-        </Fieldset>
-
-        <Fieldset legend="Notifications" description="Show system notifications for recording and export events.">
-            <Toggle leftLabel="Enable notifications" value={isNotifPending ? false : (notificationsEnabled ?? true)}
-                onChange={onChangeNotifications} disabled={isNotifPending}
-                isIndeterminate={isNotifPending} />
-        </Fieldset>
-
         <Fieldset legend="Privacy" description="Control whether Flowtake is visible in screenshots and screen recordings.">
             <Toggle leftLabel="Hide app from screenshots & recordings"
                 value={isContentProtPending ? true : (contentProtectionEnabled ?? true)}
@@ -144,26 +65,23 @@ export default function GeneralSettings() {
                 isIndeterminate={isContentProtPending} />
         </Fieldset>
 
-        <Fieldset legend="Issue reporting" description="Restart Flowtake for changes to issue reporting to go into effect.">
-            <Toggle leftLabel="Automatically report issues" value={isPending || isError ? false : isIssueReportingEnabled}
-                onChange={onChangeIsIssueReportingEnabled} disabled={isPending || isError}
-                isIndeterminate={isPending || isError} />
-        </Fieldset>
-
         <Button icon={FolderOpenIcon} onClick={openLogsDirectory}>Open logs folder</Button>
 
-        <Fieldset legend="Tutorial" description="Re-run the interactive tutorial to learn the basics.">
-            <Button icon={AcademicCapIcon} onClick={restartTutorial}>Restart Tutorial</Button>
+        <Fieldset legend="Guided help" description="Re-run the short readiness setup or the interactive recording tutorial at any time.">
+            <div className="flex flex-wrap gap-2">
+                <Button icon={ArrowPathIcon} onClick={restartSetup}>Run setup again</Button>
+                <Button icon={AcademicCapIcon} onClick={restartTutorial}>Restart tutorial</Button>
+            </div>
         </Fieldset>
 
         <Fieldset legend="Help & Feedback">
             <div className="flex flex-wrap gap-2">
-                <button className="btn btn-sm btn-ghost gap-2"
+                <button type="button" className="btn btn-sm btn-ghost gap-2"
                     onClick={() => window.electron.ipcRenderer.invoke("open-url-in-browser", "https://github.com/JNX03/Flowtake/issues")}>
                     <ChatBubbleLeftRightIcon className="size-4" />
                     Send Feedback
                 </button>
-                <button className="btn btn-sm btn-ghost gap-2"
+                <button type="button" className="btn btn-sm btn-ghost gap-2"
                     onClick={() => window.electron.ipcRenderer.invoke("open-url-in-browser", "https://github.com/JNX03/Flowtake/issues")}>
                     <LightBulbIcon className="size-4" />
                     Request a Feature

--- a/app/windows/main/components/settings/HotkeysSettings.jsx
+++ b/app/windows/main/components/settings/HotkeysSettings.jsx
@@ -10,8 +10,12 @@ export default function HotkeysSettings() {
     useHotkeys("ctrl+slash", () => { dispatch(setOpenSettings(null)) })
 
     return (<div className="flex flex-col gap-4">
-        <h4 className="font-semibold text-lg">Hotkeys</h4>
-        <table className="table table-sm table-zebra w-full rounded-box overflow-hidden">
+        <div>
+            <h4 className="font-semibold text-lg">Keyboard shortcuts</h4>
+            <p className="mt-1 text-xs text-base-content/50">Reference list for active shortcuts. Shortcut remapping is not available in this build.</p>
+        </div>
+        <div className="overflow-x-auto rounded-box">
+        <table className="table table-sm table-zebra w-full min-w-[32rem] overflow-hidden">
             <thead><tr><th>General</th><th></th></tr></thead>
             <tbody>
                 <tr>
@@ -98,7 +102,7 @@ export default function HotkeysSettings() {
                 <tr>
                     <th>Merge selected element left</th>
                     <td className="text-right">
-                        <kbd className="kbd kbd-sm mr-2">ctrl</kbd>
+                        <kbd className="kbd kbd-sm mr-2">m</kbd>
                         <kbd className="kbd kbd-sm align-bottom inline-flex items-center">
                             <ArrowLongLeftIcon className="size-4" />
                         </kbd>
@@ -125,6 +129,6 @@ export default function HotkeysSettings() {
                 </tr>
             </tbody>
         </table>
+        </div>
     </div>)
 }
-

--- a/app/windows/main/components/settings/RecorderSettings.jsx
+++ b/app/windows/main/components/settings/RecorderSettings.jsx
@@ -1,148 +1,231 @@
-import { ArrowPathIcon as ArrowPathIconSmall } from "@heroicons/react/16/solid"
 import { ArrowPathIcon } from "@heroicons/react/24/outline"
 import { useQuery } from "@tanstack/react-query"
-import {
-    useCallback,
-    useMemo,
-    useState
-} from "react"
-import {
-    useDispatch,
-    useSelector
-} from "react-redux"
+import { useCallback, useMemo, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
 import Button from "../../../../components/Button"
 import Hint from "../../../../components/Hint"
 import {
     selectCapturers,
     selectEncoders,
     setCapturers,
-    setEncoders
+    setEncoders,
 } from "@shared/redux/appSlice"
 import Fieldset from "../properties/Fieldset"
 import SystemAudio from "./SystemAudio"
 
+const optionValue = item => item?.value ?? item?.name ?? ""
+const optionLabel = item => item?.displayName ?? item?.name ?? item?.value ?? "Unknown"
+
 export default function RecorderSettings() {
     const dispatch = useDispatch()
-
-    const [userCapturer, setUserCapturer] = useState("")
-    const [userEncoder, setUserEncoder] = useState("")
-    const [isFpsLoading, setIsFpsLoading] = useState(false)
-
     const capturers = useSelector(selectCapturers)
     const encoders = useSelector(selectEncoders)
 
-    // Derive capturer from user choice or selected from Redux
+    const [userCapturer, setUserCapturer] = useState(null)
+    const [userEncoder, setUserEncoder] = useState(null)
+    const [isCapturerLoading, setIsCapturerLoading] = useState(false)
+    const [isEncoderLoading, setIsEncoderLoading] = useState(false)
+    const [engineError, setEngineError] = useState(null)
+    const [isFpsLoading, setIsFpsLoading] = useState(false)
+    const [isQualityLoading, setIsQualityLoading] = useState(false)
+
     const capturer = useMemo(() => {
         if (userCapturer) return userCapturer
-        if (capturers.length > 0) {
-            return capturers.find(({ isSelected }) => isSelected)?.name || ""
-        }
-        return ""
+        return optionValue(capturers.find(item => item.isSelected)) || optionValue(capturers[0])
     }, [userCapturer, capturers])
 
-    // Derive encoder from user choice or selected from Redux  
     const encoder = useMemo(() => {
         if (userEncoder) return userEncoder
-        if (encoders.length > 0) {
-            return encoders.find(({ isSelected }) => isSelected)?.name || ""
-        }
-        return ""
+        return optionValue(encoders.find(item => item.isSelected)) || optionValue(encoders[0])
     }, [userEncoder, encoders])
 
     const { data: fps, isPending: isPendingFps, refetch: refetchFps } = useQuery({
         queryKey: ['screenFps'],
         queryFn: () => window.electron.ipcRenderer.invoke("store-get", "screenFps"),
-        staleTime: Infinity
+        staleTime: Infinity,
+    })
+
+    const { data: quality, isPending: isPendingQuality, refetch: refetchQuality } = useQuery({
+        queryKey: ['recordingQuality'],
+        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "recordingQuality"),
+        staleTime: Infinity,
     })
 
     const refreshCapturers = useCallback(async () => {
-        setUserCapturer("")
-        dispatch(setCapturers([]))
-        dispatch(setCapturers(await window.electron.ipcRenderer.invoke("get-capturers", true) || []))
+        setIsCapturerLoading(true)
+        setEngineError(null)
+        try {
+            const next = await window.electron.ipcRenderer.invoke("get-capturers", true)
+            dispatch(setCapturers(Array.isArray(next) ? next : []))
+            setUserCapturer(null)
+        } catch (error) {
+            setEngineError(error?.message || "Could not detect screen capture engines.")
+        } finally {
+            setIsCapturerLoading(false)
+        }
+    }, [dispatch])
+
+    const refreshEncoders = useCallback(async () => {
+        setIsEncoderLoading(true)
+        setEngineError(null)
+        try {
+            const next = await window.electron.ipcRenderer.invoke("get-encoders", true)
+            dispatch(setEncoders(Array.isArray(next) ? next : []))
+            setUserEncoder(null)
+        } catch (error) {
+            setEngineError(error?.message || "Could not detect video encoders.")
+        } finally {
+            setIsEncoderLoading(false)
+        }
     }, [dispatch])
 
     const onSelectCapturer = useCallback(async ({ target }) => {
-        setUserCapturer(target.value)
-        await window.electron.ipcRenderer.invoke("set-capturer", target.value)
-    }, [])
-
-    const refreshEncoders = useCallback(async () => {
-        setUserEncoder("")
-        dispatch(setEncoders([]))
-        dispatch(setEncoders(await window.electron.ipcRenderer.invoke("get-encoders", true) || []))
+        const value = target.value
+        setUserCapturer(value)
+        setEngineError(null)
+        try {
+            await window.electron.ipcRenderer.invoke("set-capturer", value)
+            const next = await window.electron.ipcRenderer.invoke("get-capturers")
+            dispatch(setCapturers(Array.isArray(next) ? next : []))
+            setUserCapturer(null)
+        } catch (error) {
+            setUserCapturer(null)
+            setEngineError(error?.message || "Could not select that capture engine.")
+        }
     }, [dispatch])
 
     const onSelectEncoder = useCallback(async ({ target }) => {
-        setUserEncoder(target.value)
-        await window.electron.ipcRenderer.invoke("set-encoder", target.value)
-    }, [])
+        const value = target.value
+        setUserEncoder(value)
+        setEngineError(null)
+        try {
+            await window.electron.ipcRenderer.invoke("set-encoder", value)
+            const next = await window.electron.ipcRenderer.invoke("get-encoders")
+            dispatch(setEncoders(Array.isArray(next) ? next : []))
+            setUserEncoder(null)
+        } catch (error) {
+            setUserEncoder(null)
+            setEngineError(error?.message || "Could not select that encoder.")
+        }
+    }, [dispatch])
 
     const onSelectFps = async newFps => {
         setIsFpsLoading(true)
-        await window.electron.ipcRenderer.invoke("store-set", "screenFps", newFps)
-        refetchFps()
-        setIsFpsLoading(false)
+        try {
+            await window.electron.ipcRenderer.invoke("store-set", "screenFps", newFps)
+            await refetchFps()
+        } finally {
+            setIsFpsLoading(false)
+        }
+    }
+
+    const onSelectQuality = async ({ target }) => {
+        setIsQualityLoading(true)
+        try {
+            await window.electron.ipcRenderer.invoke("store-set", "recordingQuality", target.value)
+            await refetchQuality()
+        } finally {
+            setIsQualityLoading(false)
+        }
     }
 
     return (<div className="flex flex-col gap-4">
         <h4 className="font-semibold text-lg">Recorder</h4>
-        <span className="block">
-            <Hint>
-                <span className="font-bold">Having issues recording or can&apos;t see any encoders below?</span> Flowtake tries to detect available recording options for your hardware automatically.
-                Check screen recording permission and
-                click <ArrowPathIconSmall className="size-3 inline-block" /> to refresh available capturers and
-                encoders.
-            </Hint>
-        </span>
+        <Hint>
+            Flowtake probes the device and selects a compatible low-overhead capture and encoding path.
+            Use refresh after changing a GPU, display adapter, driver, or screen-recording permission.
+        </Hint>
 
         <SystemAudio />
 
-        <Fieldset legend="Screen Capturing" description="Desktop Duplication API (if available) is recommended for 
-        better system performance while recording.">
-            <div className="label">Capturer</div>
-            <div className="join">
-                <select className="select join-item flex-1"
-                    disabled={capturers.length === 0 || encoders.length === 0} onChange={onSelectCapturer}
-                    value={capturer}>
-                    {capturers.map(({ name, displayName }, i) =>
-                        (<option key={i} value={name}>{displayName}</option>))}
+        <Fieldset legend="Screen capture" description="Desktop duplication is preferred when the device supports it because it reduces CPU and memory traffic.">
+            <label className="label" htmlFor="capture-engine">Capture engine</label>
+            <div className="join w-full">
+                <select
+                    id="capture-engine"
+                    aria-label="Screen capture engine"
+                    className="select join-item flex-1 min-w-0"
+                    disabled={isCapturerLoading}
+                    onChange={onSelectCapturer}
+                    value={capturer}
+                >
+                    {capturers.length === 0 && <option value="">No capture engine detected</option>}
+                    {capturers.map((item, index) => (
+                        <option key={`${optionValue(item)}-${index}`} value={optionValue(item)}>
+                            {optionLabel(item)}
+                        </option>
+                    ))}
                 </select>
-                <Button
-                    className="join-item"
-                    disabled={capturers.length === 0 || encoders.length === 0}
+                <button
+                    type="button"
+                    className="btn join-item btn-square"
                     onClick={refreshCapturers}
-                    icon={ArrowPathIcon}
-                    isLoading={capturers.length === 0}
-                />
-            </div>
-        </Fieldset>
-
-        <Fieldset legend="Video Encoding" description="Media Foundation (if available) or a different hardware encoder
-                is recommended for better video quality and system performance while recording.">
-            <div className="label">Encoder</div>
-            <div className="join">
-                <select className="select join-item flex-1"
-                    disabled={capturers.length === 0 || encoders.length === 0} onChange={onSelectEncoder}
-                    value={encoder}>
-                    {encoders.map(({ name, displayName }, i) =>
-                        (<option key={i} value={name}>{displayName}</option>))}
-                </select>
-                <button className="btn join-item" disabled={capturers.length === 0 || encoders.length === 0}
-                    onClick={refreshEncoders} >
-                    {encoders.length > 0 && <ArrowPathIcon className="h-6 w-6" />}
-                    {encoders.length === 0 && <span className="loading loading-spinner"></span>}
+                    disabled={isCapturerLoading}
+                    aria-label="Refresh screen capture engines"
+                >
+                    {isCapturerLoading
+                        ? <span className="loading loading-spinner loading-sm" />
+                        : <ArrowPathIcon className="size-5" />}
                 </button>
             </div>
         </Fieldset>
 
-        <Fieldset legend="Screen Recording Frame Rate" description="Set the frame rate for screen recording. Higher 
-        frame rates result in smoother video but can affect system performance while recording.">
-            <div className="label">Frame Rate</div>
+        <Fieldset legend="Video encoding" description="Flowtake validates available encoders on this device. Hardware encoders usually provide the lowest recording overhead.">
+            <label className="label" htmlFor="video-encoder">Encoder</label>
+            <div className="join w-full">
+                <select
+                    id="video-encoder"
+                    aria-label="Video encoder"
+                    className="select join-item flex-1 min-w-0"
+                    disabled={isEncoderLoading}
+                    onChange={onSelectEncoder}
+                    value={encoder}
+                >
+                    {encoders.length === 0 && <option value="">No compatible encoder detected</option>}
+                    {encoders.map((item, index) => (
+                        <option key={`${optionValue(item)}-${index}`} value={optionValue(item)}>
+                            {optionLabel(item)}
+                        </option>
+                    ))}
+                </select>
+                <button
+                    type="button"
+                    className="btn join-item btn-square"
+                    onClick={refreshEncoders}
+                    disabled={isEncoderLoading}
+                    aria-label="Refresh video encoders"
+                >
+                    {isEncoderLoading
+                        ? <span className="loading loading-spinner loading-sm" />
+                        : <ArrowPathIcon className="size-5" />}
+                </button>
+            </div>
+        </Fieldset>
+
+        {engineError && <p className="text-sm text-error" role="alert">{engineError}</p>}
+
+        <Fieldset legend="Recording quality" description="Adjust the real encoder preset and resolution-aware bitrate. Performance uses the least CPU and storage bandwidth; Quality keeps more detail.">
+            <label className="label" htmlFor="recording-quality">Quality preset</label>
+            <select
+                id="recording-quality"
+                className="select w-full"
+                value={quality || "balanced"}
+                onChange={onSelectQuality}
+                disabled={isPendingQuality || isQualityLoading}
+            >
+                <option value="performance">Performance — lowest overhead</option>
+                <option value="balanced">Balanced — recommended</option>
+                <option value="quality">Quality — higher bitrate</option>
+            </select>
+        </Fieldset>
+
+        <Fieldset legend="Screen recording frame rate" description="30 FPS uses fewer resources. Choose 60 FPS for fast motion when the device has enough headroom.">
+            <div className="label">Frame rate</div>
             <div className="join">
                 <Button className={`join-item ${fps === 30 ? "btn-info" : ""}`} disabled={isFpsLoading || isPendingFps}
-                    onClick={() => onSelectFps(30)}>30FPS</Button>
+                    onClick={() => onSelectFps(30)}>30 FPS</Button>
                 <Button className={`join-item ${fps === 60 ? "btn-info" : ""}`} disabled={isFpsLoading || isPendingFps}
-                    onClick={() => onSelectFps(60)}>60FPS</Button>
+                    onClick={() => onSelectFps(60)}>60 FPS</Button>
             </div>
         </Fieldset>
     </div>)

--- a/app/windows/main/components/settings/Settings.jsx
+++ b/app/windows/main/components/settings/Settings.jsx
@@ -51,11 +51,11 @@ export default function Settings() {
     useHotkeys("ctrl+slash", () => dispatch(setOpenSettings(SETTINGS_HOTKEYS)))
 
     return (<Modal isOpen={!!openSettings} title={"Settings"} close={() => dispatch(setOpenSettings(null))}
-        modalBoxClassNames="w-full max-w-3xl h-150 flex flex-col">
-        <div className="flex flex-row gap-6 flex-1 min-h-0">
+        modalBoxClassNames="w-full max-w-3xl h-[min(600px,calc(100vh-2rem))] flex flex-col">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-5 flex-1 min-h-0">
             {/* Sidebar */}
-            <nav className="w-48 flex-shrink-0 flex flex-col">
-                <div className="flex flex-col gap-0.5">
+            <nav className="w-full sm:w-44 flex-shrink-0 flex sm:flex-col overflow-x-auto sm:overflow-visible pb-1 sm:pb-0" aria-label="Settings sections">
+                <div className="flex sm:flex-col gap-0.5 min-w-max sm:min-w-0">
                     <NavItem icon={Cog6ToothIcon} label="General"
                         active={openSettings === SETTINGS_GENERAL}
                         onClick={() => dispatch(setOpenSettings(SETTINGS_GENERAL))} />
@@ -71,10 +71,9 @@ export default function Settings() {
                     <NavItem icon={LanguageIcon} label="Speech to Text"
                         active={openSettings === SETTINGS_STT}
                         onClick={() => dispatch(setOpenSettings(SETTINGS_STT))} />
-                    <NavItem icon={BoltIcon} label="Hotkeys"
+                    <NavItem icon={BoltIcon} label="Shortcuts"
                         active={openSettings === SETTINGS_HOTKEYS}
                         onClick={() => dispatch(setOpenSettings(SETTINGS_HOTKEYS))}
-                        badge={<span className="ml-auto"><kbd className="kbd kbd-xs mr-0.5">ctrl</kbd><kbd className="kbd kbd-xs">/</kbd></span>}
                     />
                     <NavItem icon={ArrowPathIcon} label="Updates"
                         active={openSettings === SETTINGS_UPDATES}
@@ -82,15 +81,16 @@ export default function Settings() {
                 </div>
 
                 {/* Footer */}
-                <div className="mt-auto pt-4 border-t border-base-content/5">
+                <div className="hidden sm:block mt-auto pt-4 border-t border-base-content/5">
                     <div className="flex items-center gap-2 px-2">
-                        <img src={icon} className="size-5 rounded" />
+                        <img src={icon} alt="" className="size-5 rounded" />
                         <span className="text-xs font-brand">
                             <span className="font-semibold">Flowtake</span>
                             {!isPending && !isError && <span className="text-base-content/40 ml-1">{version}</span>}
                         </span>
                     </div>
                     <button
+                        type="button"
                         onClick={() => window.electron.ipcRenderer.invoke("open-url-in-browser", "https://github.com/JNX03/Flowtake")}
                         className="flex items-center gap-1.5 px-2 mt-2 text-[11px] text-base-content/25 hover:text-base-content/50 transition-colors"
                     >
@@ -101,7 +101,7 @@ export default function Settings() {
             </nav>
 
             {/* Content */}
-            <div className="flex-1 min-w-0 border-l border-base-content/5 pl-6">
+            <div className="flex-1 min-w-0 min-h-0 border-t sm:border-t-0 sm:border-l border-base-content/5 pt-3 sm:pt-0 sm:pl-5">
                 <div className="overflow-y-auto overflow-x-hidden h-full">
                     {openSettings === SETTINGS_GENERAL && <GeneralSettings />}
                     {openSettings === SETTINGS_APPEARANCE && <AppearanceSettings />}
@@ -119,7 +119,9 @@ export default function Settings() {
 function NavItem({ icon: Icon, label, active, onClick, badge }) {
     return (
         <button
+            type="button"
             onClick={onClick}
+            aria-current={active ? "page" : undefined}
             className={`flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-all
                 ${active
                     ? "bg-primary/10 text-primary font-medium"

--- a/app/windows/main/components/settings/SpeechToTextSettings.jsx
+++ b/app/windows/main/components/settings/SpeechToTextSettings.jsx
@@ -3,7 +3,6 @@ import { useQuery } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 import Hint from "../../../../components/Hint"
 import Fieldset from "../properties/Fieldset"
-import Toggle from "../properties/Toggle"
 import SubtitlesGenerator from "../../subtitles/SubtitlesGenerator"
 
 export default function SpeechToTextSettings() {
@@ -12,12 +11,6 @@ export default function SpeechToTextSettings() {
     const { data: defaultLanguage, isPending, refetch } = useQuery({
         queryKey: ['sttDefaultLanguage'],
         queryFn: () => window.electron.ipcRenderer.invoke("store-get", "sttDefaultLanguage"),
-        staleTime: Infinity
-    })
-
-    const { data: autoGenerate, isPending: isAutoGenPending, refetch: refetchAutoGen } = useQuery({
-        queryKey: ['sttAutoGenerate'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "sttAutoGenerate"),
         staleTime: Infinity
     })
 
@@ -35,17 +28,12 @@ export default function SpeechToTextSettings() {
         refetch()
     }
 
-    const onChangeAutoGenerate = async (e) => {
-        await window.electron.ipcRenderer.invoke("store-set", "sttAutoGenerate", e.target.checked)
-        refetchAutoGen()
-    }
-
     return (<div className="flex flex-col gap-4">
         <h4 className="font-semibold text-lg">Speech to Text</h4>
         <span className="block">
             <Hint>
-                Auto-generate subtitles from speech in your recordings using AI. Supports 99+ languages.
-                First-time use downloads the AI model (~75MB).
+                This language is preselected when you generate subtitles from a recording. Speech recognition supports 99+ languages.
+                First-time use downloads the local AI model (~75MB).
             </Hint>
         </span>
 
@@ -53,6 +41,7 @@ export default function SpeechToTextSettings() {
             <div className="relative">
                 <MagnifyingGlassIcon className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 opacity-50" />
                 <input
+                    aria-label="Search speech recognition languages"
                     type="text"
                     placeholder="Search languages..."
                     value={languageSearch}
@@ -61,6 +50,7 @@ export default function SpeechToTextSettings() {
                 />
             </div>
             <select
+                aria-label="Default speech recognition language"
                 className="select select-sm w-full"
                 value={isPending ? "en" : (defaultLanguage || "en")}
                 onChange={onChangeLanguage}
@@ -76,12 +66,5 @@ export default function SpeechToTextSettings() {
             )}
         </Fieldset>
 
-        <Fieldset legend="Auto-generate" description="Automatically generate subtitles when opening a recording that has audio.">
-            <Toggle leftLabel="Auto-generate subtitles"
-                value={isAutoGenPending ? false : (autoGenerate ?? false)}
-                onChange={onChangeAutoGenerate}
-                disabled={isAutoGenPending}
-                isIndeterminate={isAutoGenPending} />
-        </Fieldset>
     </div>)
 }

--- a/app/windows/main/components/settings/SystemAudio.jsx
+++ b/app/windows/main/components/settings/SystemAudio.jsx
@@ -4,13 +4,16 @@ import {
     useQuery,
     useQueryClient
 } from "@tanstack/react-query"
-import { useCallback } from "react"
+import { useCallback, useState } from "react"
 import Button from "../../../../components/Button"
+import { getSystemAudioSources } from "@shared/systemAudio"
 import Fieldset from "../properties/Fieldset"
 
 export default function SystemAudio() {
 
     const queryClient = useQueryClient()
+    const [isProbingDevices, setIsProbingDevices] = useState(false)
+    const [refreshError, setRefreshError] = useState(null)
 
     const { data: defaultDevice, isPending: isPendingDefaultDevice } = useQuery({
         queryKey: ['systemAudio'],
@@ -18,16 +21,13 @@ export default function SystemAudio() {
         staleTime: Infinity
     })
 
-    const { data: devices, isPending: isPendingDevices } = useQuery({
-        queryKey: ['audioDevices'],
+    const { data: devices, isPending: isPendingDevices, isFetching: isFetchingDevices } = useQuery({
+        queryKey: ['systemAudioDevices'],
         queryFn: async () => {
-            const devices = await navigator.mediaDevices.enumerateDevices()
-            return devices
-                .filter(({ kind }) => kind === "audioinput")
-                .filter(({ deviceId }) => deviceId !== "default" && deviceId !== "communications")
-                .map(({ label }) => label)
+            if (!navigator.mediaDevices?.enumerateDevices) return []
+            return getSystemAudioSources(await navigator.mediaDevices.enumerateDevices())
         },
-        staleTime: Infinity
+        staleTime: 30_000
     })
 
     const { mutate, isPending: isPendingMutate } = useMutation({
@@ -36,27 +36,70 @@ export default function SystemAudio() {
     })
 
     const onChange = useCallback(({ target }) => {
-        if (target.value !== "") mutate(target.value)
+        mutate(target.value || null)
     }, [mutate])
 
-    return (<Fieldset legend="System Audio" description="Select the input device for system audio. It typically has a 
-        name like 'Stereo Mix' or 'Loopback'. System audio is only available on supported audio hardware with up-to-date
-        drivers. You might need to enable the system audio input device in the Windows settings.">
+    const refreshDevices = useCallback(async () => {
+        setIsProbingDevices(true)
+        setRefreshError(null)
+        let permissionStream = null
+
+        try {
+            // Device labels are hidden in a fresh WebView until the user grants
+            // media access. Only this explicit Refresh action may prompt; the
+            // initial settings render remains permission-quiet.
+            if (navigator.mediaDevices?.getUserMedia) {
+                permissionStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false })
+            }
+        } catch (error) {
+            const permissionDenied = error?.name === "NotAllowedError" || error?.name === "PermissionDeniedError"
+            setRefreshError(permissionDenied
+                ? "Audio permission was not granted, so device names may remain hidden."
+                : "Audio devices could not be refreshed. Check that an input is available and try again.")
+        } finally {
+            permissionStream?.getTracks().forEach(track => track.stop())
+            await queryClient.invalidateQueries({ queryKey: ['systemAudioDevices'] })
+            setIsProbingDevices(false)
+        }
+    }, [queryClient])
+
+    const selectedDevice = devices?.includes(defaultDevice) ? defaultDevice : ""
+    const hasUnavailableStoredDevice = !!defaultDevice && !selectedDevice && !isPendingDevices
+    const isRefreshing = isProbingDevices || isFetchingDevices
+
+    return (<Fieldset legend="System Audio" description="Flowtake only lists real loopback inputs such as Stereo Mix, Loopback, or BlackHole. A normal microphone is never treated as system audio.">
         <div className="label">System Audio Input</div>
-        <div className="join">
+        <div className="join w-full">
             <select className="select join-item flex-1"
-                disabled={!devices || devices.length === 0} onChange={onChange}
-                value={defaultDevice ?? ""}>
-                <option disabled={true} value="">Select a system audio input device</option>
+                disabled={isRefreshing || isPendingDefaultDevice || isPendingMutate || !devices?.length}
+                onChange={onChange}
+                value={selectedDevice}>
+                <option value="">System audio off</option>
                 {devices?.map((label, i) => (<option key={i} value={label}>{label}</option>))}
             </select>
             <Button
                 className="join-item"
-                disabled={isPendingDevices || isPendingDefaultDevice || isPendingMutate}
-                onClick={() => queryClient.invalidateQueries({ queryKey: ['audioDevices'] })}
+                disabled={isRefreshing || isPendingDefaultDevice || isPendingMutate}
+                onClick={refreshDevices}
                 icon={ArrowPathIcon}
-                isLoading={isPendingDevices || isPendingDefaultDevice || isPendingMutate}
+                isLoading={isRefreshing || isPendingDefaultDevice || isPendingMutate}
+                aria-label="Refresh system audio devices"
             />
         </div>
+        {refreshError && (
+            <p className="mt-2 text-xs leading-relaxed text-warning" role="status">
+                {refreshError}
+            </p>
+        )}
+        {!isPendingDevices && devices?.length === 0 && (
+            <p className="mt-2 text-xs leading-relaxed text-warning" role="status">
+                No loopback input was found. Enable Stereo Mix in Windows sound settings or install a trusted loopback device, then refresh.
+            </p>
+        )}
+        {hasUnavailableStoredDevice && (
+            <p className="mt-2 text-xs leading-relaxed text-warning" role="status">
+                The previously selected loopback device is no longer available. System audio will stay off until you choose a new one.
+            </p>
+        )}
     </Fieldset >)
 }

--- a/app/windows/main/components/settings/UpdatesSettings.jsx
+++ b/app/windows/main/components/settings/UpdatesSettings.jsx
@@ -1,11 +1,10 @@
 import { ArrowDownTrayIcon, ArrowPathIcon, CheckCircleIcon, ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline"
 import { useQuery } from "@tanstack/react-query"
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { exit } from "@tauri-apps/plugin-process"
 import Button from "../../../../components/Button"
 import MarkdownRenderer from "../../../../components/MarkdownRenderer"
 import Fieldset from "../properties/Fieldset"
-import Toggle from "../properties/Toggle"
 
 function formatBytes(bytes) {
     if (bytes < 1024) return `${bytes} B`
@@ -23,11 +22,11 @@ export default function UpdatesSettings() {
     const [isInstalling, setIsInstalling] = useState(false)
     const unlistenRef = useRef(null)
 
-    const { data: autoUpdateEnabled, isPending: isAutoUpdatePending, refetch: refetchAutoUpdate } = useQuery({
-        queryKey: ['autoUpdateEnabled'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "autoUpdateEnabled"),
-        staleTime: Infinity
-    })
+    const removeProgressListener = useCallback(() => {
+        if (!unlistenRef.current) return
+        unlistenRef.current()
+        unlistenRef.current = null
+    }, [])
 
     const { data: version } = useQuery({
         queryKey: ['version'],
@@ -42,18 +41,8 @@ export default function UpdatesSettings() {
     })
 
     useEffect(() => {
-        return () => {
-            if (unlistenRef.current) {
-                unlistenRef.current()
-                unlistenRef.current = null
-            }
-        }
-    }, [])
-
-    const onChangeAutoUpdate = async (e) => {
-        await window.electron.ipcRenderer.invoke("store-set", "autoUpdateEnabled", e.target.checked)
-        refetchAutoUpdate()
-    }
+        return removeProgressListener
+    }, [removeProgressListener])
 
     const onCheckForUpdates = async () => {
         setChecking(true)
@@ -77,16 +66,18 @@ export default function UpdatesSettings() {
         setInstallerPath(null)
 
         // Listen for progress events
-        if (unlistenRef.current) {
-            unlistenRef.current()
-        }
-        unlistenRef.current = window.electron.ipcRenderer.on("update-download-progress", (_event, data) => {
+        removeProgressListener()
+        const handleProgress = (_event, data) => {
             setDownloadProgress({
                 bytesDownloaded: data.bytes_downloaded,
                 totalBytes: data.total_bytes,
                 percent: data.percent,
             })
-        })
+        }
+        window.electron.ipcRenderer.on("update-download-progress", handleProgress)
+        unlistenRef.current = () => {
+            window.electron.ipcRenderer.removeListener("update-download-progress", handleProgress)
+        }
 
         try {
             const result = await window.electron.ipcRenderer.invoke(
@@ -100,10 +91,7 @@ export default function UpdatesSettings() {
             setDownloadError(err?.message || String(err) || "Download failed")
             setDownloadProgress(null)
         } finally {
-            if (unlistenRef.current) {
-                unlistenRef.current()
-                unlistenRef.current = null
-            }
+            removeProgressListener()
         }
     }
 
@@ -130,14 +118,6 @@ export default function UpdatesSettings() {
 
     return (<div className="flex flex-col gap-4">
         <h4 className="font-semibold text-lg">Updates</h4>
-
-        <Fieldset legend="Auto Update" description="Automatically check for updates when Flowtake starts.">
-            <Toggle leftLabel="Check for updates automatically"
-                value={isAutoUpdatePending ? false : (autoUpdateEnabled ?? true)}
-                onChange={onChangeAutoUpdate}
-                disabled={isAutoUpdatePending}
-                isIndeterminate={isAutoUpdatePending} />
-        </Fieldset>
 
         <Fieldset legend="Check for Updates" description={`Current version: ${version || "..."}`}>
             <div className="flex flex-col gap-3">
@@ -199,7 +179,7 @@ export default function UpdatesSettings() {
                                 <Button icon={ArrowDownTrayIcon} onClick={onDownloadUpdate}>
                                     Download Update
                                 </Button>
-                                <button className="btn btn-ghost btn-sm gap-1" onClick={onOpenInBrowser}>
+                                <button type="button" className="btn btn-ghost btn-sm gap-1" onClick={onOpenInBrowser}>
                                     <ArrowTopRightOnSquareIcon className="size-4" />
                                     Open in browser
                                 </button>

--- a/app/windows/main/components/settings/plugin/features/AppRecordingFeature.jsx
+++ b/app/windows/main/components/settings/plugin/features/AppRecordingFeature.jsx
@@ -7,11 +7,14 @@ import {
     updateFeatureConfig,
 } from '@shared/redux/pluginSlice'
 
+const MAX_APP_LAYERS = 2
+
 export default function AppRecordingFeature() {
     const dispatch = useDispatch()
     const config = useSelector(selectFeatureConfig(FEATURE_IDS.APP_RECORDING))
     const [picking, setPicking] = useState(false)
     const [available, setAvailable] = useState([])
+    const [pickerError, setPickerError] = useState(null)
 
     const update = (patch) => {
         dispatch(updateFeatureConfig({ id: FEATURE_IDS.APP_RECORDING, patch }))
@@ -19,6 +22,7 @@ export default function AppRecordingFeature() {
 
     const refreshWindows = async () => {
         setPicking(true)
+        setPickerError(null)
         try {
             const list = await window.electron.ipcRenderer.invoke('get-windows')
             // Keep top-level non-tool windows that have a name
@@ -26,11 +30,13 @@ export default function AppRecordingFeature() {
             setAvailable(visible)
         } catch {
             setAvailable([])
+            setPickerError('App windows could not be listed. Close the picker and try again.')
         }
     }
 
     const toggle = (win) => {
         const exists = (config.windows || []).some(w => w.id === win.id)
+        if (!exists && (config.windows || []).length >= MAX_APP_LAYERS) return
         const nextWindows = exists
             ? config.windows.filter(w => w.id !== win.id)
             : [...(config.windows || []), { id: win.id, name: win.name }]
@@ -51,7 +57,10 @@ export default function AppRecordingFeature() {
     return (
         <div className="flex flex-col gap-3 mt-2">
             <p className="text-[11px] text-base-content/50 leading-snug">
-                Capture each selected app to its own video layer. You can show or hide layers in the editor before exporting.
+                Capture up to {MAX_APP_LAYERS} additional app regions as separate video layers. Each layer adds an encoder, so use only what you need.
+            </p>
+            <p className="text-[11px] text-warning/80 leading-snug">
+                Keep selected windows open, uncovered, and in the same position until you stop recording.
             </p>
 
             {(config.windows || []).length > 0 && (
@@ -83,17 +92,19 @@ export default function AppRecordingFeature() {
                 <div className="rounded-md border border-base-content/10 max-h-60 overflow-y-auto divide-y divide-base-content/5">
                     {available.length === 0 && (
                         <div className="px-3 py-6 text-center text-xs text-base-content/40">
-                            No windows available.
+                            {pickerError || "No windows available."}
                         </div>
                     )}
                     {available.map(w => {
                         const checked = (config.windows || []).some(s => s.id === w.id)
+                        const atLimit = !checked && (config.windows || []).length >= MAX_APP_LAYERS
                         return (
-                            <label key={w.id} className="flex items-center gap-2 px-3 py-1.5 cursor-pointer hover:bg-base-content/5">
+                            <label key={w.id} className={`flex items-center gap-2 px-3 py-1.5 hover:bg-base-content/5 ${atLimit ? "opacity-45 cursor-not-allowed" : "cursor-pointer"}`}>
                                 <input
                                     type="checkbox"
                                     className="checkbox checkbox-xs"
                                     checked={checked}
+                                    disabled={atLimit}
                                     onChange={() => toggle(w)}
                                 />
                                 <span className="text-xs truncate flex-1">{w.name}</span>

--- a/app/windows/main/components/setup/CompletionStep.jsx
+++ b/app/windows/main/components/setup/CompletionStep.jsx
@@ -1,58 +1,36 @@
 import { CheckCircleIcon, RocketLaunchIcon } from "@heroicons/react/24/outline"
-import { useQuery } from "@tanstack/react-query"
 import PropTypes from "prop-types"
 
 export default function CompletionStep({ onComplete }) {
-    const { data: launchCount } = useQuery({
-        queryKey: ['launchCount'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "launchCount"),
-        staleTime: Infinity
-    })
-
-    const { data: exportDir } = useQuery({
-        queryKey: ['exportDirectory'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "exportDirectory"),
-        staleTime: Infinity
-    })
-
-    const { data: themeName } = useQuery({
-        queryKey: ['setup-theme-name'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "appearance-theme"),
-        staleTime: Infinity
-    })
-
     return (
         <div className="flex flex-col items-center justify-center h-full text-center gap-6">
             <CheckCircleIcon className="w-16 h-16 text-success" />
 
             <div>
-                <h2 className="text-2xl font-bold">You're all set!</h2>
+                <h2 className="text-2xl font-bold">Ready for your first take</h2>
                 <p className="text-base-content/60 mt-1">
-                    Flowtake is ready to go.
+                    Your recording controls stay close, and everything is saved locally.
                 </p>
             </div>
 
-            {/* Summary */}
             <div className="bg-base-200/50 rounded-xl p-4 text-left w-full max-w-sm space-y-2">
-                <div className="flex justify-between text-sm">
-                    <span className="text-base-content/60">Theme</span>
-                    <span className="font-medium">{themeName || "Flowtake Dark"}</span>
+                <div className="flex items-center gap-2 text-sm">
+                    <CheckCircleIcon className="size-4 text-success flex-none" />
+                    <span>Pick a screen, window, or area</span>
                 </div>
-                <div className="flex justify-between text-sm">
-                    <span className="text-base-content/60">Export path</span>
-                    <span className="font-medium truncate ml-4 max-w-[200px]">{exportDir || "Default"}</span>
+                <div className="flex items-center gap-2 text-sm">
+                    <CheckCircleIcon className="size-4 text-success flex-none" />
+                    <span>Add camera or microphone only when needed</span>
                 </div>
-                {typeof launchCount === 'number' && (
-                    <div className="flex justify-between text-sm">
-                        <span className="text-base-content/60">Launch</span>
-                        <span className="font-medium">#{launchCount}</span>
-                    </div>
-                )}
+                <div className="flex items-center gap-2 text-sm">
+                    <CheckCircleIcon className="size-4 text-success flex-none" />
+                    <span>Press Record, then stop from the floating controls</span>
+                </div>
             </div>
 
-            <button className="btn btn-primary gap-2" onClick={onComplete}>
+            <button type="button" className="btn btn-primary gap-2" onClick={onComplete}>
                 <RocketLaunchIcon className="w-5 h-5" />
-                Get Started
+                Open recorder
             </button>
         </div>
     )

--- a/app/windows/main/components/setup/PermissionsStep.jsx
+++ b/app/windows/main/components/setup/PermissionsStep.jsx
@@ -7,6 +7,7 @@ import {
 import { useQuery } from "@tanstack/react-query"
 
 export default function PermissionsStep() {
+    const platform = window.electron?.process?.platform || (navigator.platform?.includes("Mac") ? "darwin" : navigator.platform?.includes("Win") ? "win32" : "other")
     const { data: permissions, isPending: permPending, refetch: refetchPerms } = useQuery({
         queryKey: ['setup-permissions'],
         queryFn: () => window.electron.ipcRenderer.invoke("check-permissions"),
@@ -39,9 +40,9 @@ export default function PermissionsStep() {
     return (
         <div className="flex flex-col gap-5 max-w-lg mx-auto">
             <div>
-                <h3 className="text-lg font-semibold">Permissions & Dependencies</h3>
+                <h3 className="text-lg font-semibold">Recorder readiness</h3>
                 <p className="text-sm text-base-content/60 mt-1">
-                    Flowtake needs certain permissions and tools to record your screen.
+                    Flowtake checks the local capture tools now. Camera and microphone access are requested only if you choose those devices.
                 </p>
             </div>
 
@@ -55,7 +56,10 @@ export default function PermissionsStep() {
                     </div>
                 ) : (
                     <div className="space-y-1">
-                        {permissions?.map((perm, i) => (
+                        {permissions?.map((perm, i) => {
+                            const isCheckedOnUse = platform === "win32" && perm.permission !== "screenCapture"
+                            const status = isCheckedOnUse ? "Checked on use" : perm.hasPermission ? "Available" : "Missing"
+                            return (
                             <div key={i} className="flex items-center gap-3 p-2 rounded-lg bg-base-200/50">
                                 {perm.hasPermission ? (
                                     <CheckCircleIcon className="w-5 h-5 text-success flex-none" />
@@ -64,10 +68,11 @@ export default function PermissionsStep() {
                                 )}
                                 <span className="text-sm flex-1">{perm.label}</span>
                                 <span className={`badge badge-sm ${perm.hasPermission ? "badge-success" : "badge-warning"}`}>
-                                    {perm.hasPermission ? "Granted" : "Missing"}
+                                    {status}
                                 </span>
                             </div>
-                        ))}
+                            )
+                        })}
                     </div>
                 )}
             </div>
@@ -108,7 +113,7 @@ export default function PermissionsStep() {
                     <ArrowPathIcon className="w-4 h-4" />
                     Refresh
                 </button>
-                {!allPermsOk && navigator.platform?.includes("Mac") && (
+                {!allPermsOk && platform === "darwin" && (
                     <button className="btn btn-ghost btn-sm gap-1" onClick={openSystemSettings}>
                         <ArrowTopRightOnSquareIcon className="w-4 h-4" />
                         Open System Settings
@@ -118,7 +123,12 @@ export default function PermissionsStep() {
 
             {allPermsOk && allDepsOk && (
                 <div className="text-sm text-success font-medium">
-                    Everything looks good! Click Next to continue.
+                    Core recording tools are ready. Device access is still your choice.
+                </div>
+            )}
+            {(!allPermsOk || !allDepsOk) && !isLoading && (
+                <div className="text-sm text-warning font-medium">
+                    A required item needs attention. You can continue, but unavailable recording options will remain off.
                 </div>
             )}
         </div>

--- a/app/windows/main/components/setup/WelcomeStep.jsx
+++ b/app/windows/main/components/setup/WelcomeStep.jsx
@@ -22,8 +22,7 @@ export default function WelcomeStep() {
             </div>
 
             <p className="text-base-content/70 max-w-md">
-                Professional screen recording with automatic zoom animations.
-                Let's get you set up in a few quick steps.
+                Record your screen, window, or a custom area with local processing and automatic zoom. One quick readiness check, then you can start.
             </p>
         </div>
     )

--- a/app/windows/main/components/tutorial/steps.js
+++ b/app/windows/main/components/tutorial/steps.js
@@ -16,7 +16,7 @@ export const TUTORIAL_STEPS = [
     {
         id: 'stop-recording',
         title: 'Recording in progress',
-        description: 'Your screen is being recorded. Press Stop or use the keyboard shortcut when you\'re done.',
+        description: 'Your screen is being recorded. Use the always-visible Stop and save button when you\'re done.',
         targetSelector: null, // No spotlight — waiting state
         placement: null,
         isWaiting: true,

--- a/app/windows/recorder/App.jsx
+++ b/app/windows/recorder/App.jsx
@@ -3,9 +3,7 @@ import {
     CameraIcon,
     DocumentTextIcon,
     MicrophoneIcon,
-    PauseIcon,
     PencilIcon,
-    PlayIcon,
     RectangleGroupIcon,
     TrashIcon,
     VideoCameraIcon,
@@ -13,6 +11,7 @@ import {
     XMarkIcon,
 } from "@heroicons/react/20/solid"
 import { StopIcon } from "@heroicons/react/24/solid"
+import { ask } from "@tauri-apps/plugin-dialog"
 import { useQuery } from "@tanstack/react-query"
 import moment from "moment"
 import momentDurationFormatSetup from "moment-duration-format"
@@ -30,6 +29,13 @@ import useAudioMeter from "@shared/hooks/useAudioMeter"
 import VolumeMeter from "../../components/VolumeMeter"
 
 const RecorderTutorial = lazy(() => import("./components/RecorderTutorial"))
+
+const IDLE_ACTION = {
+    status: "idle",
+    message: "Recording in progress",
+}
+
+const BUSY_ACTIONS = new Set(["confirming", "saving", "restarting", "discarding"])
 
 const StyleTag = () => (
     <style>{`
@@ -96,11 +102,23 @@ const pillBg = {
 }
 
 // Icon button component — uses relative positioning + z-index to ensure clickability over drag region
-const Btn = ({ onClick, title, children, className = "", dataTutorial }) => (
+const Btn = ({
+    onClick,
+    title,
+    children,
+    className = "",
+    dataTutorial,
+    disabled = false,
+    ariaPressed,
+}) => (
     <button
+        type="button"
         onClick={onClick}
         title={title}
-        className={`relative z-10 flex items-center justify-center transition-all duration-100 cursor-pointer flex-shrink-0 active:scale-90 ${className}`}
+        aria-label={title}
+        aria-pressed={ariaPressed}
+        disabled={disabled}
+        className={`relative z-10 flex items-center justify-center transition-all duration-100 cursor-pointer flex-shrink-0 active:scale-90 disabled:cursor-not-allowed disabled:opacity-50 disabled:active:scale-100 ${className}`}
         style={{ WebkitUserSelect: "none" }}
         data-tutorial={dataTutorial}
     >
@@ -115,12 +133,19 @@ const Divider = () => (
 
 // "+N apps" chip used in both the pre-recording and recording pills when the
 // Individual App Recording plugin is configured.
-const AppBadge = ({ count, title }) => (
+const AppBadge = ({ count, title, status = "planned" }) => (
     <span
         title={title}
-        className="flex items-center gap-1 px-1.5 py-[2px] rounded-full bg-indigo-500/20 text-indigo-200 text-[10px] font-semibold flex-shrink-0">
+        aria-label={title}
+        className={`flex items-center gap-1 px-1.5 py-[2px] rounded-full text-[10px] font-semibold flex-shrink-0 ${
+            status === "failed"
+                ? "bg-red-500/20 text-red-200"
+                : status === "partial"
+                    ? "bg-amber-500/20 text-amber-200"
+                    : "bg-indigo-500/20 text-indigo-200"
+        }`}>
         <RectangleGroupIcon className="size-3" />
-        +{count}
+        {status === "failed" ? "!" : `+${count}`}
     </span>
 )
 
@@ -130,14 +155,17 @@ export default function App() {
     const [intervalId, setIntervalId] = useState(null)
     const [countdown, setCountdown] = useState(null)
     const [isRecording, setIsRecording] = useState(false)
-    const [isPaused, setIsPaused] = useState(false)
+    const [isCaptureFinalized, setIsCaptureFinalized] = useState(false)
     const [deviceRecorder, setDeviceRecorder] = useState(null)
     const [isMicMuted, setIsMicMuted] = useState(false)
     const [isCameraOff, setIsCameraOff] = useState(false)
     const [isExpanded, setIsExpanded] = useState(false)
+    const [isExpansionPinned, setIsExpansionPinned] = useState(false)
     const [isDrawing, setIsDrawing] = useState(false)
     const [audioStream, setAudioStream] = useState(null)
     const [tutorialActive, setTutorialActive] = useState(false)
+    const [appCaptureStatus, setAppCaptureStatus] = useState(null)
+    const [actionState, setActionState] = useState(IDLE_ACTION)
 
     const { data: cameraMicConfig } = useQuery({
         queryKey: ['cameraMicConfig'],
@@ -153,11 +181,16 @@ export default function App() {
 
     const isKeyboardOverlayEnabled = !!pluginSettings?.enabled?.keyboardOverlay
     const isAppRecordingEnabled = !!pluginSettings?.enabled?.appRecording
-    const appRecordingWindows = pluginSettings?.config?.appRecording?.windows || []
+    const appRecordingWindows = useMemo(
+        () => pluginSettings?.config?.appRecording?.windows || [],
+        [pluginSettings]
+    )
     const showAppBadge = isAppRecordingEnabled && appRecordingWindows.length > 0
-    const appBadgeTitle = showAppBadge
+    const appBadgeStatus = appCaptureStatus?.status || "planned"
+    const appBadgeCount = appCaptureStatus?.count ?? appRecordingWindows.length
+    const appBadgeTitle = appCaptureStatus?.message || (showAppBadge
         ? `Also capturing: ${appRecordingWindows.map(w => w.name).join(", ")}`
-        : ""
+        : "")
 
     const hasMic = !!cameraMicConfig?.audioTrack
     const hasCam = !!cameraMicConfig?.videoTrack
@@ -174,6 +207,20 @@ export default function App() {
         }
     }, [deviceRecorder, isRecording])
 
+    useEffect(() => {
+        const preview = cameraVideoRef.current
+        const stream = deviceRecorder?.stream
+        if (!preview || !stream) return
+
+        // The countdown, compact recorder, and expanded recorder render
+        // different <video> elements. Reattach the live stream whenever that
+        // element changes so the camera control never turns into a blank dot.
+        preview.srcObject = stream
+        return () => {
+            if (preview.srcObject === stream) preview.srcObject = null
+        }
+    }, [deviceRecorder, isRecording, isExpanded])
+
     const formattedTime = useMemo(() => {
         if (typeof moment.duration.fn.format === "undefined") momentDurationFormatSetup(moment)
         return moment.duration(time).format("mm:ss", { trim: false })
@@ -181,25 +228,50 @@ export default function App() {
 
     const timeRef = useRef(time)
     const cameraVideoRef = useRef(null)
+    const recordingStartClaimRef = useRef(false)
+    const deviceRecorderInitRef = useRef(null)
+    const countdownArmedRef = useRef(false)
+    const actionLockRef = useRef(false)
 
     const createDeviceRecorder = useCallback(async () => {
-        const recorder = new DeviceRecorder()
+        if (deviceRecorderInitRef.current) return deviceRecorderInitRef.current
+
+        const initPromise = (async () => {
+            const recorder = new DeviceRecorder()
+            try {
+                await recorder.init(cameraMicConfig, cameraVideoRef.current)
+                await recorder.initFile()
+                setDeviceRecorder(recorder)
+                return recorder
+            } catch (e) {
+                recorder.destroy()
+                await window.electron.ipcRenderer.invoke("cancel-recording", e.message)
+                return null
+            }
+        })()
+        deviceRecorderInitRef.current = initPromise
+
         try {
-            await recorder.init(cameraMicConfig, cameraVideoRef.current)
-            await recorder.initFile()
-            setDeviceRecorder(recorder)
-        } catch (e) {
-            await window.electron.ipcRenderer.invoke("cancel-recording", e.message)
+            return await initPromise
+        } finally {
+            if (deviceRecorderInitRef.current === initPromise) {
+                deviceRecorderInitRef.current = null
+            }
         }
     }, [cameraMicConfig])
 
     const startRecording = useCallback(async () => {
-        await new Promise(resolve => {
-            window.electron.ipcRenderer.once('recording-started', (_e, value) => resolve(value))
-            window.electron.ipcRenderer.invoke("start-recording")
-        })
+        if (recordingStartClaimRef.current) return
+        recordingStartClaimRef.current = true
         try {
-            deviceRecorder?.start()
+            setIsCaptureFinalized(false)
+            setAppCaptureStatus(null)
+            // Await the command itself instead of waiting only for the success
+            // event. If FFmpeg cannot start, the command rejects; the previous
+            // event-only path waited forever and left the countdown overlay
+            // stranded with no actionable error.
+            await window.electron.ipcRenderer.invoke("start-recording")
+            await deviceRecorder?.start()
             setIsRecording(true)
             if (isKeyboardOverlayEnabled) {
                 try { await window.electron.ipcRenderer.invoke("keyboard-start") } catch (e) { console.warn("[plugin] keyboard-start failed:", e) }
@@ -221,19 +293,50 @@ export default function App() {
                         }))
                         .filter(w => w.width > 0 && w.height > 0)
                     if (picked.length > 0) {
-                        await window.electron.ipcRenderer.invoke("start-multi-app-capture", picked)
+                        const tracks = await window.electron.ipcRenderer.invoke("start-multi-app-capture", picked)
+                        const started = Array.isArray(tracks) ? tracks.length : 0
+                        if (started === 0) {
+                            setAppCaptureStatus({
+                                status: "failed",
+                                count: 0,
+                                message: "Individual app recording could not start. The main recording is still running.",
+                            })
+                        } else if (started < picked.length) {
+                            setAppCaptureStatus({
+                                status: "partial",
+                                count: started,
+                                message: `${started} of ${picked.length} individual app captures started.`,
+                            })
+                        } else {
+                            setAppCaptureStatus({
+                                status: "active",
+                                count: started,
+                                message: `${started} individual app ${started === 1 ? "capture" : "captures"} active.`,
+                            })
+                        }
+                    } else {
+                        setAppCaptureStatus({
+                            status: "failed",
+                            count: 0,
+                            message: "The selected app windows are no longer available. The main recording is still running.",
+                        })
                     }
                 } catch (e) {
                     console.warn("[plugin] start-multi-app-capture failed:", e)
+                    setAppCaptureStatus({
+                        status: "failed",
+                        count: 0,
+                        message: "Individual app recording failed. The main recording is still running.",
+                    })
                 }
             }
-        } catch {
+        } catch (error) {
+            recordingStartClaimRef.current = false
             await window.electron.ipcRenderer.invoke(
                 "cancel-recording",
-                "The selected camera or microphone could not be recorded."
+                error?.message || String(error) || "The selected source could not be recorded."
             )
         }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [deviceRecorder, isKeyboardOverlayEnabled, isAppRecordingEnabled, appRecordingWindows])
 
     useEffect(() => {
@@ -241,8 +344,14 @@ export default function App() {
     }, [cameraMicConfig, deviceRecorder, createDeviceRecorder])
 
     useEffect(() => {
-        if (cameraMicConfig && (deviceRecorder || (!cameraMicConfig.videoTrack && !cameraMicConfig.audioTrack)))
+        if (
+            !countdownArmedRef.current
+            && cameraMicConfig
+            && (deviceRecorder || (!cameraMicConfig.videoTrack && !cameraMicConfig.audioTrack))
+        ) {
+            countdownArmedRef.current = true
             setCountdown(3)
+        }
     }, [cameraMicConfig, deviceRecorder])
 
     useEffect(() => {
@@ -261,12 +370,12 @@ export default function App() {
     }, [countdown, startRecording])
 
     useEffect(() => {
-        if (intervalId !== null && (!isRecording || isPaused)) {
+        if (intervalId !== null && (!isRecording || isCaptureFinalized)) {
             clearInterval(intervalId)
             setIntervalId(null)
-        } else if (intervalId === null && isRecording && !isPaused)
+        } else if (intervalId === null && isRecording && !isCaptureFinalized)
             setIntervalId(setInterval(() => setTime(timeRef.current + 1000), 1000))
-    }, [intervalId, isRecording, isPaused])
+    }, [intervalId, isRecording, isCaptureFinalized])
 
     useEffect(() => {
         timeRef.current = time
@@ -274,44 +383,186 @@ export default function App() {
 
     // ─── Actions ─────────────────────────────────────────────────────
 
-    const onClickStop = async () => {
-        setIsRecording(false)
-        await deviceRecorder?.stop()
-        deviceRecorder?.destroy()
+    // Keep destructive actions serialized. React state alone is not enough here:
+    // two pointer events can arrive before a render disables the buttons.
+    const beginAction = (status, message) => {
+        if (actionLockRef.current) return false
+        actionLockRef.current = true
+        setActionState({ status, message })
+        return true
+    }
+
+    const releaseAction = (nextState = IDLE_ACTION) => {
+        actionLockRef.current = false
+        setActionState(nextState)
+    }
+
+    const failAction = (verb, error, message) => {
+        console.error(`[recorder] Could not ${verb}:`, error)
+        const detail = error?.message || String(error || "Unknown error")
+        releaseAction({
+            status: "error",
+            message: message || `Couldn’t ${verb}: ${detail}`,
+        })
+    }
+
+    const stopRuntimeFeatures = async ({ stopAppCapture = true } = {}) => {
         if (isKeyboardOverlayEnabled) {
-            try { await window.electron.ipcRenderer.invoke("keyboard-stop") } catch (e) { console.warn("[plugin] keyboard-stop failed:", e) }
+            try {
+                await window.electron.ipcRenderer.invoke("keyboard-stop")
+            } catch (error) {
+                console.warn("[plugin] keyboard-stop failed:", error)
+            }
         }
-        window.electron.ipcRenderer.invoke("stop-recording")
+        if (stopAppCapture && isAppRecordingEnabled) {
+            try {
+                await window.electron.ipcRenderer.invoke("stop-multi-app-capture")
+            } catch (error) {
+                console.warn("[plugin] stop-multi-app-capture failed:", error)
+            }
+        }
     }
 
-    const onClickPause = () => {
-        setIsPaused(true)
-        window.electron.ipcRenderer.invoke("pause-recording", true)
-    }
+    const onClickStop = async () => {
+        if (!beginAction("saving", "Saving recording…")) return
+        let captureWasFinalized = isCaptureFinalized
 
-    const onClickResume = () => {
-        setIsPaused(false)
-        window.electron.ipcRenderer.invoke("pause-recording", false)
+        try {
+            try {
+                await deviceRecorder?.stop()
+            } catch (error) {
+                const detail = error?.message || String(error || "Unknown error")
+                throw new Error(`Camera or microphone track could not be finalized. ${detail}`)
+            }
+            // Native stop is the single owner of app-layer shutdown and
+            // validation. Calling the plugin stop first could reject before
+            // the primary FFmpeg process was stopped, leaving the take live
+            // behind a Retry button.
+            await stopRuntimeFeatures({ stopAppCapture: false })
+            // stop-recording owns graceful capture shutdown and packaging.
+            // From this point the timer and live-device controls must not imply
+            // that frames are still being captured if packaging later rejects.
+            captureWasFinalized = true
+            setIsCaptureFinalized(true)
+            await window.electron.ipcRenderer.invoke("stop-recording")
+            // Keep the recorder and its retry/discard controls alive until the
+            // native archive and project-store transaction has fully succeeded.
+            deviceRecorder?.destroy()
+            setIsRecording(false)
+        } catch (error) {
+            const detail = error?.message || String(error || "Unknown error")
+            failAction(
+                "save the recording",
+                error,
+                captureWasFinalized
+                    ? `Recording stopped. Save failed — ${detail}`
+                    : undefined
+            )
+        }
     }
 
     const onClickRestart = async () => {
+        if (!beginAction("confirming", "Confirm restart…")) return
+
+        let confirmed
+        try {
+            confirmed = await ask("Restart this recording? The current take will be permanently discarded.", {
+                title: "Restart recording",
+                kind: "warning",
+                okLabel: "Restart",
+                cancelLabel: "Keep recording",
+            })
+        } catch (error) {
+            failAction("open the restart confirmation", error)
+            return
+        }
+
+        if (!confirmed) {
+            releaseAction()
+            return
+        }
+
+        setActionState({ status: "restarting", message: "Restarting recording…" })
+        setCountdown(null)
         setIsRecording(false)
-        await deviceRecorder?.stop()
-        await window.electron.ipcRenderer.invoke("reset-recording")
-        setTime(0)
-        setIsPaused(false)
-        setIsMicMuted(false)
-        setIsCameraOff(false)
-        await deviceRecorder?.initFile()
-        setCountdown(3)
+        let resetCompleted = false
+
+        try {
+            try {
+                await deviceRecorder?.stop()
+            } catch (error) {
+                console.warn("[recorder] Device track finalization failed during restart:", error)
+            }
+            await stopRuntimeFeatures()
+            await window.electron.ipcRenderer.invoke("reset-recording")
+            resetCompleted = true
+            recordingStartClaimRef.current = false
+            setIsCaptureFinalized(false)
+            setTime(0)
+
+            // Muting toggles MediaStreamTrack.enabled. Resetting only the React
+            // labels left the real tracks muted/off on the next take.
+            deviceRecorder?.stream?.getTracks().forEach(track => {
+                track.enabled = true
+            })
+            setIsMicMuted(false)
+            setIsCameraOff(false)
+            setAppCaptureStatus(null)
+            await deviceRecorder?.initFile()
+
+            releaseAction()
+            setCountdown(3)
+        } catch (error) {
+            // If the native reset itself failed, keep Stop & save available for
+            // the original screen capture. Otherwise show a cancellable error.
+            setIsRecording(!resetCompleted)
+            failAction("restart the recording", error)
+        }
     }
 
     const onClickCancel = async () => {
-        setIsRecording(false)
+        const hasCurrentTake = isRecording || timeRef.current > 0
+        if (!beginAction(
+            hasCurrentTake ? "confirming" : "discarding",
+            hasCurrentTake ? "Confirm discard…" : "Closing recorder…"
+        )) return
+
+        if (hasCurrentTake) {
+            let confirmed
+            try {
+                confirmed = await ask("Discard this recording? This take cannot be recovered.", {
+                    title: "Discard recording",
+                    kind: "warning",
+                    okLabel: "Discard",
+                    cancelLabel: "Keep recording",
+                })
+            } catch (error) {
+                failAction("open the discard confirmation", error)
+                return
+            }
+
+            if (!confirmed) {
+                releaseAction()
+                return
+            }
+        }
+
+        setActionState({ status: "discarding", message: "Discarding recording…" })
         setCountdown(null)
-        await deviceRecorder?.stop()
-        deviceRecorder?.destroy()
-        await window.electron.ipcRenderer.invoke("cancel-recording")
+        try {
+            try {
+                await deviceRecorder?.stop()
+            } catch (error) {
+                console.warn("[recorder] Device track finalization failed during discard:", error)
+            } finally {
+                deviceRecorder?.destroy()
+            }
+            await stopRuntimeFeatures()
+            await window.electron.ipcRenderer.invoke("cancel-recording")
+            setIsRecording(false)
+        } catch (error) {
+            failAction("discard the recording", error)
+        }
     }
 
     const toggleMic = () => {
@@ -343,17 +594,27 @@ export default function App() {
         window.electron.ipcRenderer.invoke("toggle-drawing-overlay")
     }
 
+    const isActionBusy = BUSY_ACTIONS.has(actionState.status)
+    const hasActionStatus = actionState.status !== "idle"
+    const actionStatusClass = actionState.status === "error" ? "text-red-300" : "text-white/70"
+    const stopActionTitle = actionState.status === "error"
+        ? (isCaptureFinalized ? "Retry save" : "Retry stop and save")
+        : "Stop and save recording"
+
     // ─── Pre-recording: countdown / loading ──────────────────────────
     if (!isRecording) {
         return (
             <div className="h-full w-full flex items-center justify-center" style={{ padding: 2 }}>
                 <StyleTag />
+                <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                    {actionState.message}
+                </span>
                 <div
                     className="island-pill flex items-center justify-center gap-3 overflow-hidden"
                     data-tauri-drag-region
                     style={{
                         ...pillBg,
-                        width: countdown !== null ? 200 : 200,
+                        width: hasActionStatus ? 300 : 220,
                         height: 52,
                         borderRadius: 26,
                     }}
@@ -364,24 +625,46 @@ export default function App() {
                         </div>
                     )}
 
-                    {showAppBadge && <AppBadge count={appRecordingWindows.length} title={appBadgeTitle} />}
+                    {showAppBadge && <AppBadge count={appBadgeCount} title={appBadgeTitle} status={appBadgeStatus} />}
 
-                    {countdown !== null ? (
+                    {hasActionStatus ? (
+                        <span
+                            role={actionState.status === "error" ? "alert" : "status"}
+                            className={`max-w-[190px] truncate text-[11px] font-semibold ${actionStatusClass}`}
+                            title={actionState.message}
+                        >
+                            {actionState.message}
+                        </span>
+                    ) : countdown !== null ? (
                         <>
-                            <span key={countdown} className="countdown-num text-[26px] font-bold text-white tabular-nums leading-none">
+                            <span
+                                key={countdown}
+                                role="status"
+                                aria-label={`Recording starts in ${countdown}`}
+                                className="countdown-num text-[26px] font-bold text-white tabular-nums leading-none"
+                            >
                                 {countdown}
                             </span>
                             <span className="text-[10px] uppercase tracking-wider font-semibold text-white/50">
                                 rec
                             </span>
-                            <Btn onClick={onClickCancel} title="Cancel"
-                                className="w-7 h-7 rounded-full text-white/25 hover:text-white/60 hover:bg-white/[0.08]">
-                                <XMarkIcon className="size-4" />
-                            </Btn>
                         </>
                     ) : (
-                        <span className="loading loading-spinner loading-xs text-indigo-400" style={{ width: 14, height: 14 }}></span>
+                        <span
+                            className="loading loading-spinner loading-xs text-indigo-400"
+                            role="status"
+                            aria-label="Preparing recorder"
+                            style={{ width: 14, height: 14 }}
+                        />
                     )}
+                    <Btn
+                        onClick={onClickCancel}
+                        title={hasActionStatus && actionState.status === "error" ? "Close recorder" : "Cancel"}
+                        disabled={isActionBusy}
+                        className="w-7 h-7 rounded-full text-white/30 hover:text-white/70 hover:bg-white/[0.08]"
+                    >
+                        <XMarkIcon className="size-4" />
+                    </Btn>
                 </div>
             </div>
         )
@@ -404,16 +687,27 @@ export default function App() {
     ) : null
 
     const recDot = (
-        <div className={`rec-dot w-[7px] h-[7px] rounded-full flex-shrink-0 ${isPaused ? 'bg-amber-400' : 'bg-red-500'}`}
-            style={isPaused ? { animation: 'none' } : {}} />
+        <div aria-hidden="true" className="rec-dot w-[7px] h-[7px] rounded-full flex-shrink-0 bg-red-500" />
     )
 
     const timer = (
-        <span className="font-semibold text-[13px] tabular-nums tracking-tight text-white/90"
+        <span
+            aria-label={`Recording time ${formattedTime}`}
+            className="font-semibold text-[13px] tabular-nums tracking-tight text-white/90"
             style={{ fontVariantNumeric: "tabular-nums" }}>
             {formattedTime}
         </span>
     )
+
+    const recordingReadout = hasActionStatus ? (
+        <span
+            role={actionState.status === "error" ? "alert" : "status"}
+            className={`max-w-[190px] truncate text-[11px] font-semibold ${actionStatusClass}`}
+            title={actionState.message}
+        >
+            {actionState.message}
+        </span>
+    ) : timer
 
     if (!isExpanded && !tutorialActive) {
         // ── COMPACT: just centered dot + timer ──
@@ -423,27 +717,52 @@ export default function App() {
                 style={{ pointerEvents: "none" }}
             >
                 <StyleTag />
+                <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                    {actionState.message}
+                </span>
                 <div
                     className="island-pill mt-1"
                     data-tauri-drag-region
-                    onMouseEnter={() => setIsExpanded(true)}
+                    onMouseEnter={() => { if (!isActionBusy) setIsExpanded(true) }}
                     style={{
                         ...pillBg,
-                        width: 220,
+                        width: showAppBadge || hasActionStatus ? 340 : 280,
                         height: 44,
                         borderRadius: 22,
                         display: "flex",
                         alignItems: "center",
-                        justifyContent: "center",
-                        gap: 10,
+                        padding: "4px 6px 4px 10px",
+                        gap: 4,
                         pointerEvents: "auto",
                     }}
                 >
-                    {cameraPreview}
-                    {recDot}
-                    {hasMic && <VolumeMeter level={isMicMuted ? 0 : level} compact />}
-                    {timer}
-                    {showAppBadge && <AppBadge count={appRecordingWindows.length} title={appBadgeTitle} />}
+                    <button
+                        type="button"
+                        className="relative z-10 flex min-w-0 flex-1 items-center justify-center gap-2 rounded-full px-1.5 py-1 text-white outline-none hover:bg-white/[0.05] focus-visible:ring-2 focus-visible:ring-indigo-400/80 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={() => {
+                            setIsExpansionPinned(true)
+                            setIsExpanded(true)
+                        }}
+                        aria-label={`Show recording controls. Recording time ${formattedTime}`}
+                        aria-expanded="false"
+                        disabled={isActionBusy}
+                        title="Show recording controls"
+                    >
+                        {!hasActionStatus && cameraPreview}
+                        {!isCaptureFinalized && recDot}
+                        {!hasActionStatus && hasMic && <VolumeMeter level={isMicMuted ? 0 : level} compact />}
+                        {recordingReadout}
+                        {!hasActionStatus && showAppBadge && <AppBadge count={appBadgeCount} title={appBadgeTitle} status={appBadgeStatus} />}
+                    </button>
+                    <Btn
+                        onClick={onClickStop}
+                        title={stopActionTitle}
+                        dataTutorial="rec-stop"
+                        disabled={isActionBusy}
+                        className="w-8 h-8 rounded-full bg-red-500 hover:bg-red-400 active:bg-red-600 text-white"
+                    >
+                        <StopIcon className="size-4" />
+                    </Btn>
                 </div>
                 <Suspense fallback={null}>
                     <RecorderTutorial onActiveChange={setTutorialActive} />
@@ -459,13 +778,24 @@ export default function App() {
             style={{ pointerEvents: "none" }}
         >
             <StyleTag />
+            <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                {actionState.message}
+            </span>
             <div
                 className="island-pill mt-1"
                 data-tauri-drag-region
-                onMouseLeave={() => { if (!tutorialActive) setIsExpanded(false) }}
+                onMouseLeave={() => { if (!tutorialActive && !isExpansionPinned) setIsExpanded(false) }}
+                onKeyDown={event => {
+                    if (event.key === "Escape" && !tutorialActive && !isActionBusy) {
+                        setIsExpansionPinned(false)
+                        setIsExpanded(false)
+                    }
+                }}
+                role="toolbar"
+                aria-label="Recording controls"
                 style={{
                     ...pillBg,
-                    width: 440,
+                    width: 456,
                     height: 56,
                     borderRadius: 28,
                     display: "flex",
@@ -473,23 +803,29 @@ export default function App() {
                     pointerEvents: "auto",
                 }}
             >
-                <div style={{ display: "flex", alignItems: "center", width: "100%", height: "100%", padding: "0 20px" }}>
+                <div style={{ display: "flex", alignItems: "center", width: "100%", height: "100%", padding: "0 10px" }}>
 
                     {/* ── Left: indicator + timer ── */}
-                    <div style={{ display: "flex", alignItems: "center", gap: 8, marginLeft: 8, flexShrink: 0 }}>
-                        {cameraPreview}
-                        {recDot}
-                        {timer}
-                        {showAppBadge && <AppBadge count={appRecordingWindows.length} title={appBadgeTitle} />}
+                    <div style={{ display: "flex", alignItems: "center", gap: 7, flexShrink: 0 }}>
+                        {!hasActionStatus && cameraPreview}
+                        {!isCaptureFinalized && recDot}
+                        {recordingReadout}
+                        {!hasActionStatus && showAppBadge && <AppBadge count={appBadgeCount} title={appBadgeTitle} status={appBadgeStatus} />}
                     </div>
 
                     {/* ── Center: tools (shifted right with margin) ── */}
-                    <div style={{ display: "flex", alignItems: "center", flexShrink: 0, marginLeft: 16 }}>
+                    {!hasActionStatus && (
+                    <div style={{ display: "flex", alignItems: "center", flexShrink: 0, marginLeft: 8 }}>
                         <Divider />
                         {hasMic && (
-                            <div className="flex items-center gap-1">
-                                <Btn onClick={toggleMic} title={isMicMuted ? "Unmute mic" : "Mute mic"}
-                                    className={`w-8 h-8 rounded-lg ${isMicMuted ? "text-white/20" : "text-white/50 hover:text-white/80 hover:bg-white/[0.06]"}`}>
+                            <div className="flex items-center">
+                                <Btn
+                                    onClick={toggleMic}
+                                    title={isMicMuted ? "Unmute microphone" : "Mute microphone"}
+                                    disabled={isActionBusy}
+                                    ariaPressed={isMicMuted}
+                                    className={`w-8 h-8 rounded-lg ${isMicMuted ? "text-white/20" : "text-white/50 hover:text-white/80 hover:bg-white/[0.06]"}`}
+                                >
                                     <div className="relative">
                                         <MicrophoneIcon className="size-4" />
                                         {isMicMuted && (
@@ -499,27 +835,33 @@ export default function App() {
                                         )}
                                     </div>
                                 </Btn>
-                                <div className="w-12">
-                                    <VolumeMeter level={isMicMuted ? 0 : level} />
-                                </div>
                             </div>
                         )}
                         {hasCam && (
-                            <Btn onClick={toggleCamera} title={isCameraOff ? "Camera on" : "Camera off"}
-                                className={`w-8 h-8 rounded-lg ${isCameraOff ? "text-white/20" : "text-white/50 hover:text-white/80 hover:bg-white/[0.06]"}`}>
+                            <Btn
+                                onClick={toggleCamera}
+                                title={isCameraOff ? "Turn camera on" : "Turn camera off"}
+                                disabled={isActionBusy}
+                                ariaPressed={isCameraOff}
+                                className={`w-8 h-8 rounded-lg ${isCameraOff ? "text-white/20" : "text-white/50 hover:text-white/80 hover:bg-white/[0.06]"}`}
+                            >
                                 {isCameraOff ? <VideoCameraSlashIcon className="size-4" /> : <VideoCameraIcon className="size-4" />}
                             </Btn>
                         )}
                         <div className="w-px h-3.5 mx-1 bg-white/[0.04]" />
-                        <Btn onClick={openTeleprompter} title="Teleprompter" dataTutorial="rec-teleprompter"
+                        <Btn onClick={openTeleprompter} title="Open teleprompter" dataTutorial="rec-teleprompter"
+                            disabled={isActionBusy}
                             className="w-8 h-8 rounded-lg text-white/40 hover:text-indigo-300 hover:bg-indigo-500/10">
                             <DocumentTextIcon className="size-4" />
                         </Btn>
-                        <Btn onClick={takeScreenshot} title="Screenshot" dataTutorial="rec-screenshot"
+                        <Btn onClick={takeScreenshot} title="Take screenshot" dataTutorial="rec-screenshot"
+                            disabled={isActionBusy}
                             className="w-8 h-8 rounded-lg text-white/40 hover:text-amber-300 hover:bg-amber-500/10">
                             <CameraIcon className="size-4" />
                         </Btn>
-                        <Btn onClick={toggleDrawing} title="Draw on screen" dataTutorial="rec-draw"
+                        <Btn onClick={toggleDrawing} title={isDrawing ? "Close drawing tools" : "Draw on screen"} dataTutorial="rec-draw"
+                            disabled={isActionBusy}
+                            ariaPressed={isDrawing}
                             className={`relative w-8 h-8 rounded-lg ${isDrawing ? "text-indigo-400 bg-indigo-500/15" : "text-white/40 hover:text-emerald-300 hover:bg-emerald-500/10"}`}>
                             <PencilIcon className="size-4" />
                             {isDrawing && (
@@ -527,6 +869,7 @@ export default function App() {
                             )}
                         </Btn>
                     </div>
+                    )}
 
                     {/* ── Spacer ── */}
                     <div style={{ flex: 1 }} />
@@ -534,28 +877,24 @@ export default function App() {
                     {/* ── Right: actions ── */}
                     <div style={{ display: "flex", alignItems: "center", gap: 2, flexShrink: 0 }}>
                         <Divider />
-                        <Btn onClick={onClickRestart} title="Restart"
-                            className="w-8 h-8 rounded-lg text-white/20 hover:text-white/50 hover:bg-white/[0.06]">
-                            <ArrowPathIcon className="size-4" />
-                        </Btn>
-                        <Btn onClick={onClickCancel} title="Discard"
+                        {!isCaptureFinalized && (
+                            <Btn onClick={onClickRestart} title="Restart recording"
+                                disabled={isActionBusy}
+                                className="w-8 h-8 rounded-lg text-white/20 hover:text-white/50 hover:bg-white/[0.06]">
+                                <ArrowPathIcon className="size-4" />
+                            </Btn>
+                        )}
+                        <Btn onClick={onClickCancel} title="Discard recording"
+                            disabled={isActionBusy}
                             className="w-8 h-8 rounded-lg text-white/20 hover:text-red-400/80 hover:bg-red-500/10">
                             <TrashIcon className="size-4" />
                         </Btn>
 
-                        {!isPaused ? (
-                            <Btn onClick={onClickPause} title="Pause" dataTutorial="rec-pause"
-                                className="w-9 h-9 rounded-xl bg-white/[0.06] hover:bg-white/[0.1] text-white/60 hover:text-white/90">
-                                <PauseIcon className="size-[18px]" />
-                            </Btn>
-                        ) : (
-                            <Btn onClick={onClickResume} title="Resume" dataTutorial="rec-pause"
-                                className="w-9 h-9 rounded-xl bg-emerald-500/15 hover:bg-emerald-500/25 text-emerald-400">
-                                <PlayIcon className="size-[18px]" />
-                            </Btn>
-                        )}
-
-                        <Btn onClick={onClickStop} title="Stop & save" dataTutorial="rec-stop"
+                        <Btn
+                            onClick={onClickStop}
+                            title={stopActionTitle}
+                            dataTutorial="rec-stop"
+                            disabled={isActionBusy}
                             className="w-9 h-9 rounded-xl bg-red-500 hover:bg-red-400 active:bg-red-600 text-white ml-0.5">
                             <StopIcon className="size-[18px]" />
                         </Btn>

--- a/app/windows/recorder/components/RecorderTutorial.jsx
+++ b/app/windows/recorder/components/RecorderTutorial.jsx
@@ -19,14 +19,9 @@ const TOUR = [
         body: "Capture a still frame at any moment during the recording.",
     },
     {
-        id: "rec-pause",
-        title: "Pause and resume",
-        body: "Take a break — your recording stays seamless.",
-    },
-    {
         id: "rec-stop",
-        title: "Stop and edit",
-        body: "Click here when you're done. We'll open the editor next.",
+        title: "Stop and save",
+        body: "This action stays visible when the controls collapse. Use it when your take is finished.",
     },
 ]
 
@@ -40,7 +35,8 @@ export default function RecorderTutorial({ onActiveChange }) {
     const [rect, setRect] = useState(null)
     const originalSizeRef = useRef(null)
 
-    // Decide whether to show the tour: only when both flags say it's not yet completed.
+    // The main first-run tutorial owns the user's first recording. Only offer
+    // this compact recorder tour on a later take, after the main tour is done.
     useEffect(() => {
         let cancelled = false
         const check = async () => {
@@ -51,7 +47,7 @@ export default function RecorderTutorial({ onActiveChange }) {
                     ipc.invoke("store-get", "hasCompletedRecorderTutorial"),
                 ])
                 if (cancelled) return
-                if (!main && !rec) {
+                if (main && !rec) {
                     setActive(true)
                 }
             } catch { /* ignore */ }
@@ -196,6 +192,10 @@ export default function RecorderTutorial({ onActiveChange }) {
                     }}
                 />
                 <div
+                    role="dialog"
+                    aria-modal="false"
+                    aria-labelledby="recorder-tour-title"
+                    aria-describedby="recorder-tour-body"
                     style={{
                         background: "rgba(20, 20, 36, 0.96)",
                         backdropFilter: "blur(20px) saturate(1.4)",
@@ -208,10 +208,15 @@ export default function RecorderTutorial({ onActiveChange }) {
                     }}
                 >
                     {/* dots */}
-                    <div className="flex gap-1.5 mb-2">
-                        {TOUR.map((_, i) => (
+                    <div
+                        className="flex gap-1.5 mb-2"
+                        role="status"
+                        aria-label={`Recorder tour step ${stepIndex + 1} of ${TOUR.length}`}
+                    >
+                        {TOUR.map((tourStep, i) => (
                             <div
-                                key={i}
+                                key={tourStep.id}
+                                aria-hidden="true"
                                 className="w-1.5 h-1.5 rounded-full"
                                 style={{
                                     background:
@@ -222,8 +227,8 @@ export default function RecorderTutorial({ onActiveChange }) {
                             />
                         ))}
                     </div>
-                    <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{step.title}</div>
-                    <div style={{ fontSize: 12, lineHeight: 1.5, color: "rgba(255,255,255,0.65)", marginBottom: 12 }}>
+                    <div id="recorder-tour-title" style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>{step.title}</div>
+                    <div id="recorder-tour-body" style={{ fontSize: 12, lineHeight: 1.5, color: "rgba(255,255,255,0.65)", marginBottom: 12 }}>
                         {step.body}
                     </div>
                     <div className="flex items-center justify-between">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,7 @@ export default [
       "**/.webpack",
       "**/.vite",
       "**/build",
+      "**/target/**",
       "**/coverage",
       "**/*.min.js",
       "**/vendor/**",
@@ -31,7 +32,7 @@ export default [
     ]
   },
   {
-    files: ["**/*.{js,jsx}"],
+    files: ["**/*.{js,jsx,mjs}"],
     ...eslintJs.configs.recommended,
     languageOptions: {
       ...eslintJs.configs.recommended.languageOptions,
@@ -49,6 +50,20 @@ export default [
         caughtErrorsIgnorePattern: "^_",
         varsIgnorePattern: "^_",
       }],
+    },
+  },
+  {
+    files: [
+      "**/*.config.mjs",
+      "eslint.config.mjs",
+      "scripts/**/*.mjs",
+      "test/**/*.{js,mjs}",
+      "tests/**/*.{js,mjs}",
+    ],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "use-debounce": "^10.1.1"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "9.39.5",
         "@tailwindcss/postcss": "^4.3.0",
         "@tanstack/eslint-plugin-query": "^5.100.14",
         "@tauri-apps/cli": "^2.11.2",
@@ -63,7 +63,7 @@
         "autoprefixer": "^10.5.0",
         "daisyui": "^5.5.23",
         "esbuild": "^0.28.1",
-        "eslint": "^10.3.0",
+        "eslint": "9.39.5",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -88,135 +88,247 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/@babel/compat-data": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-      "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+    "node_modules/@babel/code-frame/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
-        "@jridgewell/remapping": "^2.3.5",
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
         "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
+        "empathic": "^2.0.1",
         "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
         "json5": "^2.2.3",
-        "semver": "^6.3.1"
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+    "node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
         "jsesc": "^3.0.2"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/generator/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
         "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -240,27 +352,61 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -280,37 +426,137 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
-        "debug": "^4.3.1"
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
       },
       "engines": {
-        "node": ">=6.9.0"
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/types": {
@@ -856,89 +1102,118 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@heroicons/react": {
@@ -1614,19 +1889,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -1636,9 +1910,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -2278,329 +2552,6 @@
         "tailwindcss": "4.3.0"
       }
     },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/node": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.21.0",
-        "jiti": "^2.6.1",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
-        "@tailwindcss/oxide-darwin-x64": "4.3.0",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
-        "@napi-rs/wasm-runtime": "^1.1.4",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/postcss/node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
@@ -3016,13 +2967,6 @@
       "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
       "license": "MIT"
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3038,6 +2982,13 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/gradient-parser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.5.tgz",
@@ -3052,6 +3003,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3298,9 +3256,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3346,6 +3304,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -3359,6 +3333,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3572,11 +3553,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.12",
@@ -3612,14 +3595,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -3719,6 +3703,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -3748,6 +3742,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -3828,6 +3839,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3837,13 +3868,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4112,6 +4136,16 @@
       "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.0",
@@ -4394,30 +4428,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -4427,7 +4464,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -4435,7 +4473,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -4512,19 +4550,6 @@
         "eslint": "^9 || ^10"
       }
     },
-    "node_modules/eslint-plugin-react/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.5",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -4544,19 +4569,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4575,19 +4598,45 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -5041,6 +5090,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -5315,6 +5374,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -5873,6 +5960,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6237,6 +6347,13 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -6266,13 +6383,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {
@@ -7224,27 +7341,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/minimatch/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -7415,6 +7511,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/onnxruntime-common": {
       "version": "1.24.3",
       "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
@@ -7537,6 +7647,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parse-entities": {
@@ -7764,24 +7887,24 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8077,6 +8200,16 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/roarr": {
       "version": "2.15.4",
@@ -8597,6 +8730,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -8613,6 +8759,19 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -9406,13 +9565,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "lint": "eslint --cache .",
     "test": "node --test",
+    "diagnose:recording": "node scripts/recording-diagnostics.mjs",
     "dev:frontend": "vite --config vite.config.mjs",
     "build:frontend": "vite build --config vite.config.mjs",
     "dev": "tauri dev",
@@ -43,8 +44,21 @@
     "cross-platform"
   ],
   "license": "MIT",
+  "overrides": {
+    "eslint-plugin-react-hooks": {
+      ".": "$eslint-plugin-react-hooks",
+      "@babel/core": "8.0.1"
+    },
+    "minimatch": {
+      ".": "$minimatch",
+      "brace-expansion": "5.0.7"
+    },
+    "onnxruntime-web@1.25.0-dev.20260327-722743c0e2": {
+      "protobufjs": "7.6.3"
+    }
+  },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "9.39.5",
     "@tailwindcss/postcss": "^4.3.0",
     "@tanstack/eslint-plugin-query": "^5.100.14",
     "@tauri-apps/cli": "^2.11.2",
@@ -52,7 +66,7 @@
     "autoprefixer": "^10.5.0",
     "daisyui": "^5.5.23",
     "esbuild": "^0.28.1",
-    "eslint": "^10.3.0",
+    "eslint": "9.39.5",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",

--- a/scripts/recording-diagnostics.mjs
+++ b/scripts/recording-diagnostics.mjs
@@ -1,0 +1,267 @@
+import { spawn } from "node:child_process"
+import { once } from "node:events"
+import path from "node:path"
+import { setTimeout as delay } from "node:timers/promises"
+import { fileURLToPath } from "node:url"
+
+const DEFAULT_SAMPLE_MS = 2_000
+const MIN_SAMPLE_MS = 250
+const MAX_SAMPLE_MS = 10_000
+
+const POWERSHELL_SNAPSHOT = String.raw`
+$ErrorActionPreference = 'Stop'
+$processes = @(
+    Get-CimInstance Win32_Process |
+        Where-Object { $_.Name -match '^flowtake(\.exe)?$' -or $_.Name -match '^ffmpeg(?:-[a-z0-9_-]+)?(\.exe)?$' } |
+        ForEach-Object {
+            $cimProcess = $_
+            $nativeProcess = Get-Process -Id $cimProcess.ProcessId -ErrorAction SilentlyContinue
+            if ($null -ne $nativeProcess) {
+                $cpuSeconds = if ($null -eq $nativeProcess.CPU) { 0 } else { [double]$nativeProcess.CPU }
+                $startedAt = $null
+                try { $startedAt = $nativeProcess.StartTime.ToUniversalTime().ToString('o') } catch {}
+
+                [pscustomobject]@{
+                    pid = [int]$cimProcess.ProcessId
+                    parentPid = [int]$cimProcess.ParentProcessId
+                    name = [string]$cimProcess.Name
+                    commandLine = [string]$cimProcess.CommandLine
+                    executablePath = [string]$cimProcess.ExecutablePath
+                    cpuSeconds = $cpuSeconds
+                    workingSetBytes = [long]$nativeProcess.WorkingSet64
+                    privateBytes = [long]$nativeProcess.PrivateMemorySize64
+                    handleCount = [int]$nativeProcess.HandleCount
+                    threadCount = [int]$nativeProcess.Threads.Count
+                    startedAt = $startedAt
+                }
+            }
+        }
+)
+
+[pscustomobject]@{
+    timestamp = [DateTime]::UtcNow.ToString('o')
+    logicalProcessors = [int][Environment]::ProcessorCount
+    processes = $processes
+} | ConvertTo-Json -Depth 4 -Compress
+`
+
+const round = (value, digits = 2) => Number(value.toFixed(digits))
+const toArray = value => Array.isArray(value) ? value : value ? [value] : []
+const isFlowtake = process => /^flowtake(?:\.exe)?$/i.test(process.name)
+const isFfmpeg = process => /^ffmpeg(?:-[a-z0-9_-]+)?(?:\.exe)?$/i.test(process.name)
+
+export function parseArgs(argv) {
+    const options = {
+        sampleMs: DEFAULT_SAMPLE_MS,
+        json: false,
+        failOnOrphan: false,
+        help: false,
+    }
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const argument = argv[index]
+        if (argument === "--json") options.json = true
+        else if (argument === "--fail-on-orphan") options.failOnOrphan = true
+        else if (argument === "--help" || argument === "-h") options.help = true
+        else if (argument === "--sample-ms") {
+            const value = Number(argv[index + 1])
+            if (!Number.isInteger(value) || value < MIN_SAMPLE_MS || value > MAX_SAMPLE_MS) {
+                throw new Error(`--sample-ms must be an integer from ${MIN_SAMPLE_MS} to ${MAX_SAMPLE_MS}`)
+            }
+            options.sampleMs = value
+            index += 1
+        } else {
+            throw new Error(`Unknown option: ${argument}`)
+        }
+    }
+
+    return options
+}
+
+function normalizeSnapshot(snapshot) {
+    return {
+        timestamp: snapshot.timestamp,
+        logicalProcessors: Math.max(1, Number(snapshot.logicalProcessors) || 1),
+        processes: toArray(snapshot.processes).map(process => ({
+            ...process,
+            pid: Number(process.pid),
+            parentPid: Number(process.parentPid),
+            cpuSeconds: Number(process.cpuSeconds) || 0,
+            workingSetBytes: Number(process.workingSetBytes) || 0,
+            privateBytes: Number(process.privateBytes) || 0,
+            handleCount: Number(process.handleCount) || 0,
+            threadCount: Number(process.threadCount) || 0,
+        })),
+    }
+}
+
+function summarize(processes, predicate) {
+    const selected = processes.filter(predicate)
+    return {
+        processCount: selected.length,
+        cpuPercent: round(selected.reduce((total, process) => total + process.cpuPercent, 0)),
+        cpuPercentOneCore: round(selected.reduce((total, process) => total + process.cpuPercentOneCore, 0)),
+        workingSetBytes: selected.reduce((total, process) => total + process.workingSetBytes, 0),
+        privateBytes: selected.reduce((total, process) => total + process.privateBytes, 0),
+    }
+}
+
+export function deriveReport(beforeInput, afterInput, elapsedMs) {
+    const before = normalizeSnapshot(beforeInput)
+    const after = normalizeSnapshot(afterInput)
+    const actualElapsedMs = Math.max(1, Number(elapsedMs) || 1)
+    const beforeByPid = new Map(before.processes.map(process => [process.pid, process]))
+
+    const processes = after.processes.map(process => {
+        const previous = beforeByPid.get(process.pid)
+        const sameProcess = previous && (!previous.startedAt || !process.startedAt || previous.startedAt === process.startedAt)
+        const deltaCpuSeconds = sameProcess
+            ? Math.max(0, process.cpuSeconds - previous.cpuSeconds)
+            : 0
+        const cpuPercentOneCore = deltaCpuSeconds / (actualElapsedMs / 1_000) * 100
+
+        return {
+            ...process,
+            deltaCpuSeconds: round(deltaCpuSeconds, 3),
+            cpuPercentOneCore: round(cpuPercentOneCore),
+            cpuPercent: round(cpuPercentOneCore / after.logicalProcessors),
+        }
+    })
+
+    const flowtakePids = new Set(processes.filter(isFlowtake).map(process => process.pid))
+    const orphanCandidates = processes
+        .filter(process => {
+            if (!isFfmpeg(process) || flowtakePids.has(process.parentPid)) return false
+            const provenance = `${process.commandLine ?? ""} ${process.executablePath ?? ""}`
+            return /flowtake|recording-[^\\/\s]+|extra-\d+\.mp4|flowtake-live/i.test(provenance)
+        })
+        .map(process => ({
+            pid: process.pid,
+            parentPid: process.parentPid,
+            commandLine: process.commandLine,
+            reason: "Flowtake-like FFmpeg command has no live Flowtake parent",
+        }))
+
+    return {
+        schemaVersion: 1,
+        capturedAt: after.timestamp,
+        sampleMs: Math.round(actualElapsedMs),
+        logicalProcessors: after.logicalProcessors,
+        processes,
+        totals: {
+            flowtake: summarize(processes, isFlowtake),
+            ffmpeg: summarize(processes, isFfmpeg),
+        },
+        orphanCandidates,
+    }
+}
+
+async function takeWindowsSnapshot() {
+    const child = spawn("powershell.exe", [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy", "Bypass",
+        "-Command", POWERSHELL_SNAPSHOT,
+    ], {
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stdout = ""
+    let stderr = ""
+    child.stdout.setEncoding("utf8")
+    child.stderr.setEncoding("utf8")
+    child.stdout.on("data", chunk => { stdout += chunk })
+    child.stderr.on("data", chunk => { stderr += chunk })
+
+    const [exitCode] = await once(child, "close")
+    if (exitCode !== 0) {
+        throw new Error(`PowerShell process query failed (${exitCode}): ${stderr.trim()}`)
+    }
+
+    const payload = stdout.trim().replace(/^\uFEFF/, "")
+    if (!payload) throw new Error("PowerShell process query returned no data")
+    return normalizeSnapshot(JSON.parse(payload))
+}
+
+const toMiB = bytes => `${round(bytes / 1_048_576, 1).toFixed(1)} MiB`
+
+function printHumanReport(report) {
+    console.log("Flowtake recording diagnostics (read-only)")
+    console.log(`Sample: ${report.sampleMs} ms | Logical CPUs: ${report.logicalProcessors}`)
+
+    if (report.processes.length === 0) {
+        console.log("No Flowtake or FFmpeg processes were found. Start a recording and rerun.")
+    } else {
+        console.table(report.processes.map(process => ({
+            PID: process.pid,
+            Process: process.name,
+            "CPU machine": `${process.cpuPercent.toFixed(2)}%`,
+            "CPU one core": `${process.cpuPercentOneCore.toFixed(2)}%`,
+            "Working set": toMiB(process.workingSetBytes),
+            Private: toMiB(process.privateBytes),
+            Parent: process.parentPid,
+            Threads: process.threadCount,
+            Handles: process.handleCount,
+        })))
+    }
+
+    console.log("Totals:")
+    for (const [name, totals] of Object.entries(report.totals)) {
+        console.log(`  ${name}: ${totals.processCount} process(es), ${totals.cpuPercent.toFixed(2)}% machine CPU, ${toMiB(totals.workingSetBytes)} working set`)
+    }
+
+    if (report.orphanCandidates.length === 0) {
+        console.log("Orphan candidates: none")
+    } else {
+        console.log("Orphan candidates:")
+        for (const candidate of report.orphanCandidates) {
+            console.log(`  PID ${candidate.pid} (parent ${candidate.parentPid}): ${candidate.reason}`)
+        }
+    }
+}
+
+function printHelp() {
+    console.log(`Usage: npm run diagnose:recording -- [options]
+
+Options:
+  --sample-ms <250-10000>  CPU sampling interval (default: ${DEFAULT_SAMPLE_MS})
+  --json                   Print machine-readable JSON
+  --fail-on-orphan         Exit with code 2 when orphan candidates are found
+  -h, --help               Show this help
+
+This command only reads Windows process telemetry. It does not start, stop, or reconfigure Flowtake.`)
+}
+
+async function main() {
+    const options = parseArgs(process.argv.slice(2))
+    if (options.help) {
+        printHelp()
+        return
+    }
+    if (process.platform !== "win32") {
+        throw new Error("Recorder diagnostics currently support Windows only; no settings were changed.")
+    }
+
+    const before = await takeWindowsSnapshot()
+    const start = performance.now()
+    await delay(options.sampleMs)
+    const after = await takeWindowsSnapshot()
+    const report = deriveReport(before, after, performance.now() - start)
+
+    if (options.json) console.log(JSON.stringify(report, null, 2))
+    else printHumanReport(report)
+
+    if (options.failOnOrphan && report.orphanCandidates.length > 0) {
+        process.exitCode = 2
+    }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+if (isMain) {
+    main().catch(error => {
+        console.error(`Recording diagnostics failed: ${error.message}`)
+        process.exitCode = 1
+    })
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,8 @@ windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_System_Threading",
+    "Win32_System_JobObjects",
+    "Win32_Security",
     "Win32_Graphics_Gdi",
     "Win32_Storage_Xps",
     "Win32_Media_Audio",

--- a/src-tauri/src/commands/encoding.rs
+++ b/src-tauri/src/commands/encoding.rs
@@ -1,60 +1,289 @@
 use crate::error::{AppError, AppResult};
 use serde_json::Value;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use tauri::{AppHandle, Manager};
+use tauri_plugin_store::StoreExt;
 
-fn fallback_encoders() -> Vec<Value> {
-    vec![serde_json::json!({
-        "name": "libx264",
-        "displayName": "H.264 (CPU)",
-        "available": true,
-        "isSelected": true
-    })]
+// Probes run concurrently, so discovery is bounded by one timeout rather than
+// one timeout per GPU vendor.
+const ENCODER_PROBE_TIMEOUT: Duration = Duration::from_secs(7);
+
+const RECORDING_ENCODERS: &[(&str, &str)] = &[
+    ("h264_videotoolbox", "H.264 (VideoToolbox)"),
+    ("h264_nvenc", "H.264 (NVIDIA)"),
+    ("h264_qsv", "H.264 (Intel Quick Sync)"),
+    ("h264_amf", "H.264 (AMD)"),
+    ("libx264", "H.264 (CPU)"),
+];
+
+static ENCODER_PROBE_CACHE: LazyLock<Mutex<HashMap<String, bool>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn platform_recording_encoders() -> &'static [&'static str] {
+    #[cfg(target_os = "macos")]
+    {
+        &["h264_videotoolbox", "libx264"]
+    }
+    #[cfg(target_os = "windows")]
+    {
+        &["h264_nvenc", "h264_qsv", "h264_amf", "libx264"]
+    }
+    #[cfg(target_os = "linux")]
+    {
+        &["h264_nvenc", "h264_qsv", "libx264"]
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        &["libx264"]
+    }
+}
+
+fn preferred_encoder_order() -> &'static [&'static str] {
+    #[cfg(target_os = "macos")]
+    {
+        &["h264_videotoolbox", "libx264"]
+    }
+    #[cfg(target_os = "windows")]
+    {
+        &["h264_nvenc", "h264_qsv", "h264_amf", "libx264"]
+    }
+    #[cfg(target_os = "linux")]
+    {
+        &["h264_nvenc", "h264_qsv", "libx264"]
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        &["libx264"]
+    }
+}
+
+fn encoder_cache_key(ffmpeg: &Path, encoder: &str) -> String {
+    format!("{}\0{}", ffmpeg.to_string_lossy(), encoder)
+}
+
+fn probe_encoder_uncached(ffmpeg: &Path, encoder: &str) -> bool {
+    use std::process::{Command, Stdio};
+
+    if !platform_recording_encoders().contains(&encoder) {
+        return false;
+    }
+
+    let mut command = Command::new(ffmpeg);
+    command
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=128x128:r=30",
+            "-frames:v",
+            "1",
+            "-an",
+            "-c:v",
+            encoder,
+            "-f",
+            "null",
+            "-",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let Ok(mut child) = command.spawn() else {
+        return false;
+    };
+    crate::process_containment::contain_owned_child(&child, "encoder-probe FFmpeg");
+    let started = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) if started.elapsed() < ENCODER_PROBE_TIMEOUT => {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                log::warn!("[encoder] Runtime probe timed out for {}", encoder);
+                return false;
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                log::warn!("[encoder] Runtime probe failed for {}: {}", encoder, error);
+                return false;
+            }
+        }
+    }
+}
+
+pub(crate) fn encoder_is_runtime_usable(ffmpeg: &Path, encoder: &str, force: bool) -> bool {
+    let key = encoder_cache_key(ffmpeg, encoder);
+    if !force {
+        if let Some(available) = ENCODER_PROBE_CACHE
+            .lock()
+            .ok()
+            .and_then(|cache| cache.get(&key).copied())
+        {
+            return available;
+        }
+    }
+
+    let available = probe_encoder_uncached(ffmpeg, encoder);
+    if let Ok(mut cache) = ENCODER_PROBE_CACHE.lock() {
+        cache.insert(key, available);
+    }
+    available
+}
+
+fn choose_encoder_from_availability<F>(
+    requested: Option<&str>,
+    mut is_available: F,
+) -> Option<String>
+where
+    F: FnMut(&str) -> bool,
+{
+    if let Some(requested) = requested {
+        if RECORDING_ENCODERS
+            .iter()
+            .any(|(name, _)| *name == requested)
+            && is_available(requested)
+        {
+            return Some(requested.to_string());
+        }
+    }
+
+    preferred_encoder_order()
+        .iter()
+        .copied()
+        .find(|encoder| is_available(encoder))
+        .map(str::to_string)
+}
+
+fn probe_platform_encoders(ffmpeg: &Path, force: bool) -> Vec<String> {
+    std::thread::scope(|scope| {
+        let probes: Vec<_> = platform_recording_encoders()
+            .iter()
+            .copied()
+            .map(|encoder| {
+                scope.spawn(move || (encoder, encoder_is_runtime_usable(ffmpeg, encoder, force)))
+            })
+            .collect();
+
+        probes
+            .into_iter()
+            .filter_map(|probe| match probe.join() {
+                Ok((encoder, true)) => Some(encoder.to_string()),
+                Ok((_, false)) => None,
+                Err(_) => None,
+            })
+            .collect()
+    })
+}
+
+pub(crate) fn resolve_recording_encoder(
+    ffmpeg: &Path,
+    requested: Option<&str>,
+    force: bool,
+) -> Option<String> {
+    let available = probe_platform_encoders(ffmpeg, force);
+    choose_encoder_from_availability(requested, |encoder| {
+        available.iter().any(|available| available == encoder)
+    })
+}
+
+fn encoder_display_name(encoder: &str) -> &str {
+    RECORDING_ENCODERS
+        .iter()
+        .find_map(|(name, display_name)| (*name == encoder).then_some(*display_name))
+        .unwrap_or(encoder)
 }
 
 #[tauri::command]
 pub async fn get_encoders(app: AppHandle, force: Option<bool>) -> AppResult<Value> {
-    if force != Some(true) {
-        return Ok(Value::Array(fallback_encoders()));
+    let Some(ffmpeg) = super::recording::find_ffmpeg_path() else {
+        return Ok(Value::Array(Vec::new()));
+    };
+
+    let store = app
+        .store("store.json")
+        .map_err(|error| AppError::General(error.to_string()))?;
+    let requested = store
+        .get("encoder")
+        .and_then(|value| value.as_str().map(str::to_owned));
+    let is_automatic = store
+        .get("encoderMode")
+        .and_then(|value| value.as_str().map(|mode| mode != "manual"))
+        .unwrap_or(true);
+    let refresh = force == Some(true);
+    let ffmpeg_for_probe = ffmpeg.clone();
+    let requested_for_probe = if is_automatic {
+        None
+    } else {
+        requested.clone()
+    };
+
+    let (available_names, selected) = tokio::task::spawn_blocking(move || {
+        let available_names = probe_platform_encoders(&ffmpeg_for_probe, refresh);
+        let selected =
+            choose_encoder_from_availability(requested_for_probe.as_deref(), |encoder| {
+                available_names.iter().any(|available| available == encoder)
+            });
+        (available_names, selected)
+    })
+    .await
+    .map_err(|error| AppError::General(format!("Encoder probe failed: {}", error)))?;
+
+    let mut encoders: Vec<Value> = Vec::new();
+    if is_automatic && selected.is_some() {
+        let selected_name = selected
+            .as_deref()
+            .map(encoder_display_name)
+            .unwrap_or_default();
+        encoders.push(serde_json::json!({
+            "name": "auto",
+            "displayName": format!("Automatic · {}", selected_name),
+            "available": true,
+            "isSelected": true,
+        }));
     }
+    encoders.extend(available_names.iter().map(|encoder| {
+        serde_json::json!({
+            "name": encoder,
+            "displayName": encoder_display_name(encoder),
+            "available": true,
+            "isSelected": !is_automatic && selected.as_deref() == Some(encoder.as_str()),
+        })
+    }));
 
-    // Query FFmpeg for available encoders
-    let output = super::ffmpeg_from_app(&app)?
-        .args(["-encoders", "-hide_banner"])
-        .output()
-        .await
-        .map_err(|e| AppError::General(e.to_string()))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let mut encoders = Vec::new();
-
-    // Parse encoder list - look for video encoders
-    let relevant_encoders = [
-        ("libx264", "H.264 (CPU)"),
-        ("libx265", "H.265 (CPU)"),
-        ("h264_videotoolbox", "H.264 (VideoToolbox)"),
-        ("hevc_videotoolbox", "HEVC (VideoToolbox)"),
-        ("h264_nvenc", "H.264 (NVIDIA)"),
-        ("hevc_nvenc", "HEVC (NVIDIA)"),
-        ("h264_amf", "H.264 (AMD)"),
-        ("hevc_amf", "HEVC (AMD)"),
-        ("h264_qsv", "H.264 (Intel QSV)"),
-        ("hevc_qsv", "HEVC (Intel QSV)"),
-    ];
-
-    for (encoder, display_name) in &relevant_encoders {
-        if stdout.contains(encoder) {
-            encoders.push(serde_json::json!({
-                "name": encoder,
-                "displayName": display_name,
-                "available": true,
-                "isSelected": *encoder == "libx264",
-            }));
+    let mut changed = false;
+    if store.get("encoderMode").is_none() {
+        store.set("encoderMode", Value::String("auto".to_string()));
+        changed = true;
+    }
+    if let Some(selected) = selected {
+        if requested.as_deref() != Some(selected.as_str()) {
+            store.set("encoder", Value::String(selected));
+            changed = true;
         }
+    } else {
+        log::error!("[encoder] No H.264 recording encoder passed the runtime probe");
     }
-
-    // Always include libx264 as fallback
-    if encoders.is_empty() {
-        encoders = fallback_encoders();
+    if changed {
+        store
+            .save()
+            .map_err(|error| AppError::General(error.to_string()))?;
     }
 
     Ok(Value::Array(encoders))
@@ -62,90 +291,216 @@ pub async fn get_encoders(app: AppHandle, force: Option<bool>) -> AppResult<Valu
 
 #[tauri::command]
 pub async fn set_encoder(app: AppHandle, encoder: String) -> AppResult<()> {
-    use tauri_plugin_store::StoreExt;
+    if encoder == "auto" {
+        let store = app
+            .store("store.json")
+            .map_err(|error| AppError::General(error.to_string()))?;
+        store.set("encoderMode", Value::String("auto".to_string()));
+        store
+            .save()
+            .map_err(|error| AppError::General(error.to_string()))?;
+        return Ok(());
+    }
+
+    if !platform_recording_encoders().contains(&encoder.as_str()) {
+        return Err(AppError::General(format!(
+            "Unsupported encoder: {}",
+            encoder
+        )));
+    }
+
+    let ffmpeg = super::recording::find_ffmpeg_path()
+        .ok_or_else(|| AppError::General("FFmpeg binary not found".to_string()))?;
+    let encoder_for_probe = encoder.clone();
+    let usable = tokio::task::spawn_blocking(move || {
+        encoder_is_runtime_usable(&ffmpeg, &encoder_for_probe, false)
+    })
+    .await
+    .map_err(|error| AppError::General(format!("Encoder probe failed: {}", error)))?;
+
+    if !usable {
+        return Err(AppError::General(format!(
+            "Encoder {} is installed but cannot run on this device",
+            encoder
+        )));
+    }
+
     let store = app
         .store("store.json")
-        .map_err(|e| AppError::General(e.to_string()))?;
+        .map_err(|error| AppError::General(error.to_string()))?;
     store.set("encoder", Value::String(encoder));
+    store.set("encoderMode", Value::String("manual".to_string()));
     store
         .save()
-        .map_err(|e| AppError::General(e.to_string()))?;
+        .map_err(|error| AppError::General(error.to_string()))?;
     Ok(())
 }
 
-#[tauri::command]
-pub async fn get_capturers(_app: AppHandle, _force: Option<bool>) -> AppResult<Value> {
-    // Platform-specific capture methods
+#[cfg(target_os = "windows")]
+fn windows_is_remote_session() -> bool {
+    use windows::Win32::UI::WindowsAndMessaging::{GetSystemMetrics, SM_REMOTESESSION};
+
+    // Desktop Duplication is not available in many RDP sessions. Detect this
+    // without capturing a frame during app startup (which would be both slow
+    // and surprising) and choose the compatible GDI path instead.
+    unsafe { GetSystemMetrics(SM_REMOTESESSION) != 0 }
+}
+
+#[cfg(target_os = "windows")]
+fn normalize_windows_capturer(capturer: Option<&str>, is_remote_session: bool) -> &'static str {
+    if is_remote_session {
+        return "gdigrab";
+    }
+
+    match capturer.unwrap_or_default().to_ascii_lowercase().as_str() {
+        "gdi" | "gdigrab" => "gdigrab",
+        _ => "ddagrab",
+    }
+}
+
+pub(crate) fn normalize_capturer(capturer: Option<&str>) -> &'static str {
     #[cfg(target_os = "windows")]
-    let capturers = vec![
-        serde_json::json!({
-            "name": "GDI",
-            "value": "gdigrab",
-            "available": true
-        }),
-        serde_json::json!({
-            "name": "DirectX (DXGI)",
-            "value": "dxgi",
-            "available": true
-        }),
-    ];
-
+    {
+        normalize_windows_capturer(capturer, windows_is_remote_session())
+    }
     #[cfg(target_os = "macos")]
-    let capturers = vec![
-        serde_json::json!({
-            "name": "AVFoundation",
-            "value": "avfoundation",
-            "available": true
-        }),
-    ];
-
+    {
+        let _ = capturer;
+        "avfoundation"
+    }
     #[cfg(target_os = "linux")]
+    {
+        // PipeWire capture requires an XDG Desktop Portal session and a node/FD,
+        // not merely a `pw-cli` binary. Do not advertise a path we cannot start.
+        let _ = capturer;
+        "x11grab"
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        let _ = capturer;
+        "x11grab"
+    }
+}
+
+#[tauri::command]
+pub async fn get_capturers(app: AppHandle, _force: Option<bool>) -> AppResult<Value> {
+    let store = app
+        .store("store.json")
+        .map_err(|error| AppError::General(error.to_string()))?;
+    let stored = store
+        .get("capturer")
+        .and_then(|value| value.as_str().map(str::to_owned));
+    let is_automatic = store
+        .get("capturerMode")
+        .and_then(|value| value.as_str().map(|mode| mode != "manual"))
+        .unwrap_or(true);
+    let selected = normalize_capturer(if is_automatic {
+        None
+    } else {
+        stored.as_deref()
+    });
+
+    #[cfg(target_os = "windows")]
     let capturers = {
-        let mut caps = vec![
-            serde_json::json!({
-                "name": "X11 Grab",
-                "value": "x11grab",
-                "available": true
-            }),
-        ];
-        // Check if PipeWire is available
-        if std::process::Command::new("pw-cli")
-            .arg("info")
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false)
-        {
-            caps.push(serde_json::json!({
-                "name": "PipeWire",
-                "value": "pipewire",
-                "available": true
+        let is_remote_session = windows_is_remote_session();
+        let selected_name = if selected == "ddagrab" {
+            "DirectX (DXGI)"
+        } else {
+            "GDI (compatibility)"
+        };
+        let mut values = if is_automatic {
+            vec![serde_json::json!({
+                "name": "auto",
+                "displayName": format!("Automatic · {}", selected_name),
+                "available": true,
+                "isSelected": true,
+            })]
+        } else {
+            Vec::new()
+        };
+        if !is_remote_session {
+            values.push(serde_json::json!({
+            "name": "ddagrab",
+            "displayName": "DirectX (DXGI)",
+            "available": true,
+            "isSelected": !is_automatic && selected == "ddagrab",
             }));
         }
-        caps
+        values.push(serde_json::json!({
+            "name": "gdigrab",
+            "displayName": "GDI (compatibility)",
+            "available": true,
+            "isSelected": !is_automatic && selected == "gdigrab",
+        }));
+        values
     };
 
+    #[cfg(target_os = "macos")]
+    let capturers = vec![serde_json::json!({
+        "name": "avfoundation",
+        "displayName": "AVFoundation",
+        "available": true,
+        "isSelected": true,
+    })];
+
+    #[cfg(target_os = "linux")]
+    let capturers = vec![serde_json::json!({
+        "name": "x11grab",
+        "displayName": "X11 Grab",
+        "available": true,
+        "isSelected": true,
+    })];
+
     #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    let capturers = vec![
-        serde_json::json!({
-            "name": "X11 Grab",
-            "value": "x11grab",
-            "available": true
-        }),
-    ];
+    let capturers = vec![serde_json::json!({
+        "name": "x11grab",
+        "displayName": "X11 Grab",
+        "available": true,
+        "isSelected": true,
+    })];
+
+    let mut changed = false;
+    if store.get("capturerMode").is_none() {
+        store.set("capturerMode", Value::String("auto".to_string()));
+        changed = true;
+    }
+    if stored.as_deref() != Some(selected) {
+        store.set("capturer", Value::String(selected.to_string()));
+        changed = true;
+    }
+    if changed {
+        store
+            .save()
+            .map_err(|error| AppError::General(error.to_string()))?;
+    }
 
     Ok(Value::Array(capturers))
 }
 
 #[tauri::command]
 pub async fn set_capturer(app: AppHandle, capturer: String) -> AppResult<()> {
-    use tauri_plugin_store::StoreExt;
+    if capturer == "auto" {
+        let selected = normalize_capturer(None).to_string();
+        let store = app
+            .store("store.json")
+            .map_err(|error| AppError::General(error.to_string()))?;
+        store.set("capturer", Value::String(selected));
+        store.set("capturerMode", Value::String("auto".to_string()));
+        store
+            .save()
+            .map_err(|error| AppError::General(error.to_string()))?;
+        return Ok(());
+    }
+
+    let capturer = normalize_capturer(Some(&capturer)).to_string();
     let store = app
         .store("store.json")
-        .map_err(|e| AppError::General(e.to_string()))?;
+        .map_err(|error| AppError::General(error.to_string()))?;
     store.set("capturer", Value::String(capturer));
+    store.set("capturerMode", Value::String("manual".to_string()));
     store
         .save()
-        .map_err(|e| AppError::General(e.to_string()))?;
+        .map_err(|error| AppError::General(error.to_string()))?;
     Ok(())
 }
 
@@ -155,19 +510,20 @@ pub async fn set_capturer(app: AppHandle, capturer: String) -> AppResult<()> {
 #[tauri::command]
 pub async fn extract_audio_buffer(app: AppHandle, source: String) -> AppResult<Vec<u8>> {
     use crate::state::AppState;
-    use std::sync::Mutex;
 
     let source_file = {
         let state = app.state::<Mutex<AppState>>();
         let state = state.lock().unwrap();
-        let project_id = state
-            .project_id
-            .clone()
-            .ok_or(AppError::NoProjectOpen)?;
+        let project_id = state.project_id.clone().ok_or(AppError::NoProjectOpen)?;
         match source.as_str() {
             "screen" => state.screen_video_file(&project_id),
             "camera" | "microphone" => state.camera_video_file(&project_id),
-            _ => return Err(AppError::General(format!("Unknown audio source: {}", source))),
+            _ => {
+                return Err(AppError::General(format!(
+                    "Unknown audio source: {}",
+                    source
+                )))
+            }
         }
     };
 
@@ -180,21 +536,62 @@ pub async fn extract_audio_buffer(app: AppHandle, source: String) -> AppResult<V
         .args([
             "-i",
             source_file.to_str().unwrap_or_default(),
-            "-vn",           // no video
-            "-acodec", "pcm_s16le",
-            "-ar", "16000",  // 16kHz sample rate (Whisper expects this)
-            "-ac", "1",      // mono
-            "-f", "wav",     // WAV format
-            "pipe:1",        // output to stdout
+            "-vn",
+            "-acodec",
+            "pcm_s16le",
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            "-f",
+            "wav",
+            "pipe:1",
         ])
         .output()
         .await
         .map_err(|e| AppError::General(format!("FFmpeg audio extraction failed: {}", e)))?;
 
     if output.stdout.is_empty() {
-        // No audio track in the video
         return Ok(Vec::new());
     }
 
     Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requested_runtime_usable_encoder_wins() {
+        let selected = choose_encoder_from_availability(Some("libx264"), |name| {
+            matches!(name, "h264_qsv" | "libx264")
+        });
+        assert_eq!(selected.as_deref(), Some("libx264"));
+    }
+
+    #[test]
+    fn unavailable_request_falls_back_to_preferred_runtime_encoder() {
+        let selected = choose_encoder_from_availability(Some("h264_nvenc"), |name| {
+            matches!(name, "h264_qsv" | "libx264")
+        });
+        #[cfg(target_os = "windows")]
+        assert_eq!(selected.as_deref(), Some("h264_qsv"));
+        #[cfg(not(target_os = "windows"))]
+        assert!(selected.is_some());
+    }
+
+    #[test]
+    fn capturer_aliases_normalize_to_a_real_backend() {
+        #[cfg(target_os = "windows")]
+        {
+            assert_eq!(normalize_windows_capturer(Some("GDI"), false), "gdigrab");
+            assert_eq!(normalize_windows_capturer(Some("dxgi"), false), "ddagrab");
+            assert_eq!(normalize_windows_capturer(Some("ddagrab"), true), "gdigrab");
+        }
+        #[cfg(target_os = "macos")]
+        assert_eq!(normalize_capturer(Some("anything")), "avfoundation");
+        #[cfg(target_os = "linux")]
+        assert_eq!(normalize_capturer(Some("pipewire")), "x11grab");
+    }
 }

--- a/src-tauri/src/commands/live.rs
+++ b/src-tauri/src/commands/live.rs
@@ -248,7 +248,7 @@ fn parse_time_to_ms(s: &str) -> Option<i64> {
     let h: i64 = parts.next()?.parse().ok()?;
     let m: i64 = parts.next()?.parse().ok()?;
     let sec: f64 = parts.next()?.parse().ok()?;
-    Some(h * 3600_000 + m * 60_000 + (sec * 1000.0) as i64)
+    Some(h * 3_600_000 + m * 60_000 + (sec * 1000.0) as i64)
 }
 
 #[tauri::command]
@@ -257,9 +257,7 @@ pub async fn start_live_streaming(app: AppHandle, config: LiveConfig) -> AppResu
     {
         let st = state_handle.lock().unwrap();
         if st.live_ffmpeg_process.is_some() {
-            return Err(AppError::General(
-                "Live stream already active".to_string(),
-            ));
+            return Err(AppError::General("Live stream already active".to_string()));
         }
     }
 
@@ -273,7 +271,15 @@ pub async fn start_live_streaming(app: AppHandle, config: LiveConfig) -> AppResu
         .ok_or_else(|| AppError::General("FFmpeg binary not found".to_string()))?;
 
     let args = build_ffmpeg_args(&config, local_path.as_ref());
-    log::info!("[live] FFmpeg args: {:?}", args);
+    // Never log the command line: the RTMP target contains the user's stream
+    // key. Keep only non-sensitive operational fields in diagnostics.
+    log::info!(
+        "[live] starting stream: fps={} bitrate_kbps={} remote={} save_local={}",
+        config.framerate,
+        config.video_bitrate_kbps,
+        !config.rtmp_url.is_empty(),
+        config.save_local
+    );
 
     use std::process::{Command, Stdio};
     let mut cmd = Command::new(&ffmpeg_path);
@@ -291,6 +297,7 @@ pub async fn start_live_streaming(app: AppHandle, config: LiveConfig) -> AppResu
     let mut child = cmd
         .spawn()
         .map_err(|e| AppError::General(format!("Failed to spawn FFmpeg: {}", e)))?;
+    crate::process_containment::contain_owned_child(&child, "live-stream FFmpeg");
 
     let stdin = child
         .stdin
@@ -382,9 +389,8 @@ pub async fn push_live_frame(app: AppHandle, chunk: Vec<u8>) -> AppResult<()> {
         st.live_stdin_tx.clone()
     };
     if let Some(tx) = tx {
-        tx.send(chunk).map_err(|_| {
-            AppError::General("Live stream stdin channel closed".to_string())
-        })?;
+        tx.send(chunk)
+            .map_err(|_| AppError::General("Live stream stdin channel closed".to_string()))?;
         Ok(())
     } else {
         Err(AppError::General("Live stream not active".to_string()))
@@ -567,11 +573,11 @@ pub async fn get_cursor_position(_app: AppHandle) -> AppResult<CursorSample> {
         unsafe {
             let _ = GetCursorPos(&mut p);
         }
-        return Ok(CursorSample {
+        Ok(CursorSample {
             x: p.x,
             y: p.y,
             timestamp_ms,
-        });
+        })
     }
 
     #[cfg(target_os = "macos")]
@@ -611,11 +617,7 @@ pub async fn get_cursor_position(_app: AppHandle) -> AppResult<CursorSample> {
                     y = v.parse().unwrap_or(0);
                 }
             }
-            return Ok(CursorSample {
-                x,
-                y,
-                timestamp_ms,
-            });
+            return Ok(CursorSample { x, y, timestamp_ms });
         }
         return Ok(CursorSample {
             x: 0,

--- a/src-tauri/src/commands/multi_app.rs
+++ b/src-tauri/src/commands/multi_app.rs
@@ -1,12 +1,85 @@
-use std::path::PathBuf;
-use std::process::Stdio;
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ExitStatus, Stdio};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
 
 use crate::error::{AppError, AppResult};
 use crate::state::AppState;
+
+const FINALIZE_TIMEOUT: Duration = Duration::from_secs(8);
+const FINALIZE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const VALIDATION_TIMEOUT: Duration = Duration::from_secs(6);
+const STARTUP_HEALTH_DELAY: Duration = Duration::from_millis(200);
+
+#[derive(Debug, Clone)]
+struct CaptureOutput {
+    path: PathBuf,
+    ffmpeg: PathBuf,
+}
+
+fn capture_outputs() -> &'static Mutex<HashMap<u32, CaptureOutput>> {
+    static OUTPUTS: OnceLock<Mutex<HashMap<u32, CaptureOutput>>> = OnceLock::new();
+    OUTPUTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn invalid_capture_outputs() -> &'static Mutex<HashMap<PathBuf, String>> {
+    static INVALID_OUTPUTS: OnceLock<Mutex<HashMap<PathBuf, String>>> = OnceLock::new();
+    INVALID_OUTPUTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn register_capture_output(pid: u32, ffmpeg: &Path, path: &Path) {
+    let path = path.to_path_buf();
+    capture_outputs()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            pid,
+            CaptureOutput {
+                path: path.clone(),
+                ffmpeg: ffmpeg.to_path_buf(),
+            },
+        );
+    invalid_capture_outputs()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&path);
+}
+
+fn take_capture_output(pid: u32) -> Option<CaptureOutput> {
+    capture_outputs()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(&pid)
+}
+
+fn clear_multi_app_init(state: &Mutex<AppState>) {
+    let mut state = state.lock().unwrap();
+    state.multi_app_init_in_progress = false;
+    state.multi_app_stop_requested = false;
+}
+
+fn abort_capture_start(children: Vec<Child>) {
+    for child in children {
+        let pid = child.id();
+        crate::process_containment::terminate_owned_child(child, "App-layer startup FFmpeg").ok();
+        if let Some(output) = take_capture_output(pid) {
+            std::fs::remove_file(output.path).ok();
+        }
+    }
+}
+
+fn startup_must_be_canceled(state: &AppState, session_project_id: &str) -> bool {
+    state.multi_app_stop_requested
+        || !state.is_recording
+        || !state.recording_capture_claimed
+        || state.recording_stop_in_progress
+        || state.project_id.as_deref() != Some(session_project_id)
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct WindowSpec {
@@ -34,6 +107,43 @@ pub struct CapturedTrack {
     pub start_offset_ms: i64,
 }
 
+impl CapturedTrack {
+    /// Return the exact capture filename used for this track. Track filenames
+    /// are generated internally, but validating the value here keeps a
+    /// corrupted manifest from escaping the project directory or creating a
+    /// path-traversal entry in the saved ZIP.
+    pub(crate) fn archive_filename(&self) -> AppResult<&str> {
+        if self.filename.is_empty()
+            || self.filename == "."
+            || self.filename == ".."
+            || self.filename.contains('/')
+            || self.filename.contains('\\')
+        {
+            return Err(AppError::General(format!(
+                "Invalid multi-app track filename: {:?}",
+                self.filename
+            )));
+        }
+        Ok(self.filename.as_str())
+    }
+
+    pub(crate) fn capture_path(&self, project_temp: &std::path::Path) -> AppResult<PathBuf> {
+        let path = project_temp.join(self.archive_filename()?);
+        if let Some(reason) = invalid_capture_outputs()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(&path)
+            .cloned()
+        {
+            return Err(AppError::General(format!(
+                "App-layer recording {:?} is invalid and cannot be packaged: {}",
+                path, reason
+            )));
+        }
+        Ok(path)
+    }
+}
+
 /// Spawn one FFmpeg child per selected window. Each writes to
 /// `<project_temp>/extra-<idx>.mp4` using a platform-specific screen-grab
 /// input. Returns the manifest of tracks so the recorder can stash it for the
@@ -48,21 +158,41 @@ pub async fn start_multi_app_capture(
         return Ok(Vec::new());
     }
 
-    let (project_temp, recording_start_ts) = {
-        let s = state.lock().unwrap();
-        let pid = s
-            .project_id
-            .clone()
-            .ok_or(AppError::NoProjectOpen)?;
-        (s.project_temp_dir(&pid), s.recording_start_timestamp)
+    let (session_project_id, project_temp, recording_start_ts) = {
+        let mut s = state.lock().unwrap();
+        if !s.is_recording || !s.recording_capture_claimed {
+            return Err(AppError::General(
+                "The main recording must be running before App layers can start.".to_string(),
+            ));
+        }
+        if s.multi_app_init_in_progress || !s.multi_app_children.is_empty() {
+            return Err(AppError::General(
+                "App-layer capture is already active.".to_string(),
+            ));
+        }
+        let pid = s.project_id.clone().ok_or(AppError::NoProjectOpen)?;
+        s.multi_app_init_in_progress = true;
+        s.multi_app_stop_requested = false;
+        (
+            pid.clone(),
+            s.project_temp_dir(&pid),
+            s.recording_start_timestamp,
+        )
     };
-    std::fs::create_dir_all(&project_temp).ok();
+    if let Err(error) = std::fs::create_dir_all(&project_temp) {
+        clear_multi_app_init(&state);
+        return Err(AppError::General(format!(
+            "Could not create the App-layer recording workspace: {}",
+            error
+        )));
+    }
 
     // Reuse the same path-resolution as the main recorder so we find the
     // bundled sidecar in dev AND in production.
     let ffmpeg_path = match crate::commands::recording::find_ffmpeg_path() {
         Some(p) => p,
         None => {
+            clear_multi_app_init(&state);
             log::error!("[multi_app] FFmpeg binary not found; multi-app capture skipped");
             return Err(AppError::General(
                 "FFmpeg binary not found for multi-app capture".to_string(),
@@ -74,13 +204,20 @@ pub async fn start_multi_app_capture(
 
     let mut tracks = Vec::with_capacity(windows.len());
     let mut children = Vec::with_capacity(windows.len());
+    let mut startup_failures = Vec::new();
 
     for (idx, w) in windows.iter().enumerate() {
         let filename = format!("extra-{}.mp4", idx);
         let out_path = project_temp.join(&filename);
         log::info!(
             "[multi_app] spawning capture {} for window '{}' ({}x{}) at ({}, {}) -> {:?}",
-            idx, w.name, w.width, w.height, w.x, w.y, out_path
+            idx,
+            w.name,
+            w.width,
+            w.height,
+            w.x,
+            w.y,
+            out_path
         );
 
         let spawn_ts_ms = std::time::SystemTime::now()
@@ -95,10 +232,17 @@ pub async fn start_multi_app_capture(
         let mut child = match spawn_window_capture(&app, &ffmpeg_path, w, &out_path) {
             Ok(c) => c,
             Err(e) => {
-                log::warn!("[multi_app] failed to spawn capture for '{}': {}", w.name, e);
+                log::warn!(
+                    "[multi_app] failed to spawn capture for '{}': {}",
+                    w.name,
+                    e
+                );
+                startup_failures.push(format!("{}: {}", w.name, e));
                 continue;
             }
         };
+        crate::process_containment::contain_owned_child(&child, "app-layer FFmpeg");
+        register_capture_output(child.id(), &ffmpeg_path, &out_path);
 
         // Drain stderr to log so we can see if FFmpeg fails (gdigrab windowing
         // errors, libx264 errors, etc.) instead of silent /dev/null.
@@ -125,14 +269,64 @@ pub async fn start_multi_app_capture(
         });
     }
 
-    if tracks.is_empty() {
-        log::warn!("[multi_app] no extra captures spawned (all failed?)");
+    // `Command::spawn` succeeds even when FFmpeg immediately rejects a device,
+    // display, crop, or encoder. Give every selected layer one short health
+    // window and make startup all-or-none so the returned manifest is truthful.
+    if startup_failures.is_empty() && !children.is_empty() {
+        std::thread::sleep(STARTUP_HEALTH_DELAY);
+        for (index, child) in children.iter_mut().enumerate() {
+            match child.try_wait() {
+                Ok(Some(status)) => startup_failures.push(format!(
+                    "{}: FFmpeg exited during startup with {}",
+                    tracks
+                        .get(index)
+                        .map(|track| track.name.as_str())
+                        .unwrap_or("App layer"),
+                    status
+                )),
+                Ok(None) => {}
+                Err(error) => startup_failures.push(format!(
+                    "{}: could not verify FFmpeg startup: {}",
+                    tracks
+                        .get(index)
+                        .map(|track| track.name.as_str())
+                        .unwrap_or("App layer"),
+                    error
+                )),
+            }
+        }
     }
 
-    {
+    if !startup_failures.is_empty() || tracks.len() != windows.len() {
+        abort_capture_start(children);
+        clear_multi_app_init(&state);
+        return Err(AppError::General(format!(
+            "Could not start every selected App layer: {}",
+            startup_failures.join(" | ")
+        )));
+    }
+
+    let startup_was_canceled = {
         let mut s = state.lock().unwrap();
-        s.multi_app_children = children;
-        s.multi_app_tracks = tracks.clone();
+        s.multi_app_init_in_progress = false;
+        let canceled = startup_must_be_canceled(&s, &session_project_id);
+        s.multi_app_stop_requested = false;
+        if !canceled {
+            s.multi_app_children = std::mem::take(&mut children);
+            s.multi_app_tracks = tracks.clone();
+            s.multi_app_finalize_error = None;
+        }
+        canceled
+    };
+
+    if startup_was_canceled {
+        // Stop won the race before the children were published. They are still
+        // locally owned here, so terminate/finalize them rather than orphaning
+        // them after the project has already been saved or closed.
+        abort_capture_start(children);
+        return Err(AppError::General(
+            "App-layer startup was canceled because recording stop had already begun.".to_string(),
+        ));
     }
 
     log::info!("[multi_app] started {} extra captures", tracks.len());
@@ -141,35 +335,438 @@ pub async fn start_multi_app_capture(
 
 #[tauri::command]
 pub async fn stop_multi_app_capture(state: State<'_, Mutex<AppState>>) -> AppResult<()> {
-    let children = {
-        let mut s = state.lock().unwrap();
-        std::mem::take(&mut s.multi_app_children)
+    finalize_state_captures(&state)
+}
+
+/// Stop and validate the App-layer children owned by a recording session. A
+/// failed result is cached in AppState because the first attempt necessarily
+/// consumes the Child handles. Subsequent Stop/Retry calls must return the
+/// same failure rather than treating an empty child list as success.
+pub fn finalize_state_captures(state: &Mutex<AppState>) -> AppResult<()> {
+    let (children, previous_error, startup_in_progress) = {
+        let mut state = state.lock().unwrap();
+        let startup_in_progress = state.multi_app_init_in_progress;
+        if startup_in_progress {
+            state.multi_app_stop_requested = true;
+        }
+        (
+            std::mem::take(&mut state.multi_app_children),
+            state.multi_app_finalize_error.clone(),
+            startup_in_progress,
+        )
     };
-    graceful_shutdown(children);
-    log::info!("[multi_app] stopped extra captures");
-    Ok(())
+
+    if children.is_empty() {
+        if let Some(error) = previous_error {
+            return Err(AppError::General(error));
+        }
+        if startup_in_progress {
+            log::info!("[multi_app] Stop requested while App-layer startup was in progress");
+        }
+        return Ok(());
+    }
+
+    match shutdown_and_validate(children) {
+        Ok(()) => {
+            state.lock().unwrap().multi_app_finalize_error = None;
+            log::info!("[multi_app] stopped and validated extra captures");
+            Ok(())
+        }
+        Err(error) => {
+            let message = error.to_string();
+            state.lock().unwrap().multi_app_finalize_error = Some(message.clone());
+            log::error!("[multi_app] app-layer finalization failed: {}", message);
+            Err(AppError::General(message))
+        }
+    }
 }
 
 /// Shared shutdown helper used by both the explicit stop command and
 /// stop_recording to ensure all FFmpeg children are quiesced and their files
 /// have valid moov atoms before we return.
-pub fn graceful_shutdown(mut children: Vec<std::process::Child>) {
+pub fn graceful_shutdown(children: Vec<Child>) -> AppResult<()> {
+    shutdown_and_validate(children)
+}
+
+#[derive(Debug)]
+struct ManagedCapture {
+    child: Child,
+    pid: u32,
+    status: Option<ExitStatus>,
+    poll_error: Option<String>,
+    forced: bool,
+}
+
+fn shutdown_and_validate(children: Vec<Child>) -> AppResult<()> {
     if children.is_empty() {
-        return;
+        return Ok(());
     }
-    for child in children.iter_mut() {
+
+    let mut captures: Vec<ManagedCapture> = children
+        .into_iter()
+        .map(|child| ManagedCapture {
+            pid: child.id(),
+            child,
+            status: None,
+            poll_error: None,
+            forced: false,
+        })
+        .collect();
+
+    for capture in captures.iter_mut() {
         // Closing stdin via take() signals EOF to FFmpeg after sending 'q'.
-        if let Some(mut stdin) = child.stdin.take() {
+        if let Some(mut stdin) = capture.child.stdin.take() {
             use std::io::Write;
-            let _ = stdin.write_all(b"q\n");
+            if let Err(error) = stdin.write_all(b"q\n") {
+                // A broken pipe commonly means FFmpeg exited on its own. The
+                // exit status and output validation below remain authoritative.
+                log::debug!(
+                    "[multi_app] could not send quit to FFmpeg pid {}: {}",
+                    capture.pid,
+                    error
+                );
+            }
             // Drop closes the pipe.
         }
     }
-    std::thread::sleep(std::time::Duration::from_millis(500));
-    for mut child in children {
-        let _ = child.kill();
-        let _ = child.wait();
+
+    let deadline = Instant::now() + FINALIZE_TIMEOUT;
+    loop {
+        for capture in captures.iter_mut() {
+            if capture.status.is_some() || capture.poll_error.is_some() {
+                continue;
+            }
+            match capture.child.try_wait() {
+                Ok(Some(status)) => capture.status = Some(status),
+                Ok(None) => {}
+                Err(error) => capture.poll_error = Some(error.to_string()),
+            }
+        }
+
+        if captures
+            .iter()
+            .all(|capture| capture.status.is_some() || capture.poll_error.is_some())
+            || Instant::now() >= deadline
+        {
+            break;
+        }
+        std::thread::sleep(FINALIZE_POLL_INTERVAL);
     }
+
+    for capture in captures.iter_mut() {
+        if capture.status.is_some() {
+            continue;
+        }
+        capture.forced = true;
+        if let Err(error) = capture.child.kill() {
+            log::debug!(
+                "[multi_app] FFmpeg pid {} could not be killed after finalization timeout: {}",
+                capture.pid,
+                error
+            );
+        }
+        match capture.child.wait() {
+            Ok(status) => capture.status = Some(status),
+            Err(error) => {
+                let message = error.to_string();
+                capture.poll_error = Some(match capture.poll_error.take() {
+                    Some(previous) => format!("{}; wait failed: {}", previous, message),
+                    None => format!("wait failed: {}", message),
+                });
+            }
+        }
+    }
+
+    let mut failures = Vec::new();
+    for capture in captures {
+        let output = take_capture_output(capture.pid);
+        let mut reasons = Vec::new();
+
+        if capture.forced {
+            reasons.push(format!(
+                "FFmpeg did not finalize within {} seconds",
+                FINALIZE_TIMEOUT.as_secs()
+            ));
+        }
+        if let Some(error) = capture.poll_error {
+            reasons.push(format!("could not observe FFmpeg exit: {}", error));
+        }
+        match capture.status {
+            Some(status) if !status.success() => {
+                reasons.push(format!("FFmpeg exited with {}", status));
+            }
+            None => reasons.push("FFmpeg exit status was unavailable".to_string()),
+            _ => {}
+        }
+
+        match output.as_ref() {
+            Some(output) if reasons.is_empty() => {
+                if let Err(error) = validate_capture_output(output) {
+                    reasons.push(error);
+                }
+            }
+            None => reasons.push("capture output was not registered".to_string()),
+            _ => {}
+        }
+
+        if reasons.is_empty() {
+            if let Some(output) = output {
+                log::info!(
+                    "[multi_app] finalized and validated app-layer output {:?}",
+                    output.path
+                );
+            }
+            continue;
+        }
+
+        let label = output
+            .as_ref()
+            .map(|output| output.path.display().to_string())
+            .unwrap_or_else(|| format!("FFmpeg pid {}", capture.pid));
+        let mut reason = reasons.join("; ");
+
+        if let Some(output) = output {
+            if let Err(exclusion_error) = exclude_invalid_output(&output.path) {
+                invalid_capture_outputs()
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .insert(output.path.clone(), reason.clone());
+                reason.push_str(&format!(
+                    "; could not exclude invalid output: {}",
+                    exclusion_error
+                ));
+            }
+        }
+        failures.push(format!("{}: {}", label, reason));
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(AppError::General(format!(
+            "One or more app-layer recordings could not be finalized: {}",
+            failures.join(" | ")
+        )))
+    }
+}
+
+fn validate_capture_output(output: &CaptureOutput) -> Result<(), String> {
+    validate_mp4_structure(&output.path)?;
+    run_decode_probe(&output.ffmpeg, &output.path, false)?;
+    run_decode_probe(&output.ffmpeg, &output.path, true)?;
+    Ok(())
+}
+
+fn validate_mp4_structure(path: &Path) -> Result<(), String> {
+    let mut file = std::fs::File::open(path)
+        .map_err(|error| format!("could not open finalized MP4: {}", error))?;
+    let file_len = file
+        .metadata()
+        .map_err(|error| format!("could not inspect finalized MP4: {}", error))?
+        .len();
+    if file_len < 24 {
+        return Err(format!(
+            "finalized MP4 is too small to be readable ({} bytes)",
+            file_len
+        ));
+    }
+
+    let mut offset = 0_u64;
+    let mut has_ftyp = false;
+    let mut has_moov = false;
+    let mut has_mdat = false;
+
+    while offset < file_len {
+        let remaining = file_len - offset;
+        if remaining < 8 {
+            return Err(format!(
+                "finalized MP4 has a truncated box header at byte {}",
+                offset
+            ));
+        }
+
+        file.seek(SeekFrom::Start(offset))
+            .map_err(|error| format!("could not seek finalized MP4: {}", error))?;
+        let mut header = [0_u8; 8];
+        file.read_exact(&mut header)
+            .map_err(|error| format!("could not read finalized MP4 header: {}", error))?;
+        let size32 = u32::from_be_bytes(header[0..4].try_into().expect("four-byte size"));
+        let box_type: [u8; 4] = header[4..8].try_into().expect("four-byte box type");
+
+        let (box_size, header_size) = if size32 == 1 {
+            if remaining < 16 {
+                return Err(format!(
+                    "finalized MP4 has a truncated extended box header at byte {}",
+                    offset
+                ));
+            }
+            let mut extended = [0_u8; 8];
+            file.read_exact(&mut extended).map_err(|error| {
+                format!("could not read finalized MP4 extended header: {}", error)
+            })?;
+            (u64::from_be_bytes(extended), 16_u64)
+        } else if size32 == 0 {
+            (remaining, 8_u64)
+        } else {
+            (u64::from(size32), 8_u64)
+        };
+
+        if box_size < header_size || box_size > remaining {
+            return Err(format!(
+                "finalized MP4 has an invalid {} box size {} at byte {}",
+                String::from_utf8_lossy(&box_type),
+                box_size,
+                offset
+            ));
+        }
+
+        match &box_type {
+            b"ftyp" => has_ftyp = true,
+            b"moov" => has_moov = true,
+            b"mdat" => has_mdat = true,
+            _ => {}
+        }
+        offset = offset
+            .checked_add(box_size)
+            .ok_or_else(|| "finalized MP4 box offsets overflowed".to_string())?;
+    }
+
+    let mut missing = Vec::new();
+    if !has_ftyp {
+        missing.push("ftyp");
+    }
+    if !has_moov {
+        missing.push("moov");
+    }
+    if !has_mdat {
+        missing.push("mdat");
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "finalized MP4 is missing required {} box(es)",
+            missing.join(", ")
+        ))
+    }
+}
+
+fn run_decode_probe(ffmpeg: &Path, path: &Path, tail: bool) -> Result<(), String> {
+    let mut command = std::process::Command::new(ffmpeg);
+    command.args(["-hide_banner", "-loglevel", "error", "-xerror", "-nostdin"]);
+    if tail {
+        command.args(["-sseof", "-1"]);
+    }
+    command
+        .arg("-i")
+        .arg(path)
+        .args(["-map", "0:v:0", "-frames:v", "1", "-f", "null", "-"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("could not start FFmpeg decode validation: {}", error))?;
+    crate::process_containment::contain_owned_child(&child, "decode-validation FFmpeg");
+    let stderr = child.stderr.take();
+    let diagnostics = std::thread::spawn(move || {
+        let mut message = String::new();
+        if let Some(mut stderr) = stderr {
+            let _ = stderr.read_to_string(&mut message);
+        }
+        message
+    });
+
+    let deadline = Instant::now() + VALIDATION_TIMEOUT;
+    let mut wait_error = None;
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(FINALIZE_POLL_INTERVAL);
+            }
+            Ok(None) => {
+                timed_out = true;
+                let _ = child.kill();
+                break child.wait().ok();
+            }
+            Err(error) => {
+                wait_error = Some(error.to_string());
+                let _ = child.kill();
+                break child.wait().ok();
+            }
+        }
+    };
+    let diagnostics = diagnostics.join().unwrap_or_default();
+
+    let probe_label = if tail { "tail-frame" } else { "first-frame" };
+    if timed_out {
+        return Err(format!(
+            "{} decode validation timed out after {} seconds",
+            probe_label,
+            VALIDATION_TIMEOUT.as_secs()
+        ));
+    }
+    if let Some(error) = wait_error {
+        return Err(format!(
+            "{} decode validation could not be observed: {}",
+            probe_label, error
+        ));
+    }
+    match status {
+        Some(status) if status.success() => Ok(()),
+        Some(status) => {
+            let detail = diagnostics.trim();
+            if detail.is_empty() {
+                Err(format!(
+                    "{} decode validation failed with {}",
+                    probe_label, status
+                ))
+            } else {
+                Err(format!(
+                    "{} decode validation failed with {}: {}",
+                    probe_label, status, detail
+                ))
+            }
+        }
+        None => Err(format!(
+            "{} decode validation exit status was unavailable",
+            probe_label
+        )),
+    }
+}
+
+fn exclude_invalid_output(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    if std::fs::remove_file(path).is_ok() {
+        return Ok(());
+    }
+
+    let quarantine = path.with_extension("mp4.invalid");
+    let _ = std::fs::remove_file(&quarantine);
+    if std::fs::rename(path, &quarantine).is_ok() {
+        let _ = std::fs::remove_file(&quarantine);
+        return Ok(());
+    }
+
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|error| format!("could not remove, quarantine, or truncate file: {}", error))?;
+    file.sync_all()
+        .map_err(|error| format!("could not sync truncated invalid file: {}", error))
 }
 
 #[cfg(target_os = "windows")]
@@ -208,13 +805,20 @@ fn spawn_window_capture(
     let mut cmd = std::process::Command::new(ffmpeg);
     cmd.args([
         "-y",
-        "-f", "lavfi",
-        "-i", &ddagrab,
-        "-vf", "hwdownload,format=bgra,format=yuv420p",
-        "-c:v", "libx264",
-        "-preset", "ultrafast",
-        "-pix_fmt", "yuv420p",
-        "-movflags", "+faststart",
+        "-f",
+        "lavfi",
+        "-i",
+        &ddagrab,
+        "-vf",
+        "hwdownload,format=bgra,format=yuv420p",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "ultrafast",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
     ])
     .arg(out_path)
     .stdin(Stdio::piped())
@@ -224,8 +828,14 @@ fn spawn_window_capture(
     cmd.spawn()
 }
 
-#[cfg(target_os = "windows")]
-fn monitor_for(app: &AppHandle, win_x: i32, win_y: i32, win_w: u32, win_h: u32) -> (usize, i32, i32) {
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+fn monitor_for(
+    app: &AppHandle,
+    win_x: i32,
+    win_y: i32,
+    win_w: u32,
+    win_h: u32,
+) -> (usize, i32, i32) {
     let cx = win_x + (win_w as i32) / 2;
     let cy = win_y + (win_h as i32) / 2;
     if let Ok(monitors) = app.available_monitors() {
@@ -246,24 +856,37 @@ fn monitor_for(app: &AppHandle, win_x: i32, win_y: i32, win_w: u32, win_h: u32) 
 
 #[cfg(target_os = "macos")]
 fn spawn_window_capture(
-    _app: &AppHandle,
+    app: &AppHandle,
     ffmpeg: &PathBuf,
     spec: &WindowSpec,
     out_path: &PathBuf,
 ) -> std::io::Result<std::process::Child> {
+    let (monitor_index, monitor_x, monitor_y) =
+        monitor_for(app, spec.x, spec.y, spec.width, spec.height);
+    let screen_device = crate::commands::recording::macos_screen_device_index(monitor_index as i64);
     let w = (spec.width as i32) & !1;
     let h = (spec.height as i32) & !1;
+    let offset_x = (spec.x - monitor_x).max(0);
+    let offset_y = (spec.y - monitor_y).max(0);
     std::process::Command::new(ffmpeg)
         .args([
             "-y",
-            "-f", "avfoundation",
-            "-framerate", "30",
-            "-i", "1:none",
-            "-vf", &format!("crop={}:{}:{}:{}", w, h, spec.x.max(0), spec.y.max(0)),
-            "-c:v", "libx264",
-            "-preset", "veryfast",
-            "-pix_fmt", "yuv420p",
-            "-movflags", "+faststart",
+            "-f",
+            "avfoundation",
+            "-framerate",
+            "30",
+            "-i",
+            &format!("{}:none", screen_device),
+            "-vf",
+            &format!("crop={}:{}:{}:{}", w, h, offset_x, offset_y),
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
         ])
         .arg(out_path)
         .stdin(Stdio::piped())
@@ -279,19 +902,28 @@ fn spawn_window_capture(
     spec: &WindowSpec,
     out_path: &PathBuf,
 ) -> std::io::Result<std::process::Child> {
+    let display = std::env::var("DISPLAY").unwrap_or_else(|_| ":0".to_string());
     let w = (spec.width as i32) & !1;
     let h = (spec.height as i32) & !1;
     std::process::Command::new(ffmpeg)
         .args([
             "-y",
-            "-f", "x11grab",
-            "-framerate", "30",
-            "-video_size", &format!("{}x{}", w, h),
-            "-i", &format!(":0.0+{},{}", spec.x, spec.y),
-            "-c:v", "libx264",
-            "-preset", "veryfast",
-            "-pix_fmt", "yuv420p",
-            "-movflags", "+faststart",
+            "-f",
+            "x11grab",
+            "-framerate",
+            "30",
+            "-video_size",
+            &format!("{}x{}", w, h),
+            "-i",
+            &format!("{}+{},{}", display, spec.x, spec.y),
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-pix_fmt",
+            "yuv420p",
+            "-movflags",
+            "+faststart",
         ])
         .arg(out_path)
         .stdin(Stdio::piped())
@@ -300,3 +932,248 @@ fn spawn_window_capture(
         .spawn()
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_path(label: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "flowtake-multi-app-{}-{}-{}.mp4",
+            std::process::id(),
+            nonce,
+            label
+        ))
+    }
+
+    fn mp4_box(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let size = u32::try_from(8 + payload.len()).expect("test box fits u32");
+        let mut bytes = Vec::with_capacity(size as usize);
+        bytes.extend_from_slice(&size.to_be_bytes());
+        bytes.extend_from_slice(kind);
+        bytes.extend_from_slice(payload);
+        bytes
+    }
+
+    fn write_structural_mp4(path: &Path, include_moov: bool) {
+        let mut bytes = mp4_box(b"ftyp", b"isom\0\0\0\0");
+        if include_moov {
+            bytes.extend(mp4_box(b"moov", b"metadata"));
+        }
+        bytes.extend(mp4_box(b"mdat", b"video-payload"));
+        std::fs::write(path, bytes).expect("write test MP4");
+    }
+
+    fn track(filename: &str) -> CapturedTrack {
+        CapturedTrack {
+            id: "window-id".to_string(),
+            name: "Window".to_string(),
+            filename: filename.to_string(),
+            width: 1280,
+            height: 720,
+            start_offset_ms: 0,
+        }
+    }
+
+    #[test]
+    fn capture_path_uses_the_track_actual_filename() {
+        let root = std::path::Path::new("project-temp");
+        let captured = track("extra-2.mp4");
+
+        assert_eq!(captured.archive_filename().unwrap(), "extra-2.mp4");
+        assert_eq!(
+            captured.capture_path(root).unwrap(),
+            root.join("extra-2.mp4")
+        );
+    }
+
+    #[test]
+    fn track_filename_rejects_paths_and_parent_segments() {
+        for filename in [
+            "",
+            ".",
+            "..",
+            "../extra-0.mp4",
+            "nested/extra-0.mp4",
+            "nested\\extra-0.mp4",
+        ] {
+            assert!(track(filename).archive_filename().is_err(), "{filename}");
+        }
+    }
+
+    #[test]
+    fn structural_validation_requires_complete_mp4_boxes() {
+        let valid_path = test_path("valid");
+        write_structural_mp4(&valid_path, true);
+        assert!(validate_mp4_structure(&valid_path).is_ok());
+
+        let missing_moov_path = test_path("missing-moov");
+        write_structural_mp4(&missing_moov_path, false);
+        let missing_error = validate_mp4_structure(&missing_moov_path).unwrap_err();
+        assert!(missing_error.contains("moov"), "{missing_error}");
+
+        let truncated_path = test_path("truncated");
+        let mut truncated = Vec::new();
+        truncated.extend_from_slice(&64_u32.to_be_bytes());
+        truncated.extend_from_slice(b"ftyp");
+        truncated.extend_from_slice(&[0_u8; 20]);
+        std::fs::write(&truncated_path, truncated).expect("write truncated MP4");
+        let truncated_error = validate_mp4_structure(&truncated_path).unwrap_err();
+        assert!(
+            truncated_error.contains("invalid ftyp box size"),
+            "{truncated_error}"
+        );
+
+        let _ = std::fs::remove_file(valid_path);
+        let _ = std::fs::remove_file(missing_moov_path);
+        let _ = std::fs::remove_file(truncated_path);
+    }
+
+    #[test]
+    fn invalid_finalized_output_returns_error_and_is_excluded() {
+        let output_path = test_path("invalid-finalized");
+        // This passes the lightweight box checks, then proves the decoder gate
+        // is authoritative before a track can be reported as successful.
+        write_structural_mp4(&output_path, true);
+
+        #[cfg(target_os = "windows")]
+        let child = std::process::Command::new("cmd")
+            .args(["/C", "exit", "0"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn successful child");
+
+        #[cfg(not(target_os = "windows"))]
+        let child = std::process::Command::new("sh")
+            .args(["-c", "exit 0"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn successful child");
+
+        register_capture_output(child.id(), Path::new("unused-ffmpeg"), &output_path);
+        let error = shutdown_and_validate(vec![child]).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("could not be finalized"), "{message}");
+        assert!(message.contains("decode validation"), "{message}");
+        assert!(
+            !output_path.exists()
+                || output_path
+                    .metadata()
+                    .map(|metadata| metadata.len() == 0)
+                    .unwrap_or(true),
+            "invalid output must not remain packageable"
+        );
+    }
+
+    #[test]
+    fn shutdown_waits_for_delayed_clean_exit_instead_of_killing_at_500ms() {
+        let output_path = test_path("delayed-finalize");
+        write_structural_mp4(&output_path, true);
+
+        #[cfg(target_os = "windows")]
+        let child = std::process::Command::new("powershell.exe")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "Start-Sleep -Milliseconds 750; exit 0",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn delayed successful child");
+
+        #[cfg(not(target_os = "windows"))]
+        let child = std::process::Command::new("sh")
+            .args(["-c", "sleep 0.75; exit 0"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn delayed successful child");
+
+        register_capture_output(child.id(), Path::new("unused-ffmpeg"), &output_path);
+        let started = Instant::now();
+        let error = shutdown_and_validate(vec![child]).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            started.elapsed() >= Duration::from_millis(600),
+            "shutdown returned before delayed finalization"
+        );
+        assert!(
+            !message.contains("did not finalize within"),
+            "delayed clean exit must not be force-killed: {message}"
+        );
+    }
+
+    #[test]
+    fn unexcludable_invalid_track_is_rejected_by_packaging_path() {
+        let root = test_path("invalid-root").with_extension("");
+        let path = root.join("extra-0.mp4");
+        invalid_capture_outputs()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(path.clone(), "decode failed".to_string());
+
+        let error = track("extra-0.mp4").capture_path(&root).unwrap_err();
+        assert!(error.to_string().contains("cannot be packaged"));
+
+        invalid_capture_outputs()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&path);
+    }
+
+    #[test]
+    fn app_layer_finalize_failure_remains_durable_across_stop_retries() {
+        let state = Mutex::new(AppState::new());
+        state.lock().unwrap().multi_app_finalize_error =
+            Some("required App layer failed".to_string());
+
+        let first = finalize_state_captures(&state).unwrap_err().to_string();
+        let second = finalize_state_captures(&state).unwrap_err().to_string();
+        assert!(first.contains("required App layer failed"));
+        assert_eq!(first, second);
+        assert!(state.lock().unwrap().multi_app_finalize_error.is_some());
+    }
+
+    #[test]
+    fn immediate_stop_cancels_unpublished_app_layer_startup() {
+        let state = Mutex::new(AppState::new());
+        {
+            let mut session = state.lock().unwrap();
+            session.is_recording = true;
+            session.recording_capture_claimed = true;
+            session.multi_app_init_in_progress = true;
+            session.project_id = Some("session-a".to_string());
+        }
+
+        // Stop sees no published children yet, but must leave a cancellation
+        // token for the starter that still owns them locally.
+        finalize_state_captures(&state).unwrap();
+        let session = state.lock().unwrap();
+        assert!(session.multi_app_stop_requested);
+        assert!(startup_must_be_canceled(&session, "session-a"));
+        assert!(session.multi_app_children.is_empty());
+    }
+
+    #[test]
+    fn old_startup_cannot_publish_into_a_replacement_recording_session() {
+        let mut state = AppState::new();
+        state.is_recording = true;
+        state.recording_capture_claimed = true;
+        state.project_id = Some("new-session".to_string());
+
+        assert!(startup_must_be_canceled(&state, "old-session"));
+        assert!(!startup_must_be_canceled(&state, "new-session"));
+    }
+}

--- a/src-tauri/src/commands/plugins.rs
+++ b/src-tauri/src/commands/plugins.rs
@@ -74,7 +74,7 @@ pub async fn list_plugins(state: State<'_, Mutex<AppState>>) -> AppResult<Vec<Pl
             is_dir: metadata.is_dir(),
         });
     }
-    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    out.sort_by_key(|entry| entry.name.to_lowercase());
     Ok(out)
 }
 

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::sync::atomic::Ordering;
 use std::sync::{Mutex, OnceLock};
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri_plugin_store::StoreExt;
 
 static FFMPEG_PATH_CACHE: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
 
@@ -228,68 +229,461 @@ fn ffmpeg_stderr_is_capture_error(msg: &str) -> bool {
         || lower.contains("input/output error")
 }
 
-#[cfg(target_os = "macos")]
-fn ffmpeg_encoder_available(encoder: &str) -> bool {
-    let Some(ffmpeg) = find_ffmpeg_path() else {
-        return false;
-    };
-
-    std::process::Command::new(&ffmpeg)
-        .args(["-hide_banner", "-encoders"])
-        .output()
-        .map(|output| {
-            output.status.success() && String::from_utf8_lossy(&output.stdout).contains(encoder)
-        })
-        .unwrap_or(false)
-}
-
-fn recording_video_output_args() -> Vec<String> {
-    #[cfg(target_os = "macos")]
-    {
-        if ffmpeg_encoder_available("h264_videotoolbox") {
-            return vec![
-                "-c:v".to_string(),
-                "h264_videotoolbox".to_string(),
-                "-b:v".to_string(),
-                "9000k".to_string(),
-                "-maxrate".to_string(),
-                "12000k".to_string(),
-                "-bufsize".to_string(),
-                "18000k".to_string(),
-                "-allow_sw".to_string(),
-                "1".to_string(),
-                "-realtime".to_string(),
-                "1".to_string(),
-                "-pix_fmt".to_string(),
-                "yuv420p".to_string(),
-                // Some static macOS FFmpeg builds report AVFoundation screen
-                // capture as 1000k fps. Clamp output to a normal frame rate so
-                // stop/finalization can complete and the MP4 gets its moov atom.
-                "-r".to_string(),
-                "30".to_string(),
-            ];
-        }
+fn handle_ffmpeg_diagnostic(app: &AppHandle, message: &str) {
+    let message = message.trim();
+    if message.is_empty() {
+        return;
     }
 
-    vec![
-        "-c:v".to_string(),
-        "libx264".to_string(),
-        "-crf".to_string(),
-        "25".to_string(),
-        "-preset".to_string(),
-        "ultrafast".to_string(),
-        "-pix_fmt".to_string(),
-        "yuv420p".to_string(),
-        "-r".to_string(),
-        "30".to_string(),
-    ]
+    log::debug!("[FFmpeg] {}", message);
+    #[cfg(target_os = "macos")]
+    let is_permission_error = macos_ffmpeg_stderr_is_permission_error(message);
+    #[cfg(not(target_os = "macos"))]
+    let is_permission_error = {
+        let lower = message.to_ascii_lowercase();
+        lower.contains("permission denied") || lower.contains("not granted")
+    };
+
+    if is_permission_error {
+        app.emit("recording-error", "ScreenPermissionDenied").ok();
+    } else if ffmpeg_stderr_is_capture_error(message) {
+        app.emit("recording-error", "CaptureError").ok();
+    }
+}
+
+/// Drain FFmpeg stderr for the lifetime of the process. FFmpeg progress uses
+/// carriage returns instead of newlines, so `BufRead::lines` can retain a very
+/// large buffer during long recordings and eventually block the child process.
+fn spawn_ffmpeg_stderr_reader(stderr: std::process::ChildStderr, app: AppHandle) {
+    std::thread::spawn(move || {
+        use std::io::Read;
+
+        let mut stderr = stderr;
+        let mut chunk = [0_u8; 4096];
+        let mut pending = Vec::with_capacity(4096);
+        loop {
+            let read = match stderr.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(read) => read,
+                Err(error) => {
+                    log::debug!("[FFmpeg] stderr reader stopped: {}", error);
+                    break;
+                }
+            };
+
+            for byte in &chunk[..read] {
+                if *byte == b'\n' || *byte == b'\r' {
+                    if !pending.is_empty() {
+                        handle_ffmpeg_diagnostic(&app, &String::from_utf8_lossy(&pending));
+                        pending.clear();
+                    }
+                } else if pending.len() < 32 * 1024 {
+                    pending.push(*byte);
+                } else {
+                    // A diagnostic line should never be this large. Flush the
+                    // bounded prefix so malformed output cannot grow forever.
+                    handle_ffmpeg_diagnostic(&app, &String::from_utf8_lossy(&pending));
+                    pending.clear();
+                }
+            }
+        }
+
+        if !pending.is_empty() {
+            handle_ffmpeg_diagnostic(&app, &String::from_utf8_lossy(&pending));
+        }
+    });
+}
+
+fn verify_capture_process_start(
+    process: &mut std::process::Child,
+    startup_window: std::time::Duration,
+) -> AppResult<()> {
+    let deadline = std::time::Instant::now() + startup_window;
+    loop {
+        match process.try_wait() {
+            Ok(Some(status)) => {
+                return Err(AppError::General(format!(
+                    "FFmpeg exited during capture startup with {}",
+                    status
+                )))
+            }
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            Ok(None) => return Ok(()),
+            Err(error) => {
+                process.kill().ok();
+                process.wait().ok();
+                return Err(AppError::General(format!(
+                    "Could not verify FFmpeg capture startup: {}",
+                    error
+                )))
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RecordingPreferences {
+    fps: u32,
+    encoder: String,
+    capturer: String,
+    quality: String,
+}
+
+fn normalize_recording_quality(quality: Option<&str>) -> &'static str {
+    match quality.unwrap_or_default().to_ascii_lowercase().as_str() {
+        "performance" => "performance",
+        "quality" => "quality",
+        _ => "balanced",
+    }
+}
+
+async fn load_recording_preferences(app: &AppHandle) -> AppResult<RecordingPreferences> {
+    let ffmpeg = find_ffmpeg_path()
+        .ok_or_else(|| AppError::General("FFmpeg binary not found".to_string()))?;
+    let store = app
+        .store("store.json")
+        .map_err(|error| AppError::General(error.to_string()))?;
+
+    let fps = match store.get("screenFps").and_then(|value| value.as_u64()) {
+        Some(60) => 60,
+        _ => 30,
+    };
+    let stored_quality = store
+        .get("recordingQuality")
+        .and_then(|value| value.as_str().map(str::to_owned));
+    let quality = normalize_recording_quality(stored_quality.as_deref());
+    let requested_encoder = store
+        .get("encoder")
+        .and_then(|value| value.as_str().map(str::to_owned));
+    let automatic_encoder = store
+        .get("encoderMode")
+        .and_then(|value| value.as_str().map(|mode| mode != "manual"))
+        .unwrap_or(true);
+    let stored_capturer = store
+        .get("capturer")
+        .and_then(|value| value.as_str().map(str::to_owned));
+    let automatic_capturer = store
+        .get("capturerMode")
+        .and_then(|value| value.as_str().map(|mode| mode != "manual"))
+        .unwrap_or(true);
+    let capturer = crate::commands::encoding::normalize_capturer(if automatic_capturer {
+        None
+    } else {
+        stored_capturer.as_deref()
+    });
+
+    let ffmpeg_for_probe = ffmpeg.clone();
+    let requested_for_probe = if automatic_encoder {
+        None
+    } else {
+        requested_encoder.clone()
+    };
+    let encoder = tokio::task::spawn_blocking(move || {
+        crate::commands::encoding::resolve_recording_encoder(
+            &ffmpeg_for_probe,
+            requested_for_probe.as_deref(),
+            false,
+        )
+    })
+    .await
+    .map_err(|error| AppError::General(format!("Encoder probe failed: {}", error)))?
+    .ok_or_else(|| AppError::General("No usable H.264 recording encoder was found".to_string()))?;
+
+    let preferences = RecordingPreferences {
+        fps,
+        encoder,
+        capturer: capturer.to_string(),
+        quality: quality.to_string(),
+    };
+
+    let mut changed = false;
+    if requested_encoder.as_deref() != Some(preferences.encoder.as_str()) {
+        store.set("encoder", Value::String(preferences.encoder.clone()));
+        changed = true;
+    }
+    if stored_capturer.as_deref() != Some(preferences.capturer.as_str()) {
+        store.set("capturer", Value::String(preferences.capturer.clone()));
+        changed = true;
+    }
+    if store.get("screenFps").and_then(|value| value.as_u64()) != Some(fps as u64) {
+        store.set("screenFps", Value::from(fps));
+        changed = true;
+    }
+    if stored_quality.as_deref() != Some(preferences.quality.as_str()) {
+        store.set(
+            "recordingQuality",
+            Value::String(preferences.quality.clone()),
+        );
+        changed = true;
+    }
+    if changed {
+        store
+            .save()
+            .map_err(|error| AppError::General(error.to_string()))?;
+    }
+
+    Ok(preferences)
+}
+
+fn target_video_bitrate_kbps(width: u32, height: u32, fps: u32, quality: &str) -> u32 {
+    let pixels = (width.max(16) as f64) * (height.max(16) as f64);
+    let resolution_scale = pixels / (1920.0 * 1080.0);
+    let frame_rate_scale = if fps >= 60 { 1.5 } else { 1.0 };
+    let quality_scale = match quality {
+        "performance" => 0.7,
+        "quality" => 1.45,
+        _ => 1.0,
+    };
+
+    (9000.0 * resolution_scale * frame_rate_scale * quality_scale)
+        .round()
+        .clamp(3_000.0, 60_000.0) as u32
+}
+
+fn estimated_recording_dimensions(
+    source: &Value,
+    source_type: &str,
+    fallback_width: u32,
+    fallback_height: u32,
+) -> (u32, u32) {
+    let positive_u32 = |key: &str| {
+        source
+            .get(key)
+            .and_then(|value| value.as_u64())
+            .and_then(|value| u32::try_from(value).ok())
+            .filter(|value| *value > 0)
+    };
+
+    let (width, height) = match source_type {
+        "window" => (
+            positive_u32("width").unwrap_or(fallback_width),
+            positive_u32("height").unwrap_or(fallback_height),
+        ),
+        "area" => {
+            let width_percent = source
+                .get("width")
+                .and_then(|value| value.as_f64())
+                .unwrap_or(100.0)
+                .clamp(1.0, 100.0);
+            let height_percent = source
+                .get("height")
+                .and_then(|value| value.as_f64())
+                .unwrap_or(100.0)
+                .clamp(1.0, 100.0);
+            (
+                ((fallback_width as f64) * width_percent / 100.0).round() as u32,
+                ((fallback_height as f64) * height_percent / 100.0).round() as u32,
+            )
+        }
+        _ => (
+            positive_u32("physicalWidth")
+                .or_else(|| positive_u32("monitorWidth"))
+                .unwrap_or(fallback_width),
+            positive_u32("physicalHeight")
+                .or_else(|| positive_u32("monitorHeight"))
+                .unwrap_or(fallback_height),
+        ),
+    };
+
+    // Every supported H.264 path requires even dimensions.
+    ((width.max(16) & !1), (height.max(16) & !1))
+}
+
+fn recording_video_output_args(
+    encoder: &str,
+    fps: u32,
+    width: u32,
+    height: u32,
+    quality: &str,
+    qsv_zero_copy: bool,
+) -> Vec<String> {
+    let mut args = vec!["-c:v".to_string(), encoder.to_string()];
+    let bitrate = target_video_bitrate_kbps(width, height, fps, quality);
+    let max_rate = ((bitrate as f64) * 1.25).round() as u32;
+    let buffer_size = bitrate.saturating_mul(2);
+
+    match encoder {
+        "libx264" => {
+            let (crf, preset) = match quality {
+                "performance" => ("28", "ultrafast"),
+                "quality" => ("20", "veryfast"),
+                _ => ("24", "superfast"),
+            };
+            args.extend([
+                "-crf".to_string(),
+                crf.to_string(),
+                "-preset".to_string(),
+                preset.to_string(),
+            ]);
+        }
+        "h264_videotoolbox" => args.extend([
+            "-b:v".to_string(),
+            format!("{}k", bitrate),
+            "-maxrate".to_string(),
+            format!("{}k", max_rate),
+            "-bufsize".to_string(),
+            format!("{}k", buffer_size),
+            "-allow_sw".to_string(),
+            "1".to_string(),
+            "-realtime".to_string(),
+            "1".to_string(),
+        ]),
+        "h264_qsv" => {
+            let (preset, async_depth) = match quality {
+                "performance" => ("veryfast", "1"),
+                "quality" => ("medium", "2"),
+                _ => ("veryfast", "2"),
+            };
+            args.extend([
+                "-b:v".to_string(),
+                format!("{}k", bitrate),
+                "-maxrate".to_string(),
+                format!("{}k", max_rate),
+                "-bufsize".to_string(),
+                format!("{}k", buffer_size),
+                "-preset".to_string(),
+                preset.to_string(),
+                "-async_depth".to_string(),
+                async_depth.to_string(),
+            ]);
+            if quality == "performance" {
+                args.extend(["-bf".to_string(), "0".to_string()]);
+            }
+        }
+        _ => args.extend([
+            "-b:v".to_string(),
+            format!("{}k", bitrate),
+            "-maxrate".to_string(),
+            format!("{}k", max_rate),
+            "-bufsize".to_string(),
+            format!("{}k", buffer_size),
+        ]),
+    }
+
+    if let Some(pixel_format) = recording_pixel_format(encoder, qsv_zero_copy) {
+        args.extend(["-pix_fmt".to_string(), pixel_format.to_string()]);
+    }
+    args.extend(["-r".to_string(), fps.to_string()]);
+    args
+}
+
+fn recording_pixel_format(encoder: &str, qsv_zero_copy: bool) -> Option<&'static str> {
+    match encoder {
+        "libx264" => Some("yuv420p"),
+        "h264_videotoolbox" => Some("nv12"),
+        // The mapped D3D11 path must remain a QSV hardware surface. GDI and
+        // other system-memory inputs must keep negotiating NV12 themselves.
+        "h264_qsv" if qsv_zero_copy => Some("qsv"),
+        "h264_qsv" => None,
+        // NVENC/AMF may receive D3D11 hardware frames directly. Forcing a
+        // software pixel format there makes FFmpeg insert an invalid transfer.
+        "h264_nvenc" | "h264_amf" => None,
+        _ => Some("yuv420p"),
+    }
+}
+
+/// Append output-only options after every input. FFmpeg applies options to the
+/// next file, so placing filters before the optional audio input makes `-vf`
+/// target that input and causes startup to fail.
+struct RecordingOutputConfig<'a> {
+    video_filters: &'a [String],
+    encoder: &'a str,
+    fps: u32,
+    width: u32,
+    height: u32,
+    quality: &'a str,
+    has_system_audio: bool,
+    stop_on_video_eof: bool,
+}
+
+fn append_recording_output_args(
+    args: &mut Vec<String>,
+    config: RecordingOutputConfig<'_>,
+) {
+    let RecordingOutputConfig {
+        video_filters,
+        encoder,
+        fps,
+        width,
+        height,
+        quality,
+        has_system_audio,
+        stop_on_video_eof,
+    } = config;
+
+    let qsv_zero_copy = encoder == "h264_qsv"
+        && video_filters
+            .iter()
+            .any(|filter| filter == "hwmap=derive_device=qsv:mode=read+write+direct");
+
+    if !video_filters.is_empty() {
+        args.extend(["-vf".to_string(), video_filters.join(",")]);
+    }
+
+    args.extend(["-map".to_string(), "0:v:0".to_string()]);
+    if has_system_audio {
+        args.extend([
+            "-map".to_string(),
+            "1:a:0".to_string(),
+            "-af".to_string(),
+            if stop_on_video_eof {
+                "aresample=async=1000:first_pts=0,apad".to_string()
+            } else {
+                "aresample=async=1000:first_pts=0".to_string()
+            },
+        ]);
+    }
+
+    args.extend(recording_video_output_args(
+        encoder,
+        fps,
+        width,
+        height,
+        quality,
+        qsv_zero_copy,
+    ));
+    if has_system_audio {
+        let audio_bitrate = match quality {
+            "performance" => "128k",
+            "quality" => "256k",
+            _ => "192k",
+        };
+        args.extend([
+            "-c:a".to_string(),
+            "aac".to_string(),
+            "-b:a".to_string(),
+            audio_bitrate.to_string(),
+            "-ar".to_string(),
+            "48000".to_string(),
+            "-ac".to_string(),
+            "2".to_string(),
+        ]);
+        if stop_on_video_eof {
+            args.push("-shortest".to_string());
+        }
+    } else {
+        args.push("-an".to_string());
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn ddagrab_transfer_filter(encoder: &str) -> Option<&'static str> {
+    match encoder {
+        "h264_nvenc" | "h264_amf" => None,
+        // Keep DXGI frames in video memory. This avoids a full-resolution BGRA
+        // download followed by another QSV upload for every frame.
+        "h264_qsv" => Some("hwmap=derive_device=qsv:mode=read+write+direct"),
+        _ => Some("hwdownload,format=bgra"),
+    }
 }
 
 /// Detect the avfoundation device index for screen capture on macOS.
 /// Camera devices come first (e.g. [0] FaceTime HD Camera), then screens (e.g. [1] Capture screen 0).
 /// Returns the device index for the requested monitor, falling back to first screen device.
 #[cfg(target_os = "macos")]
-fn macos_screen_device_index(monitor_index: i64) -> i64 {
+pub(crate) fn macos_screen_device_index(monitor_index: i64) -> i64 {
     if let Some(ffmpeg) = find_ffmpeg_path() {
         if let Ok(output) = std::process::Command::new(&ffmpeg)
             .args(["-f", "avfoundation", "-list_devices", "true", "-i", ""])
@@ -415,26 +809,29 @@ fn capture_window_frame(hwnd_raw: isize, width: i32, height: i32, buffer: &mut [
 }
 
 /// Capture loop for window recording. Runs in a dedicated thread.
-/// Captures frames using PrintWindow at ~30fps and writes raw BGRA to FFmpeg stdin.
+/// Captures frames using PrintWindow at the configured rate and writes raw BGRA to FFmpeg stdin.
 #[cfg(target_os = "windows")]
 fn window_capture_loop(
     hwnd: isize,
     width: i32,
     height: i32,
+    fps: u32,
     mut stdin: std::process::ChildStdin,
     stop_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) {
     use std::io::Write;
 
-    let frame_duration = std::time::Duration::from_nanos(1_000_000_000 / 30); // ~33ms for 30fps
+    let fps = fps.clamp(1, 120);
+    let frame_duration = std::time::Duration::from_secs_f64(1.0 / fps as f64);
     let buf_size = (width * height * 4) as usize;
     let mut frame_buffer = vec![0u8; buf_size];
 
     log::info!(
-        "[capture_loop] Starting window capture: hwnd={} {}x{}",
+        "[capture_loop] Starting window capture: hwnd={} {}x{} at {} fps",
         hwnd,
         width,
-        height
+        height,
+        fps
     );
 
     while !stop_flag.load(Ordering::Relaxed) {
@@ -557,8 +954,65 @@ fn screenshot_window_printwindow(hwnd_raw: isize, width: i32, height: i32) -> Op
     }
 }
 
+fn close_camera_file_handle(state: &mut AppState) {
+    if let Some(mut file) = state.camera_file_handle.take() {
+        use std::io::Write;
+        if let Err(error) = file.flush() {
+            log::warn!("Failed to flush camera/microphone capture file: {}", error);
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn init_recording(
+    app: AppHandle,
+    source: Value,
+    camera_mic_config: Value,
+    system_audio: Value,
+    mode: Option<String>,
+) -> AppResult<()> {
+    {
+        let state = app.state::<Mutex<AppState>>();
+        let mut state = state.lock().unwrap();
+        if recording_init_is_blocked(&state) {
+            return Err(AppError::General(
+                "A recording session is already active, changing state, or waiting to be saved or discarded."
+                    .to_string(),
+            ));
+        }
+        state.recording_init_in_progress = true;
+    }
+
+    let result =
+        init_recording_impl(app.clone(), source, camera_mic_config, system_audio, mode).await;
+
+    let failed_recording_id = {
+        let state = app.state::<Mutex<AppState>>();
+        let mut state = state.lock().unwrap();
+        state.recording_init_in_progress = false;
+        if result.is_err() {
+            state.is_recording = false;
+            state.recording_capture_claimed = false;
+            state.recording_stop_in_progress = false;
+            state.project_id = None;
+            state.camera_mic_config = None;
+            close_camera_file_handle(&mut state);
+            state.recording_id.take()
+        } else {
+            None
+        }
+    };
+
+    if let Some(recording_id) = failed_recording_id {
+        let state = app.state::<Mutex<AppState>>();
+        let temp_dir = state.lock().unwrap().project_temp_dir(&recording_id);
+        std::fs::remove_dir_all(temp_dir).ok();
+    }
+
+    result
+}
+
+async fn init_recording_impl(
     app: AppHandle,
     source: Value,
     camera_mic_config: Value,
@@ -582,6 +1036,29 @@ pub async fn init_recording(
         return open_live_overlay(app, source).await;
     }
 
+    // Resolve persisted recorder settings before mutating recording state. The
+    // encoder is tested with a real one-frame encode so a compiled-but-missing
+    // GPU runtime cannot make the recording fail after the countdown.
+    let preferences = load_recording_preferences(&app).await?;
+    let fps = preferences.fps;
+    let encoder = preferences.encoder;
+    let capturer = preferences.capturer;
+    let quality = preferences.quality;
+    let has_system_audio = match &system_audio {
+        Value::String(device) => !device.is_empty(),
+        Value::Bool(enabled) => *enabled,
+        _ => false,
+    };
+
+    log::info!(
+        "[recording] preferences: {} fps, encoder={}, capturer={}, quality={}, system_audio={}",
+        fps,
+        encoder,
+        capturer,
+        quality,
+        has_system_audio
+    );
+
     let state = app.state::<Mutex<AppState>>();
 
     // Create new recording ID and project temp dir
@@ -590,10 +1067,22 @@ pub async fn init_recording(
 
     {
         let mut state = state.lock().unwrap();
+        if state.is_recording {
+            return Err(AppError::General(
+                "A recording is already being initialized or captured.".to_string(),
+            ));
+        }
         state.is_recording = true;
+        state.recording_capture_claimed = false;
+        state.recording_stop_in_progress = false;
         state.project_id = Some(project_id.clone());
         state.recording_id = Some(recording_id.clone());
         state.camera_mic_config = Some(camera_mic_config.clone());
+        state.multi_app_children.clear();
+        state.multi_app_tracks.clear();
+        state.multi_app_init_in_progress = false;
+        state.multi_app_stop_requested = false;
+        state.multi_app_finalize_error = None;
 
         let temp_dir = state.project_temp_dir(&recording_id);
         std::fs::create_dir_all(&temp_dir)?;
@@ -614,6 +1103,21 @@ pub async fn init_recording(
         .and_then(|v| v.as_str())
         .unwrap_or("screen");
 
+    let fallback_dimensions = app
+        .get_webview_window("main")
+        .and_then(|window| window.current_monitor().ok().flatten())
+        .map(|monitor| {
+            let size = monitor.size();
+            (size.width, size.height)
+        })
+        .unwrap_or((1920, 1080));
+    let (recording_width, recording_height) = estimated_recording_dimensions(
+        &source,
+        source_type,
+        fallback_dimensions.0,
+        fallback_dimensions.1,
+    );
+
     // For window capture, we use a custom PrintWindow pipeline instead of gdigrab
     let is_window_capture = source_type == "window";
 
@@ -630,6 +1134,7 @@ pub async fn init_recording(
     }
 
     let mut ffmpeg_args: Vec<String> = Vec::new();
+    let mut video_filters: Vec<String> = Vec::new();
     let (recording_offset_x, recording_offset_y): (i64, i64);
 
     if is_window_capture {
@@ -670,7 +1175,7 @@ pub async fn init_recording(
                 "-video_size".to_string(),
                 format!("{}x{}", w, h),
                 "-framerate".to_string(),
-                "30".to_string(),
+                fps.to_string(),
                 "-i".to_string(),
                 "pipe:0".to_string(),
             ];
@@ -693,16 +1198,15 @@ pub async fn init_recording(
                 "-f".to_string(),
                 "avfoundation".to_string(),
                 "-framerate".to_string(),
-                "30".to_string(),
+                fps.to_string(),
                 "-pixel_format".to_string(),
                 "nv12".to_string(),
                 "-capture_cursor".to_string(),
                 "0".to_string(),
                 "-i".to_string(),
                 format!("{}:none", screen_dev),
-                "-vf".to_string(),
-                format!("crop={}:{}:{}:{}", w, h, x, y),
             ];
+            video_filters.push(format!("crop={}:{}:{}:{}", w, h, x, y));
         }
 
         #[cfg(target_os = "linux")]
@@ -723,7 +1227,7 @@ pub async fn init_recording(
                 "-f".to_string(),
                 "x11grab".to_string(),
                 "-framerate".to_string(),
-                "30".to_string(),
+                fps.to_string(),
                 "-draw_mouse".to_string(),
                 "0".to_string(),
                 "-video_size".to_string(),
@@ -753,7 +1257,7 @@ pub async fn init_recording(
                 "-f".to_string(),
                 capture_format.to_string(),
                 "-framerate".to_string(),
-                "30".to_string(),
+                fps.to_string(),
             ]);
         }
 
@@ -805,21 +1309,41 @@ pub async fn init_recording(
                     // so we pass them straight through as offset_x/offset_y/video_size.
                     // Note: ddagrab cannot capture across monitor boundaries — the area UI
                     // clamps to a single monitor, so this isn't a regression.
-                    let monitor_idx = source
-                        .get("monitorIndex")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-                    ffmpeg_args.extend([
-                        "-f".to_string(),
-                        "lavfi".to_string(),
-                        "-i".to_string(),
-                        format!(
-                            "ddagrab=output_idx={}:framerate=30:draw_mouse=0:offset_x={}:offset_y={}:video_size={}x{}",
-                            monitor_idx, x, y, width, height
-                        ),
-                        "-vf".to_string(),
-                        "hwdownload,format=bgra".to_string(),
-                    ]);
+                    if capturer == "gdigrab" {
+                        ffmpeg_args.extend([
+                            "-f".to_string(),
+                            "gdigrab".to_string(),
+                            "-framerate".to_string(),
+                            fps.to_string(),
+                            "-draw_mouse".to_string(),
+                            "0".to_string(),
+                            "-offset_x".to_string(),
+                            x.to_string(),
+                            "-offset_y".to_string(),
+                            y.to_string(),
+                            "-video_size".to_string(),
+                            format!("{}x{}", width, height),
+                            "-i".to_string(),
+                            "desktop".to_string(),
+                        ]);
+                    } else {
+                        let monitor_idx = source
+                            .get("monitorIndex")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0);
+                        ffmpeg_args.extend([
+                            "-f".to_string(),
+                            "lavfi".to_string(),
+                            "-i".to_string(),
+                            format!(
+                                "ddagrab=output_idx={}:framerate={}:draw_mouse=0:offset_x={}:offset_y={}:video_size={}x{}",
+                                monitor_idx, fps, x, y, width, height
+                            ),
+                        ]);
+                        if let Some(filter) = ddagrab_transfer_filter(&encoder) {
+                            video_filters.push(filter.to_string());
+                        }
+                    }
                 }
                 #[cfg(target_os = "macos")]
                 {
@@ -832,9 +1356,8 @@ pub async fn init_recording(
                         "0".to_string(),
                         "-i".to_string(),
                         format!("{}:none", screen_dev),
-                        "-vf".to_string(),
-                        format!("crop={}:{}:{}:{}", width, height, x, y),
                     ]);
+                    video_filters.push(format!("crop={}:{}:{}:{}", width, height, x, y));
                 }
                 #[cfg(target_os = "linux")]
                 {
@@ -887,46 +1410,68 @@ pub async fn init_recording(
 
                 #[cfg(target_os = "windows")]
                 {
-                    // ddagrab captures one DXGI output at a time. Pick the monitor via
-                    // output_idx; offsets are relative to that output, so for a whole-
-                    // monitor capture they're (0, 0).
-                    let monitor_idx = source
-                        .get("monitorIndex")
-                        .and_then(|v| v.as_i64())
-                        .unwrap_or(0);
-
-                    let mut filter = format!(
-                        "ddagrab=output_idx={}:framerate=30:draw_mouse=0",
-                        monitor_idx
-                    );
-                    if let (Some(w), Some(h)) = (monitor_w, monitor_h) {
-                        let w = (w - (w % 2)).max(2);
-                        let h = (h - (h % 2)).max(2);
-                        log::info!(
-                            "[recording] monitor capture (ddagrab): idx={} w={} h={}",
-                            monitor_idx,
-                            w,
-                            h
-                        );
-                        filter.push_str(&format!(":video_size={}x{}", w, h));
+                    if capturer == "gdigrab" {
+                        ffmpeg_args.extend([
+                            "-f".to_string(),
+                            "gdigrab".to_string(),
+                            "-framerate".to_string(),
+                            fps.to_string(),
+                            "-draw_mouse".to_string(),
+                            "0".to_string(),
+                            "-offset_x".to_string(),
+                            monitor_x.to_string(),
+                            "-offset_y".to_string(),
+                            monitor_y.to_string(),
+                        ]);
+                        if let (Some(w), Some(h)) = (monitor_w, monitor_h) {
+                            let w = (w - (w % 2)).max(2);
+                            let h = (h - (h % 2)).max(2);
+                            ffmpeg_args.extend(["-video_size".to_string(), format!("{}x{}", w, h)]);
+                        }
+                        ffmpeg_args.extend(["-i".to_string(), "desktop".to_string()]);
                     } else {
-                        log::info!(
-                            "[recording] monitor capture (ddagrab): idx={} (native size)",
-                            monitor_idx
-                        );
-                    }
-                    // monitor_x/monitor_y are virtual-desktop coordinates — intentionally
-                    // unused here because ddagrab is per-output.
-                    let _ = (monitor_x, monitor_y);
+                        // ddagrab captures one DXGI output at a time. Pick the monitor via
+                        // output_idx; offsets are relative to that output, so for a whole-
+                        // monitor capture they're (0, 0).
+                        let monitor_idx = source
+                            .get("monitorIndex")
+                            .and_then(|v| v.as_i64())
+                            .unwrap_or(0);
 
-                    ffmpeg_args.extend([
-                        "-f".to_string(),
-                        "lavfi".to_string(),
-                        "-i".to_string(),
-                        filter,
-                        "-vf".to_string(),
-                        "hwdownload,format=bgra".to_string(),
-                    ]);
+                        let mut filter = format!(
+                            "ddagrab=output_idx={}:framerate={}:draw_mouse=0",
+                            monitor_idx, fps
+                        );
+                        if let (Some(w), Some(h)) = (monitor_w, monitor_h) {
+                            let w = (w - (w % 2)).max(2);
+                            let h = (h - (h % 2)).max(2);
+                            log::info!(
+                                "[recording] monitor capture (ddagrab): idx={} w={} h={}",
+                                monitor_idx,
+                                w,
+                                h
+                            );
+                            filter.push_str(&format!(":video_size={}x{}", w, h));
+                        } else {
+                            log::info!(
+                                "[recording] monitor capture (ddagrab): idx={} (native size)",
+                                monitor_idx
+                            );
+                        }
+                        // monitor_x/monitor_y are virtual-desktop coordinates — intentionally
+                        // unused here because ddagrab is per-output.
+                        let _ = (monitor_x, monitor_y);
+
+                        ffmpeg_args.extend([
+                            "-f".to_string(),
+                            "lavfi".to_string(),
+                            "-i".to_string(),
+                            filter,
+                        ]);
+                        if let Some(filter) = ddagrab_transfer_filter(&encoder) {
+                            video_filters.push(filter.to_string());
+                        }
+                    }
                 }
                 #[cfg(target_os = "macos")]
                 {
@@ -945,17 +1490,10 @@ pub async fn init_recording(
                         "-i".to_string(),
                         format!("{}:none", screen_dev),
                     ]);
-                    // Crop if specific monitor region
-                    if let (Some(w), Some(h)) = (monitor_w, monitor_h) {
-                        let w = (w - (w % 2)).max(2);
-                        let h = (h - (h % 2)).max(2);
-                        if monitor_x != 0 || monitor_y != 0 {
-                            ffmpeg_args.extend([
-                                "-vf".to_string(),
-                                format!("crop={}:{}:{}:{}", w, h, monitor_x, monitor_y),
-                            ]);
-                        }
-                    }
+                    // Each AVFoundation screen device is already local to the
+                    // selected display. Applying virtual-desktop x/y offsets a
+                    // second time makes secondary-display capture out of bounds.
+                    let _ = (monitor_x, monitor_y, monitor_w, monitor_h);
                 }
                 #[cfg(target_os = "linux")]
                 {
@@ -989,30 +1527,37 @@ pub async fn init_recording(
         recording_offset_y = oy;
     }
 
-    // Add system audio capture if requested (screen/area capture only)
-    if !is_window_capture {
-        let has_system_audio = match &system_audio {
-            Value::String(s) if !s.is_empty() => true,
-            Value::Bool(b) => *b,
-            _ => false,
+    // Add every input before any output/filter option. This also enables
+    // system audio for window recordings, where the video arrives on stdin.
+    if has_system_audio {
+        let audio_device = match &system_audio {
+            Value::String(device) => device.clone(),
+            _ => platform_default_audio_device(),
         };
-        if has_system_audio {
-            let audio_device = match &system_audio {
-                Value::String(s) => s.clone(),
-                _ => platform_default_audio_device(),
-            };
-            let (audio_format, audio_input) = platform_audio_capture_args(&audio_device);
-            ffmpeg_args.extend([
-                "-f".to_string(),
-                audio_format,
-                "-i".to_string(),
-                audio_input,
-            ]);
-        }
+        let (audio_format, audio_input) = platform_audio_capture_args(&audio_device);
+        ffmpeg_args.extend([
+            "-thread_queue_size".to_string(),
+            "512".to_string(),
+            "-f".to_string(),
+            audio_format,
+            "-i".to_string(),
+            audio_input,
+        ]);
     }
 
-    // Output settings
-    ffmpeg_args.extend(recording_video_output_args());
+    append_recording_output_args(
+        &mut ffmpeg_args,
+        RecordingOutputConfig {
+            video_filters: &video_filters,
+            encoder: &encoder,
+            fps,
+            width: recording_width,
+            height: recording_height,
+            quality: &quality,
+            has_system_audio,
+            stop_on_video_eof: is_window_capture && cfg!(target_os = "windows"),
+        },
+    );
     ffmpeg_args.push(screen_video_path);
 
     // Store config for start_recording
@@ -1035,6 +1580,11 @@ pub async fn init_recording(
             "isWindowCapture": is_window_capture,
             "sourceType": source_type,
             "source": source,
+            "fps": fps,
+            "encoder": encoder,
+            "capturer": capturer,
+            "quality": quality,
+            "hasSystemAudio": has_system_audio,
         });
 
         // Store window handle info for the capture thread
@@ -1200,8 +1750,160 @@ async fn open_live_overlay(app: AppHandle, source: Value) -> AppResult<()> {
     Ok(())
 }
 
+fn try_claim_recording_capture(state: &mut AppState) -> bool {
+    if state.recording_capture_claimed {
+        return false;
+    }
+    state.recording_capture_claimed = true;
+    true
+}
+
+fn recording_init_is_blocked(state: &AppState) -> bool {
+    state.is_recording
+        || state.recording_init_in_progress
+        || state.recording_stop_in_progress
+        // A failed save deliberately keeps recording_id as its retry token.
+        // A new take must not overwrite the IDs and orphan those staged files.
+        || state.recording_id.is_some()
+}
+
+fn recording_start_prerequisites_met(state: &AppState) -> bool {
+    let has_ffmpeg_args = state
+        .camera_mic_config
+        .as_ref()
+        .and_then(|config| config.get("ffmpegArgs"))
+        .and_then(|args| args.as_array())
+        .map(|args| !args.is_empty())
+        .unwrap_or(false);
+
+    state.is_recording
+        && !state.recording_init_in_progress
+        && !state.recording_stop_in_progress
+        && state.recording_id.is_some()
+        && has_ffmpeg_args
+}
+
+fn try_begin_recording_stop(state: &mut AppState) -> bool {
+    // After FFmpeg has stopped, project packaging may still fail (disk full,
+    // store write, temporarily locked destination, and so on). Keep the same
+    // recording identifiers as a retry token until the complete save commits.
+    let has_pending_save =
+        !state.is_recording && state.recording_id.is_some() && state.project_id.is_some();
+    if state.recording_stop_in_progress
+        || (!state.is_recording
+            && state.ffmpeg_process.is_none()
+            && state.ffmpeg_child_id.is_none()
+            && !has_pending_save)
+    {
+        return false;
+    }
+
+    state.recording_stop_in_progress = true;
+    state.recording_capture_claimed = false;
+    state.is_recording = false;
+    true
+}
+
+fn clear_failed_recording_start(state: &mut AppState) -> Vec<std::path::PathBuf> {
+    state.is_recording = false;
+    state.recording_capture_claimed = false;
+    state.recording_start_timestamp = None;
+    state.camera_mic_config = None;
+    state.ffmpeg_child_id = None;
+    state.ffmpeg_child = None;
+    state.ffmpeg_process = None;
+    state.multi_app_tracks.clear();
+    state.multi_app_init_in_progress = false;
+    state.multi_app_stop_requested = false;
+    state.multi_app_finalize_error = None;
+    state.file_handles.clear();
+    close_camera_file_handle(state);
+
+    let recording_id = state.recording_id.take();
+    let project_id = state.project_id.take();
+    let mut directories = Vec::with_capacity(2);
+    for id in [recording_id, project_id].into_iter().flatten() {
+        let path = state.project_temp_dir(&id);
+        if !directories.contains(&path) {
+            directories.push(path);
+        }
+    }
+    directories
+}
+
 #[tauri::command]
 pub async fn start_recording(app: AppHandle) -> AppResult<()> {
+    let claim_result = {
+        let state = app.state::<Mutex<AppState>>();
+        let mut state = state.lock().unwrap();
+        if !recording_start_prerequisites_met(&state) {
+            Err(AppError::General(
+                "Recording must be initialized before capture starts.".to_string(),
+            ))
+        } else {
+            Ok(try_claim_recording_capture(&mut state))
+        }
+    };
+
+    let claimed = claim_result?;
+
+    if !claimed {
+        log::warn!("[start_recording] Ignoring duplicate start command");
+        return Ok(());
+    }
+
+    let result = start_recording_impl(app.clone()).await;
+    if result.is_err() {
+        let state = app.state::<Mutex<AppState>>();
+        let should_rollback = {
+            let mut state = state.lock().unwrap();
+            state.recording_capture_claimed = false;
+            !state.recording_stop_in_progress
+        };
+
+        // A spawn/configuration error happens after init_recording has claimed
+        // the session and created the recorder window. Fully unwind that state
+        // so the user can immediately try again. A concurrent stop/cancel owns
+        // its own cleanup and must not be raced here.
+        if should_rollback {
+            tokio::task::spawn_blocking({
+                let app = app.clone();
+                move || kill_ffmpeg(&app)
+            })
+            .await
+            .ok();
+            crate::commands::audio::unmute_all_sessions(&app);
+
+            let directories = {
+                let mut state = state.lock().unwrap();
+                clear_failed_recording_start(&mut state)
+            };
+            for directory in directories {
+                if directory.exists() {
+                    if let Err(error) = std::fs::remove_dir_all(&directory) {
+                        log::warn!(
+                            "[start_recording] Could not remove failed session {:?}: {}",
+                            directory,
+                            error
+                        );
+                    }
+                }
+            }
+
+            if let Some(recorder) = app.get_webview_window("recorder") {
+                recorder.close().ok();
+            }
+            if let Some(main) = app.get_webview_window("main") {
+                main.unminimize().ok();
+                main.show().ok();
+                main.set_focus().ok();
+            }
+        }
+    }
+    result
+}
+
+async fn start_recording_impl(app: AppHandle) -> AppResult<()> {
     #[cfg(target_os = "macos")]
     crate::mouse_tracker::restore_macos_cursor();
 
@@ -1209,7 +1911,7 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
 
     // Get config from stored state
     #[allow(unused_variables)]
-    let (ffmpeg_args, is_window_capture, window_hwnd, window_width, window_height) = {
+    let (ffmpeg_args, is_window_capture, window_hwnd, window_width, window_height, fps) = {
         let state = state.lock().unwrap();
         let config = state.camera_mic_config.as_ref();
         let args = config
@@ -1237,7 +1939,12 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
             .and_then(|c| c.get("windowHeight"))
             .and_then(|v| v.as_i64())
             .unwrap_or(1080) as i32;
-        (args, is_win, hwnd, ww, wh)
+        let fps = config
+            .and_then(|c| c.get("fps"))
+            .and_then(|v| v.as_u64())
+            .filter(|fps| *fps == 30 || *fps == 60)
+            .unwrap_or(30) as u32;
+        (args, is_win, hwnd, ww, wh, fps)
     };
 
     if let Some(args) = ffmpeg_args {
@@ -1276,13 +1983,26 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
             let mut process = cmd
                 .spawn()
                 .map_err(|e| AppError::General(format!("Failed to spawn FFmpeg: {}", e)))?;
+            crate::process_containment::contain_owned_child(&process, "window-capture FFmpeg");
 
             let pid = process.id();
             let stdin = process.stdin.take().unwrap();
+            if let Some(stderr) = process.stderr.take() {
+                spawn_ffmpeg_stderr_reader(stderr, app.clone());
+            }
+            verify_capture_process_start(&mut process, std::time::Duration::from_millis(200))?;
 
             // Reset stop flag and start capture thread
             let stop_flag = {
                 let mut state = state.lock().unwrap();
+                if !state.recording_capture_claimed || !state.is_recording {
+                    drop(state);
+                    process.kill().ok();
+                    process.wait().ok();
+                    return Err(AppError::General(
+                        "Recording start was canceled before capture began.".to_string(),
+                    ));
+                }
                 state.window_capture_stop.store(false, Ordering::Relaxed);
                 state.ffmpeg_child_id = Some(pid);
                 state.ffmpeg_process = Some(process);
@@ -1297,7 +2017,7 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
 
             #[cfg(target_os = "windows")]
             let capture_thread = std::thread::spawn(move || {
-                window_capture_loop(window_hwnd, w, h, stdin, stop_flag);
+                window_capture_loop(window_hwnd, w, h, fps, stdin, stop_flag);
             });
 
             // On macOS/Linux, window capture via stdin pipe is not yet supported;
@@ -1347,39 +2067,28 @@ pub async fn start_recording(app: AppHandle) -> AppResult<()> {
 
             match cmd.spawn() {
                 Ok(mut process) => {
+                    crate::process_containment::contain_owned_child(
+                        &process,
+                        "screen-capture FFmpeg",
+                    );
                     let pid = process.id();
-                    let stderr = process.stderr.take();
-                    let app_clone = app.clone();
-                    if let Some(stderr) = stderr {
-                        std::thread::spawn(move || {
-                            use std::io::BufRead;
-                            let reader = std::io::BufReader::new(stderr);
-                            for line in reader.lines() {
-                                match line {
-                                    Ok(msg) => {
-                                        log::info!("[FFmpeg] {}", msg);
-                                        #[cfg(target_os = "macos")]
-                                        let is_permission_error =
-                                            macos_ffmpeg_stderr_is_permission_error(&msg);
-                                        #[cfg(not(target_os = "macos"))]
-                                        let is_permission_error = msg.contains("Permission denied")
-                                            || msg.contains("not granted");
-
-                                        if is_permission_error {
-                                            app_clone
-                                                .emit("recording-error", "ScreenPermissionDenied")
-                                                .ok();
-                                        } else if ffmpeg_stderr_is_capture_error(&msg) {
-                                            app_clone.emit("recording-error", "CaptureError").ok();
-                                        }
-                                    }
-                                    Err(_) => break,
-                                }
-                            }
-                        });
+                    if let Some(stderr) = process.stderr.take() {
+                        spawn_ffmpeg_stderr_reader(stderr, app.clone());
                     }
+                    verify_capture_process_start(
+                        &mut process,
+                        std::time::Duration::from_millis(200),
+                    )?;
                     {
                         let mut state = state.lock().unwrap();
+                        if !state.recording_capture_claimed || !state.is_recording {
+                            drop(state);
+                            process.kill().ok();
+                            process.wait().ok();
+                            return Err(AppError::General(
+                                "Recording start was canceled before capture began.".to_string(),
+                            ));
+                        }
                         state.ffmpeg_child_id = Some(pid);
                         state.ffmpeg_process = Some(process);
                     }
@@ -1453,8 +2162,278 @@ pub async fn pause_recording(app: AppHandle, pause: bool) -> AppResult<()> {
     Ok(())
 }
 
+#[derive(Clone, Debug)]
+struct ProjectArchiveEntry {
+    archive_name: String,
+    source_path: std::path::PathBuf,
+}
+
+fn recording_save_error(stage: &str, error: impl std::fmt::Display) -> AppError {
+    AppError::General(format!("Recording save failed while {}: {}", stage, error))
+}
+
+fn ensure_non_empty_recording_file(path: &std::path::Path, description: &str) -> AppResult<u64> {
+    let metadata = path
+        .metadata()
+        .map_err(|error| recording_save_error(&format!("checking {}", description), error))?;
+    if !metadata.is_file() || metadata.len() == 0 {
+        return Err(recording_save_error(
+            &format!("checking {}", description),
+            "the file is missing or empty",
+        ));
+    }
+    Ok(metadata.len())
+}
+
+fn move_or_copy_recording_file(
+    source: &std::path::Path,
+    destination: &std::path::Path,
+    description: &str,
+) -> AppResult<()> {
+    if source == destination {
+        ensure_non_empty_recording_file(destination, description)?;
+        return Ok(());
+    }
+
+    let expected_size = ensure_non_empty_recording_file(source, description)?;
+    if let Err(rename_error) = std::fs::rename(source, destination) {
+        log::warn!(
+            "[stop_recording] Could not move {} ({}); falling back to copy",
+            description,
+            rename_error
+        );
+        let copied = std::fs::copy(source, destination).map_err(|copy_error| {
+            recording_save_error(
+                &format!("copying {} into the project", description),
+                format!("{} (move also failed: {})", copy_error, rename_error),
+            )
+        })?;
+        if copied != expected_size {
+            return Err(recording_save_error(
+                &format!("copying {} into the project", description),
+                format!("copied {} of {} bytes", copied, expected_size),
+            ));
+        }
+        if let Err(error) = std::fs::remove_file(source) {
+            log::warn!(
+                "[stop_recording] Saved {} but could not remove source {:?}: {}",
+                description,
+                source,
+                error
+            );
+        }
+    }
+
+    let saved_size = ensure_non_empty_recording_file(destination, description)?;
+    if saved_size != expected_size {
+        return Err(recording_save_error(
+            &format!("verifying {}", description),
+            format!("expected {} bytes but saved {}", expected_size, saved_size),
+        ));
+    }
+    Ok(())
+}
+
+/// Prefer an already-staged project file on retries. The first save moves the
+/// capture from the recording workspace into the project workspace before
+/// later fallible steps (device validation, archive creation, store commit).
+/// Requiring the original capture path again would make every such retry fail.
+fn recording_save_source(
+    capture_path: &std::path::Path,
+    staged_path: &std::path::Path,
+) -> std::path::PathBuf {
+    if staged_path.exists() {
+        staged_path.to_path_buf()
+    } else {
+        capture_path.to_path_buf()
+    }
+}
+
+fn successful_extra_tracks(
+    project_temp: &std::path::Path,
+    tracks: Vec<crate::commands::multi_app::CapturedTrack>,
+) -> AppResult<Vec<crate::commands::multi_app::CapturedTrack>> {
+    let mut successful = Vec::with_capacity(tracks.len());
+    for track in tracks {
+        let path = track.capture_path(project_temp)?;
+        match path.metadata() {
+            Ok(metadata) if metadata.is_file() && metadata.len() > 0 => successful.push(track),
+            Ok(_) => {
+                return Err(recording_save_error(
+                    &format!("checking required App-layer track {:?}", path),
+                    "the selected track is empty",
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Err(recording_save_error(
+                    &format!("checking required App-layer track {:?}", path),
+                    "the selected track is missing",
+                ));
+            }
+            Err(error) => {
+                return Err(recording_save_error(
+                    &format!("checking multi-app track {:?}", path),
+                    error,
+                ));
+            }
+        }
+    }
+    Ok(successful)
+}
+
+fn validate_archive_entry_name(name: &str) -> AppResult<()> {
+    if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\\') {
+        return Err(recording_save_error(
+            "validating the project archive",
+            format!("invalid entry name {:?}", name),
+        ));
+    }
+    Ok(())
+}
+
+fn write_project_zip<W>(writer: W, entries: &[ProjectArchiveEntry]) -> AppResult<W>
+where
+    W: std::io::Write + std::io::Seek,
+{
+    let mut zip = zip::ZipWriter::new(writer);
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    let mut names = std::collections::HashSet::new();
+
+    for entry in entries {
+        validate_archive_entry_name(&entry.archive_name)?;
+        if !names.insert(entry.archive_name.as_str()) {
+            return Err(recording_save_error(
+                "validating the project archive",
+                format!("duplicate entry {:?}", entry.archive_name),
+            ));
+        }
+
+        let expected_size = ensure_non_empty_recording_file(
+            &entry.source_path,
+            &format!("archive entry {}", entry.archive_name),
+        )?;
+        let mut source = std::fs::File::open(&entry.source_path).map_err(|error| {
+            recording_save_error(
+                &format!("opening archive entry {}", entry.archive_name),
+                error,
+            )
+        })?;
+        zip.start_file(&entry.archive_name, options)
+            .map_err(|error| {
+                recording_save_error(
+                    &format!("starting archive entry {}", entry.archive_name),
+                    error,
+                )
+            })?;
+        let copied = std::io::copy(&mut source, &mut zip).map_err(|error| {
+            recording_save_error(
+                &format!("writing archive entry {}", entry.archive_name),
+                error,
+            )
+        })?;
+        if copied != expected_size {
+            return Err(recording_save_error(
+                &format!("writing archive entry {}", entry.archive_name),
+                format!("wrote {} of {} bytes", copied, expected_size),
+            ));
+        }
+    }
+
+    zip.finish()
+        .map_err(|error| recording_save_error("finalizing the project archive", error))
+}
+
+fn partial_archive_path(zip_path: &std::path::Path) -> std::path::PathBuf {
+    let mut path = zip_path.as_os_str().to_os_string();
+    path.push(".partial");
+    path.into()
+}
+
+fn create_project_archive(
+    zip_path: &std::path::Path,
+    entries: &[ProjectArchiveEntry],
+) -> AppResult<()> {
+    let partial_path = partial_archive_path(zip_path);
+    if partial_path.exists() {
+        std::fs::remove_file(&partial_path).map_err(|error| {
+            recording_save_error("removing an earlier partial project archive", error)
+        })?;
+    }
+    if zip_path.exists() {
+        return Err(recording_save_error(
+            "committing the project archive",
+            format!("the destination already exists: {:?}", zip_path),
+        ));
+    }
+
+    let result = (|| -> AppResult<()> {
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&partial_path)
+            .map_err(|error| recording_save_error("creating the project archive", error))?;
+        let file = write_project_zip(file, entries)?;
+        file.sync_all()
+            .map_err(|error| recording_save_error("syncing the project archive", error))?;
+        std::fs::rename(&partial_path, zip_path)
+            .map_err(|error| recording_save_error("committing the project archive", error))?;
+        Ok(())
+    })();
+
+    if result.is_err() && partial_path.exists() {
+        if let Err(cleanup_error) = std::fs::remove_file(&partial_path) {
+            log::error!(
+                "[stop_recording] Could not remove partial archive {:?}: {}",
+                partial_path,
+                cleanup_error
+            );
+        }
+    }
+    result
+}
+
+fn prepare_project_archive_destination(
+    zip_path: &std::path::Path,
+    staged_retry: bool,
+) -> AppResult<()> {
+    if !zip_path.exists() {
+        return Ok(());
+    }
+    if !staged_retry {
+        return Err(recording_save_error(
+            "committing the project archive",
+            format!("the destination already exists: {:?}", zip_path),
+        ));
+    }
+
+    // A staged retry owns this UUID-scoped destination. The previous attempt
+    // may have atomically committed the archive and then crashed or failed
+    // while opening/updating the library store.
+    std::fs::remove_file(zip_path)
+        .map_err(|error| recording_save_error("preparing the project archive retry", error))
+}
+
 #[tauri::command]
 pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
+    let should_stop = {
+        let state = app.state::<Mutex<AppState>>();
+        let mut state = state.lock().unwrap();
+        try_begin_recording_stop(&mut state)
+    };
+
+    if !should_stop {
+        log::warn!("[stop_recording] Ignoring duplicate stop command");
+        return Ok(());
+    }
+
+    let result = stop_recording_impl(app.clone()).await;
+    let state = app.state::<Mutex<AppState>>();
+    state.lock().unwrap().recording_stop_in_progress = false;
+    result
+}
+
+async fn stop_recording_impl(app: AppHandle) -> AppResult<()> {
     use tauri_plugin_store::StoreExt;
 
     let state = app.state::<Mutex<AppState>>();
@@ -1477,20 +2456,19 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
     crate::commands::audio::unmute_all_sessions(&app);
 
     // Stop any extra multi-app captures (plugin: individual app recording).
-    {
-        let children = {
-            let mut s = state.lock().unwrap();
-            std::mem::take(&mut s.multi_app_children)
-        };
-        crate::commands::multi_app::graceful_shutdown(children);
-    }
+    // Keep cleaning up the primary/device trackers even when a required layer
+    // fails, then surface the durable layer error before project packaging.
+    let app_layer_finalize_failure =
+        crate::commands::multi_app::finalize_state_captures(&state).err();
 
     let (project_id, recording_id, mouse_events, keyboard_events, extra_tracks, recording_start_ts) = {
         let mut state = state.lock().unwrap();
         state.is_recording = false;
+        state.recording_capture_claimed = false;
 
         state.mouse_tracker.stop();
         state.keyboard_tracker.stop();
+        close_camera_file_handle(&mut state);
 
         #[cfg(target_os = "macos")]
         crate::mouse_tracker::restore_macos_cursor();
@@ -1498,13 +2476,14 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
         let start_ts = state.recording_start_timestamp.unwrap_or(stop_timestamp);
         let events = state.mouse_tracker.get_events(start_ts);
         let key_events = state.keyboard_tracker.get_events(start_ts);
-        let tracks = std::mem::take(&mut state.multi_app_tracks);
+        // Retain track metadata until the archive and library transaction has
+        // committed so a failed package can be retried from the staged files.
+        let tracks = state.multi_app_tracks.clone();
 
         let pid = state.project_id.clone();
         let rid = state.recording_id.clone();
         state.ffmpeg_child_id = None;
         state.ffmpeg_child = None;
-        state.recording_start_timestamp = None;
         (pid, rid, events, key_events, tracks, start_ts)
     };
 
@@ -1514,16 +2493,11 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
         recording_id
     );
 
-    // Close recorder window
-    if let Some(recorder_win) = app.get_webview_window("recorder") {
-        recorder_win.close().ok();
-    }
-
-    // Restore main window
-    if let Some(main_win) = app.get_webview_window("main") {
-        main_win.unminimize().ok();
-        main_win.show().ok();
-        main_win.set_focus().ok();
+    if let Some(error) = app_layer_finalize_failure {
+        let message = error.to_string();
+        app.emit_to("main", "recording-error", &message).ok();
+        app.emit_to("main", "load", serde_json::Value::Null).ok();
+        return Err(error);
     }
 
     app.emit_to("main", "load", "Creating project...").ok();
@@ -1531,9 +2505,15 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
     // Check if we have a valid recording
     let recording_video_path = if let Some(ref rid) = recording_id {
         let state_lock = state.lock().unwrap();
-        let path = state_lock.project_temp_dir(rid).join("screen.mp4");
+        let capture_path = state_lock.project_temp_dir(rid).join("screen.mp4");
+        let staged_path = project_id
+            .as_ref()
+            .map(|pid| state_lock.project_temp_dir(pid).join("screen.mp4"));
         drop(state_lock);
-        Some(path)
+        Some(match staged_path {
+            Some(path) => recording_save_source(&capture_path, &path),
+            None => capture_path,
+        })
     } else {
         None
     };
@@ -1553,290 +2533,343 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
         })
         .unwrap_or(false);
 
-    let has_video = if has_non_empty_video {
+    let requires_system_audio = {
+        let state = state.lock().unwrap();
+        state
+            .camera_mic_config
+            .as_ref()
+            .and_then(|config| config.get("hasSystemAudio"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    };
+
+    let screen_metadata = if has_non_empty_video {
         if let Some(ref path) = recording_video_path {
-            if recording_video_is_readable(&app, path).await {
-                true
-            } else {
-                log::error!(
-                    "[stop_recording] Recording video exists but is not readable: {:?}",
-                    path
-                );
-                false
+            match probe_video_metadata(path, requires_system_audio).await {
+                Ok(metadata) => Some(metadata),
+                Err(error) => {
+                    log::error!(
+                        "[stop_recording] Recording video exists but its first frame is not readable: {:?}: {}",
+                        path,
+                        error
+                    );
+                    None
+                }
             }
         } else {
-            false
+            None
         }
     } else {
-        false
+        None
     };
+    let has_video = screen_metadata.is_some();
+
+    let mut project_save_failure: Option<AppError> = None;
 
     if has_video {
         if let (Some(ref rid), Some(ref pid)) = (&recording_id, &project_id) {
-            let (recording_video, project_temp, projects_dir) = {
-                let state_lock = state.lock().unwrap();
-                (
-                    state_lock.project_temp_dir(rid).join("screen.mp4"),
-                    state_lock.project_temp_dir(pid),
-                    state_lock.projects_dir.clone(),
-                )
-            };
-
-            if let Err(e) = std::fs::create_dir_all(&project_temp) {
-                log::error!("[stop_recording] Failed to create project temp dir: {}", e);
-            }
-            let dest_video = project_temp.join("screen.mp4");
-
-            if std::fs::rename(&recording_video, &dest_video).is_err() {
-                log::warn!("[stop_recording] rename failed, trying copy");
-                if let Err(e) = std::fs::copy(&recording_video, &dest_video) {
-                    log::error!("[stop_recording] copy also failed: {}", e);
-                } else {
-                    std::fs::remove_file(&recording_video).ok();
-                }
-            }
-
-            log::info!(
-                "[stop_recording] dest_video exists={}, size={}",
-                dest_video.exists(),
-                dest_video.metadata().map(|m| m.len()).unwrap_or(0)
-            );
-
-            let (source_name, left_trim, right_trim, top_trim, bottom_trim, has_camera, has_mic) = {
-                let s = state.lock().unwrap();
-                let config = s.camera_mic_config.as_ref();
-                let name = config
-                    .and_then(|c| c.get("sourceName"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("Recording")
-                    .to_string();
-                let has_camera = config
-                    .and_then(|c| c.get("videoTrack"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| !s.is_empty())
-                    .unwrap_or(false);
-                let has_mic = config
-                    .and_then(|c| c.get("audioTrack"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| !s.is_empty())
-                    .unwrap_or(false);
-                (name, 0, 0, 0, 0, has_camera, has_mic)
-            };
-
-            // Copy camera.webm from recording temp to project temp if camera/mic was used
-            let has_camera_file = if has_camera || has_mic {
-                let camera_src = {
+            let save_result: AppResult<()> = async {
+                let (project_temp, projects_dir) = {
                     let state_lock = state.lock().unwrap();
-                    state_lock.camera_video_file(rid)
+                    (
+                        state_lock.project_temp_dir(pid),
+                        state_lock.projects_dir.clone(),
+                    )
                 };
-                if camera_src.exists()
-                    && camera_src.metadata().map(|m| m.len() > 0).unwrap_or(false)
-                {
+
+                std::fs::create_dir_all(&project_temp).map_err(|error| {
+                    recording_save_error("creating the project workspace", error)
+                })?;
+                let dest_video = project_temp.join("screen.mp4");
+                let recording_video = recording_video_path.clone().ok_or_else(|| {
+                    recording_save_error(
+                        "staging the screen recording",
+                        "the recording source path is unavailable",
+                    )
+                })?;
+                move_or_copy_recording_file(&recording_video, &dest_video, "screen recording")?;
+
+                log::info!(
+                    "[stop_recording] dest_video exists={}, size={}",
+                    dest_video.exists(),
+                    dest_video.metadata().map(|m| m.len()).unwrap_or(0)
+                );
+
+                let (
+                    source_name,
+                    left_trim,
+                    right_trim,
+                    top_trim,
+                    bottom_trim,
+                    has_camera,
+                    has_mic,
+                    has_system_audio,
+                ) = {
+                    let s = state.lock().unwrap();
+                    let config = s.camera_mic_config.as_ref();
+                    let name = config
+                        .and_then(|c| c.get("sourceName"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Recording")
+                        .to_string();
+                    let has_camera = config
+                        .and_then(|c| c.get("videoTrack"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false);
+                    let has_mic = config
+                        .and_then(|c| c.get("audioTrack"))
+                        .and_then(|v| v.as_str())
+                        .map(|s| !s.is_empty())
+                        .unwrap_or(false);
+                    let has_system_audio = config
+                        .and_then(|c| c.get("hasSystemAudio"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    (name, 0, 0, 0, 0, has_camera, has_mic, has_system_audio)
+                };
+
+                // A selected camera or microphone is a required project track, not
+                // an optional enhancement. Missing, empty, unreadable, or stream-
+                // mismatched output must fail the save instead of publishing a
+                // manifest that silently drops what the user selected.
+                let has_camera_file = has_camera || has_mic;
+                let camera_metadata = if has_camera_file {
                     let camera_dest = project_temp.join("camera.webm");
-                    log::info!(
-                        "[stop_recording] Copying camera file: {:?} -> {:?} (size={})",
-                        camera_src,
-                        camera_dest,
-                        camera_src.metadata().map(|m| m.len()).unwrap_or(0)
-                    );
-                    if std::fs::rename(&camera_src, &camera_dest).is_err() {
-                        log::warn!("[stop_recording] camera rename failed, trying copy");
-                        if let Err(e) = std::fs::copy(&camera_src, &camera_dest) {
-                            log::error!("[stop_recording] camera copy also failed: {}", e);
-                            false
+                    let camera_src = {
+                        let state_lock = state.lock().unwrap();
+                        let capture_path = state_lock.camera_video_file(rid);
+                        if !capture_path.exists() && camera_dest.exists() {
+                            camera_dest.clone()
                         } else {
-                            std::fs::remove_file(&camera_src).ok();
-                            true
+                            capture_path
                         }
-                    } else {
-                        true
-                    }
-                } else {
-                    log::warn!(
-                        "[stop_recording] Camera file not found or empty at {:?}",
-                        camera_src
+                    };
+                    log::info!(
+                        "[stop_recording] Staging camera/microphone file: {:?} -> {:?}",
+                        camera_src,
+                        camera_dest
                     );
-                    false
-                }
-            } else {
-                false
-            };
+                    move_or_copy_recording_file(
+                        &camera_src,
+                        &camera_dest,
+                        "selected camera/microphone recording",
+                    )?;
+                    probe_device_recording(&camera_dest, has_camera, has_mic)
+                        .await
+                        .map_err(|error| {
+                            recording_save_error(
+                                "validating the selected camera/microphone recording",
+                                error,
+                            )
+                        })?
+                } else {
+                    None
+                };
 
-            // Get camera video dimensions if camera was recorded
-            let camera_dims = if has_camera_file && has_camera {
-                let camera_path = project_temp.join("camera.webm");
-                match get_video_dimensions(&camera_path).await {
-                    Ok((w, h)) => {
-                        log::info!("[stop_recording] Camera dimensions: {}x{}", w, h);
-                        Some((w, h))
+                let camera_dims = camera_metadata.map(|metadata| {
+                    log::info!(
+                        "[stop_recording] Camera dimensions: {}x{}",
+                        metadata.width,
+                        metadata.height
+                    );
+                    (metadata.width, metadata.height)
+                });
+
+                // FFmpeg children that failed after spawning can leave no usable
+                // file. Keep the main recording and every successful extra, while
+                // ensuring the manifest only references entries actually saved.
+                let extra_tracks = successful_extra_tracks(&project_temp, extra_tracks)?;
+
+                let duration_ms = screen_metadata
+                    .and_then(|metadata| metadata.duration_ms)
+                    .unwrap_or_else(|| (stop_timestamp - recording_start_ts).max(1000));
+                log::info!("[stop_recording] Video duration: {}ms", duration_ms);
+
+                let camera_dims_json = match camera_dims {
+                    Some((w, h)) => serde_json::json!({"x": w, "y": h}),
+                    None => serde_json::json!(null),
+                };
+
+                let clip_layout = if has_camera && has_camera_file {
+                    serde_json::json!({
+                        "mode": "camera-overlay",
+                        "config": {
+                            "cameraPosition": { "x": 0, "y": 1 },
+                            "cameraBaseScale": 0.5,
+                            "cameraBorderRadius": 0.25
+                        }
+                    })
+                } else {
+                    serde_json::json!({
+                        "mode": "screen-fullscreen"
+                    })
+                };
+
+                let project_json = serde_json::json!({
+                    "version": 1,
+                    "project": {
+                        "id": pid,
+                        "name": source_name,
+                        "hasCameraVideo": has_camera && has_camera_file,
+                        "hasMicrophoneAudio": has_mic && has_camera_file,
+                        "hasSystemAudio": has_system_audio,
+                        "cameraVideoDimensions": camera_dims_json,
+                        "padding": 1,
+                        "borderRadius": 0,
+                        "mouseEvents": mouse_events,
+                        "keyboardEvents": keyboard_events,
+                        "extraTracks": extra_tracks,
+                        "leftTrim": left_trim,
+                        "rightTrim": right_trim,
+                        "topTrim": top_trim,
+                        "bottomTrim": bottom_trim,
+                        "videoDetails": {
+                            "start": 0,
+                            "end": duration_ms
+                        }
+                    },
+                    "clipAnims": {
+                        "entities": [{
+                            "start": 0,
+                            "end": duration_ms,
+                            "layout": clip_layout
+                        }]
                     }
-                    Err(e) => {
-                        log::warn!("[stop_recording] Could not probe camera dimensions ({}), using defaults", e);
-                        Some((1280, 720))
-                    }
-                }
-            } else {
-                None
-            };
+                });
 
-            let duration_ms = get_video_duration_ms(&app, &dest_video)
-                .await
-                .unwrap_or_else(|_| (stop_timestamp - recording_start_ts).max(1000));
-            log::info!("[stop_recording] Video duration: {}ms", duration_ms);
+                let project_json_path = project_temp.join("project.json");
+                let project_json_bytes =
+                    serde_json::to_vec_pretty(&project_json).map_err(|error| {
+                        recording_save_error("serializing the project manifest", error)
+                    })?;
+                std::fs::write(&project_json_path, project_json_bytes)
+                    .map_err(|error| recording_save_error("writing the project manifest", error))?;
 
-            let camera_dims_json = match camera_dims {
-                Some((w, h)) => serde_json::json!({"x": w, "y": h}),
-                None => serde_json::json!(null),
-            };
+                let zip_path = projects_dir.join(format!("{}.zip", pid));
+                std::fs::create_dir_all(&projects_dir).map_err(|error| {
+                    recording_save_error("creating the project library directory", error)
+                })?;
 
-            let clip_layout = if has_camera && has_camera_file {
-                serde_json::json!({
-                    "mode": "camera-overlay",
-                    "config": {
-                        "cameraPosition": { "x": 0, "y": 1 },
-                        "cameraBaseScale": 0.5,
-                        "cameraBorderRadius": 0.25
-                    }
-                })
-            } else {
-                serde_json::json!({
-                    "mode": "screen-fullscreen"
-                })
-            };
+                // A prior attempt can have completed the ZIP but failed to publish
+                // the library store. On a retry the capture is already staged at
+                // dest_video, so replacing that unpublished archive is safe.
+                prepare_project_archive_destination(&zip_path, recording_video == dest_video)?;
 
-            let project_json = serde_json::json!({
-                "version": 1,
-                "project": {
-                    "id": pid,
-                    "name": source_name,
-                    "hasCameraVideo": has_camera && has_camera_file,
-                    "hasMicrophoneAudio": has_mic && has_camera_file,
-                    "hasSystemAudio": false,
-                    "cameraVideoDimensions": camera_dims_json,
-                    "padding": 1,
-                    "borderRadius": 0,
-                    "mouseEvents": mouse_events,
-                    "keyboardEvents": keyboard_events,
-                    "extraTracks": extra_tracks,
-                    "leftTrim": left_trim,
-                    "rightTrim": right_trim,
-                    "topTrim": top_trim,
-                    "bottomTrim": bottom_trim,
-                    "videoDetails": {
-                        "start": 0,
-                        "end": duration_ms
-                    }
-                },
-                "clipAnims": {
-                    "entities": [{
-                        "start": 0,
-                        "end": duration_ms,
-                        "layout": clip_layout
-                    }]
-                }
-            });
+                log::info!("[stop_recording] Creating zip at: {:?}", zip_path);
 
-            let project_json_path = project_temp.join("project.json");
-            if let Err(e) = std::fs::write(
-                &project_json_path,
-                serde_json::to_string_pretty(&project_json).unwrap_or_default(),
-            ) {
-                log::error!("[stop_recording] Failed to write project.json: {}", e);
-            }
-
-            let zip_path = projects_dir.join(format!("{}.zip", pid));
-            std::fs::create_dir_all(&projects_dir).ok();
-
-            log::info!("[stop_recording] Creating zip at: {:?}", zip_path);
-
-            let zip_ok = if let Ok(zip_file) = std::fs::File::create(&zip_path) {
-                let mut zip = zip::ZipWriter::new(zip_file);
-                let options = zip::write::SimpleFileOptions::default()
-                    .compression_method(zip::CompressionMethod::Stored);
-
-                if let Ok(pj_data) = std::fs::read(&project_json_path) {
-                    zip.start_file("project.json", options).ok();
-                    std::io::Write::write_all(&mut zip, &pj_data).ok();
-                }
-
-                if let Ok(video_meta) = dest_video.metadata() {
-                    let video_size = video_meta.len();
-                    log::info!("[stop_recording] Adding video to zip, size={}", video_size);
-                    if let Ok(mut video_file) = std::fs::File::open(&dest_video) {
-                        zip.start_file("screen.mp4", options).ok();
-                        std::io::copy(&mut video_file, &mut zip).ok();
-                    }
-                }
-
-                // Add camera.webm to zip if present
+                let mut archive_entries = vec![
+                    ProjectArchiveEntry {
+                        archive_name: "project.json".to_string(),
+                        source_path: project_json_path.clone(),
+                    },
+                    ProjectArchiveEntry {
+                        archive_name: "screen.mp4".to_string(),
+                        source_path: dest_video.clone(),
+                    },
+                ];
                 if has_camera_file {
-                    let camera_dest = project_temp.join("camera.webm");
-                    if let Ok(mut camera_file) = std::fs::File::open(&camera_dest) {
-                        let camera_size = camera_dest.metadata().map(|m| m.len()).unwrap_or(0);
-                        log::info!(
-                            "[stop_recording] Adding camera video to zip, size={}",
-                            camera_size
-                        );
-                        zip.start_file("camera.webm", options).ok();
-                        std::io::copy(&mut camera_file, &mut zip).ok();
-                    }
+                    archive_entries.push(ProjectArchiveEntry {
+                        archive_name: "camera.webm".to_string(),
+                        source_path: project_temp.join("camera.webm"),
+                    });
                 }
+                for track in &extra_tracks {
+                    let archive_name = track.archive_filename()?.to_string();
+                    let source_path = track.capture_path(&project_temp)?;
+                    log::info!(
+                        "[stop_recording] Adding multi-app track {} from {:?}",
+                        archive_name,
+                        source_path
+                    );
+                    archive_entries.push(ProjectArchiveEntry {
+                        archive_name,
+                        source_path,
+                    });
+                }
+                create_project_archive(&zip_path, &archive_entries)?;
 
-                // Add extra-N.mp4 files captured by the individual app recording plugin.
-                for (idx, _track) in extra_tracks.iter().enumerate() {
-                    let extra_path = project_temp.join(format!("extra-{}.mp4", idx));
-                    if extra_path.exists() {
-                        if let Ok(mut f) = std::fs::File::open(&extra_path) {
-                            let sz = extra_path.metadata().map(|m| m.len()).unwrap_or(0);
-                            log::info!(
-                                "[stop_recording] Adding extra-{}.mp4 to zip, size={}",
-                                idx, sz
+                // Publish to the library only after the complete archive has been
+                // finalized and atomically renamed into place.
+                let store = match app.store("store.json") {
+                    Ok(store) => store,
+                    Err(error) => {
+                        if let Err(cleanup_error) = std::fs::remove_file(&zip_path) {
+                            log::error!(
+                                "[stop_recording] Could not remove unpublished archive {:?}: {}",
+                                zip_path,
+                                cleanup_error
                             );
-                            zip.start_file(format!("extra-{}.mp4", idx), options).ok();
-                            std::io::copy(&mut f, &mut zip).ok();
+                        }
+                        return Err(recording_save_error(
+                            "opening the project library",
+                            error,
+                        ));
+                    }
+                };
+                let zip_str = zip_path.to_string_lossy().to_string();
+                let projects_key = "projects";
+                let path_key = format!("projects.{}.path", pid);
+                let previous_projects = store.get(projects_key);
+                let previous_path = store.get(&path_key);
+                let mut projects = previous_projects
+                    .clone()
+                    .and_then(|value| match value {
+                        Value::Object(map) => Some(map),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+
+                projects.insert(
+                    pid.clone(),
+                    serde_json::json!({
+                        "id": pid,
+                        "lastSaved": chrono::Utc::now().timestamp_millis(),
+                        "name": source_name,
+                        "path": zip_str,
+                    }),
+                );
+                store.set(projects_key, Value::Object(projects));
+                store.set(&path_key, serde_json::json!(zip_str));
+                if let Err(error) = store.save() {
+                    match previous_projects {
+                        Some(value) => store.set(projects_key, value),
+                        None => {
+                            store.delete(projects_key);
                         }
                     }
+                    match previous_path {
+                        Some(value) => store.set(&path_key, value),
+                        None => {
+                            store.delete(&path_key);
+                        }
+                    }
+                    // Restore the last known in-memory state. If the first write
+                    // partially touched disk, this best-effort second save also
+                    // gives the store plugin a chance to put the old data back.
+                    if let Err(rollback_error) = store.save() {
+                        log::error!(
+                            "[stop_recording] Project library rollback also failed: {}",
+                            rollback_error
+                        );
+                    }
+                    if let Err(cleanup_error) = std::fs::remove_file(&zip_path) {
+                        log::error!(
+                            "[stop_recording] Could not remove the unpublished archive {:?}: {}",
+                            zip_path,
+                            cleanup_error
+                        );
+                    }
+                    return Err(recording_save_error("updating the project library", error));
                 }
+                log::info!("[stop_recording] Project stored: {}", pid);
 
-                zip.finish().ok();
-                true
-            } else {
-                log::error!("[stop_recording] Failed to create zip file");
-                false
-            };
+                Ok(())
+            }
+            .await;
 
-            if zip_ok {
-                if let Ok(store) = app.store("store.json") {
-                    let zip_str = zip_path.to_string_lossy().to_string();
-
-                    let mut projects = store
-                        .get("projects")
-                        .and_then(|v| {
-                            if let Value::Object(map) = v {
-                                Some(map)
-                            } else {
-                                None
-                            }
-                        })
-                        .unwrap_or_default();
-
-                    projects.insert(
-                        pid.clone(),
-                        serde_json::json!({
-                            "id": pid,
-                            "lastSaved": chrono::Utc::now().timestamp_millis(),
-                            "name": source_name,
-                            "path": zip_str,
-                        }),
-                    );
-
-                    store.set("projects", Value::Object(projects));
-                    store.set(format!("projects.{}.path", pid), serde_json::json!(zip_str));
-                    store.save().ok();
-                    log::info!("[stop_recording] Project stored: {}", pid);
-                } else {
-                    log::error!("[stop_recording] Failed to open store");
-                }
+            if let Err(error) = save_result {
+                project_save_failure = Some(error);
             }
 
             {
@@ -1850,9 +2883,16 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
                 state.file_handles.clear();
             }
 
-            log::info!("[stop_recording] Emitting project-created: {}", pid);
-            app.emit_to("main", "project-created", pid.as_str()).ok();
-            app.emit_to("main", "load", "").ok();
+            if project_save_failure.is_none() {
+                log::info!("[stop_recording] Emitting project-created: {}", pid);
+                app.emit_to("main", "project-created", pid.as_str()).ok();
+                app.emit_to("main", "load", "").ok();
+            }
+        } else {
+            project_save_failure = Some(recording_save_error(
+                "finalizing the recording",
+                "the project or recording identifier is missing",
+            ));
         }
     } else {
         log::warn!(
@@ -1884,14 +2924,47 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
                 log::error!("[stop_recording] No frames captured, but macOS screen recording permission check passed. Treating as a capture startup failure.");
             }
         }
-        app.emit_to("main", "recording-canceled", "").ok();
-        app.emit_to("main", "load", serde_json::Value::Null).ok();
+        project_save_failure = Some(recording_save_error(
+            "validating the screen recording",
+            error_code,
+        ));
     }
 
-    // Fan out "recording-stopped" to every live window except the recorder,
-    // which was just destroyed above. A broadcast emit() would also target
-    // the recorder's stale HWND and make winit log a spurious
-    // "PostMessage failed ; Invalid window handle" warning on Windows.
+    if let Some(error) = project_save_failure.take() {
+        let message = error.to_string();
+        log::error!("[stop_recording] {}", message);
+        app.emit_to("main", "recording-error", message).ok();
+        app.emit_to("main", "load", serde_json::Value::Null).ok();
+        // Do not close the recorder or clear the staging token. The renderer
+        // remains available with Retry and Discard controls, and a retry can
+        // package the already-stopped capture from the staged project files.
+        return Err(error);
+    }
+
+    {
+        let mut state = state.lock().unwrap();
+        state.recording_id = None;
+        state.recording_start_timestamp = None;
+        state.multi_app_tracks.clear();
+        state.multi_app_init_in_progress = false;
+        state.multi_app_stop_requested = false;
+        state.multi_app_finalize_error = None;
+        state.file_handles.clear();
+    }
+
+    // The project is fully durable and registered. Only now close the retry UI
+    // and return focus to the main window.
+    if let Some(recorder_win) = app.get_webview_window("recorder") {
+        recorder_win.close().ok();
+    }
+    if let Some(main_win) = app.get_webview_window("main") {
+        main_win.unminimize().ok();
+        main_win.show().ok();
+        main_win.set_focus().ok();
+    }
+
+    // Fan out "recording-stopped" to every live window except the recorder.
+    // A broadcast emit() would target its closed HWND on Windows.
     for (label, _) in app.webview_windows() {
         if label == "recorder" {
             continue;
@@ -1913,6 +2986,18 @@ pub async fn stop_recording(app: AppHandle) -> AppResult<()> {
 
 #[tauri::command]
 pub async fn reset_recording(app: AppHandle) -> AppResult<()> {
+    let state = app.state::<Mutex<AppState>>();
+    {
+        let mut state = state.lock().unwrap();
+        if !state.is_recording || state.recording_stop_in_progress {
+            return Err(AppError::General(
+                "Recording cleanup is already in progress.".to_string(),
+            ));
+        }
+        state.recording_stop_in_progress = true;
+        state.recording_capture_claimed = false;
+    }
+
     tokio::task::spawn_blocking({
         let app = app.clone();
         move || kill_ffmpeg(&app)
@@ -1920,10 +3005,24 @@ pub async fn reset_recording(app: AppHandle) -> AppResult<()> {
     .await
     .ok();
 
+    let children = {
+        let mut state = state.lock().unwrap();
+        state.keyboard_tracker.stop();
+        state.mouse_tracker.stop();
+        close_camera_file_handle(&mut state);
+        state.multi_app_tracks.clear();
+        state.multi_app_init_in_progress = false;
+        state.multi_app_stop_requested = false;
+        state.multi_app_finalize_error = None;
+        std::mem::take(&mut state.multi_app_children)
+    };
+    if let Err(error) = crate::commands::multi_app::graceful_shutdown(children) {
+        log::warn!("[reset_recording] App-layer cleanup failed: {}", error);
+    }
+
     #[cfg(target_os = "macos")]
     crate::mouse_tracker::restore_macos_cursor();
 
-    let state = app.state::<Mutex<AppState>>();
     let recording_id = {
         let mut state = state.lock().unwrap();
         state.ffmpeg_child_id = None;
@@ -1943,12 +3042,24 @@ pub async fn reset_recording(app: AppHandle) -> AppResult<()> {
         }
     }
 
+    state.lock().unwrap().recording_stop_in_progress = false;
+
     Ok(())
 }
 
 #[tauri::command]
 pub async fn cancel_recording(app: AppHandle, error: Option<String>) -> AppResult<()> {
     let state = app.state::<Mutex<AppState>>();
+    {
+        let mut state = state.lock().unwrap();
+        if state.recording_stop_in_progress {
+            log::warn!("[cancel_recording] Cleanup is already in progress");
+            return Ok(());
+        }
+        state.recording_stop_in_progress = true;
+        state.recording_capture_claimed = false;
+        state.is_recording = false;
+    }
 
     tokio::task::spawn_blocking({
         let app = app.clone();
@@ -1957,27 +3068,52 @@ pub async fn cancel_recording(app: AppHandle, error: Option<String>) -> AppResul
     .await
     .ok();
 
+    crate::commands::audio::unmute_all_sessions(&app);
+    let children = {
+        let mut state = state.lock().unwrap();
+        state.keyboard_tracker.stop();
+        state.multi_app_tracks.clear();
+        state.multi_app_init_in_progress = false;
+        state.multi_app_stop_requested = false;
+        state.multi_app_finalize_error = None;
+        std::mem::take(&mut state.multi_app_children)
+    };
+    if let Err(error) = crate::commands::multi_app::graceful_shutdown(children) {
+        log::warn!("[cancel_recording] App-layer cleanup failed: {}", error);
+    }
+
     #[cfg(target_os = "macos")]
     crate::mouse_tracker::restore_macos_cursor();
 
-    let recording_id = {
+    let temp_dirs = {
         let mut state = state.lock().unwrap();
         state.is_recording = false;
+        state.recording_capture_claimed = false;
         state.ffmpeg_child_id = None;
         state.ffmpeg_child = None;
         state.ffmpeg_process = None;
         state.mouse_tracker.stop();
+        close_camera_file_handle(&mut state);
         #[cfg(target_os = "macos")]
         crate::mouse_tracker::restore_macos_cursor();
         state.recording_start_timestamp = None;
-        state.recording_id.take()
+        state.camera_mic_config = None;
+        let recording_id = state.recording_id.take();
+        let project_id = state.project_id.take();
+        let mut dirs = Vec::with_capacity(2);
+        if let Some(ref rid) = recording_id {
+            dirs.push(state.project_temp_dir(rid));
+        }
+        if let Some(ref pid) = project_id {
+            let project_dir = state.project_temp_dir(pid);
+            if !dirs.contains(&project_dir) {
+                dirs.push(project_dir);
+            }
+        }
+        dirs
     };
 
-    if let Some(rid) = recording_id {
-        let state_lock = state.lock().unwrap();
-        let temp_dir = state_lock.project_temp_dir(&rid);
-        drop(state_lock);
-
+    for temp_dir in temp_dirs {
         if temp_dir.exists() {
             std::fs::remove_dir_all(&temp_dir).ok();
         }
@@ -2000,79 +3136,213 @@ pub async fn cancel_recording(app: AppHandle, error: Option<String>) -> AppResul
         app.emit_to("main", "recording-error", &err_str).ok();
     }
 
+    state.lock().unwrap().recording_stop_in_progress = false;
+
     Ok(())
 }
 
-/// Get video duration in milliseconds using FFmpeg
-async fn get_video_duration_ms(
-    _app: &AppHandle,
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct VideoMetadata {
+    duration_ms: Option<i64>,
+    width: i64,
+    height: i64,
+}
+
+fn parse_duration_ms(stderr: &str) -> Option<i64> {
+    let duration = stderr
+        .lines()
+        .find_map(|line| line.split_once("Duration: ").map(|(_, value)| value))?
+        .split(',')
+        .next()?
+        .trim();
+    if duration.eq_ignore_ascii_case("N/A") {
+        return None;
+    }
+
+    let mut parts = duration.split(':');
+    let hours = parts.next()?.parse::<f64>().ok()?;
+    let minutes = parts.next()?.parse::<f64>().ok()?;
+    let seconds = parts.next()?.parse::<f64>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let duration_ms = ((hours * 3600.0 + minutes * 60.0 + seconds) * 1000.0).round() as i64;
+    (duration_ms > 0).then_some(duration_ms)
+}
+
+fn dimensions_from_video_line(line: &str) -> Option<(i64, i64)> {
+    if !line.contains("Video:") {
+        return None;
+    }
+
+    let bytes = line.as_bytes();
+    for index in 1..bytes.len().saturating_sub(1) {
+        if bytes[index] != b'x' && bytes[index] != b'X' {
+            continue;
+        }
+        let mut start = index;
+        while start > 0 && bytes[start - 1].is_ascii_digit() {
+            start -= 1;
+        }
+        let mut end = index + 1;
+        while end < bytes.len() && bytes[end].is_ascii_digit() {
+            end += 1;
+        }
+        if start == index || end == index + 1 {
+            continue;
+        }
+
+        let width = line[start..index].parse::<i64>().ok()?;
+        let height = line[index + 1..end].parse::<i64>().ok()?;
+        if (16..=32768).contains(&width) && (16..=32768).contains(&height) {
+            return Some((width, height));
+        }
+    }
+    None
+}
+
+fn parse_video_metadata(stderr: &str) -> Result<VideoMetadata, String> {
+    let (width, height) = stderr
+        .lines()
+        .find_map(dimensions_from_video_line)
+        .ok_or_else(|| "Could not parse video dimensions".to_string())?;
+    Ok(VideoMetadata {
+        duration_ms: parse_duration_ms(stderr),
+        width,
+        height,
+    })
+}
+
+/// Validate a recording and collect its metadata with one first-frame decode.
+/// The old stop path decoded the complete screen file three times, making stop
+/// time scale with recording length and needlessly consuming CPU/GPU.
+fn screen_recording_probe_args(
     video_path: &std::path::Path,
-) -> Result<i64, String> {
-    let path_str = video_path.to_string_lossy().to_string();
-    let output = run_ffmpeg(&["-i", &path_str, "-f", "null", "-"])
-        .await
-        .map_err(|e| format!("FFmpeg error: {}", e))?;
-
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    if let Some(pos) = stderr.find("Duration: ") {
-        let duration_str = &stderr[pos + 10..];
-        if let Some(end) = duration_str.find(',') {
-            let time_str = &duration_str[..end];
-            let parts: Vec<&str> = time_str.split(':').collect();
-            if parts.len() == 3 {
-                let hours: f64 = parts[0].parse().unwrap_or(0.0);
-                let minutes: f64 = parts[1].parse().unwrap_or(0.0);
-                let seconds: f64 = parts[2].parse().unwrap_or(0.0);
-                let total_ms = ((hours * 3600.0 + minutes * 60.0 + seconds) * 1000.0) as i64;
-                if total_ms > 0 {
-                    return Ok(total_ms);
-                }
-            }
-        }
+    requires_audio: bool,
+) -> Vec<String> {
+    let mut args = vec![
+        "-hide_banner".to_string(),
+        "-nostdin".to_string(),
+        "-i".to_string(),
+        video_path.to_string_lossy().to_string(),
+        "-map".to_string(),
+        "0:v:0".to_string(),
+        "-frames:v".to_string(),
+        "1".to_string(),
+    ];
+    if requires_audio {
+        args.extend([
+            "-map".to_string(),
+            "0:a:0".to_string(),
+            "-frames:a".to_string(),
+            "1".to_string(),
+        ]);
     }
-
-    Err("Could not parse duration".to_string())
+    args.extend(["-f".to_string(), "null".to_string(), "-".to_string()]);
+    args
 }
 
-/// Get video dimensions (width, height) using FFmpeg
-async fn get_video_dimensions(video_path: &std::path::Path) -> Result<(i64, i64), String> {
-    let path_str = video_path.to_string_lossy().to_string();
-    let output = run_ffmpeg(&["-i", &path_str, "-f", "null", "-"])
-        .await
-        .map_err(|e| format!("FFmpeg error: {}", e))?;
-
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    // Parse "Video: ... 1280x720" or similar from FFmpeg stderr
-    for line in stderr.lines() {
-        if line.contains("Video:") {
-            // Look for WxH pattern like "1280x720" in the Video stream line
-            for part in line.split([',', ' ']) {
-                let part = part.trim();
-                if let Some(x_pos) = part.find('x') {
-                    let w_str = &part[..x_pos];
-                    let h_str = &part[x_pos + 1..];
-                    if let (Ok(w), Ok(h)) = (w_str.parse::<i64>(), h_str.parse::<i64>()) {
-                        if w > 0 && h > 0 && w < 10000 && h < 10000 {
-                            return Ok((w, h));
-                        }
-                    }
-                }
-            }
-        }
+async fn probe_video_metadata(
+    video_path: &std::path::Path,
+    requires_audio: bool,
+) -> Result<VideoMetadata, String> {
+    let args = screen_recording_probe_args(video_path, requires_audio);
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let output = run_ffmpeg(&arg_refs)
+    .await
+    .map_err(|error| format!("FFmpeg error: {}", error))?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        let reason = stderr
+            .lines()
+            .rev()
+            .find(|line| !line.trim().is_empty())
+            .unwrap_or("first-frame decode failed");
+        return Err(reason.to_string());
     }
-    Err("Could not parse video dimensions".to_string())
+    parse_video_metadata(&stderr)
 }
 
-async fn recording_video_is_readable(app: &AppHandle, video_path: &std::path::Path) -> bool {
-    get_video_duration_ms(app, video_path).await.is_ok()
-        && get_video_dimensions(video_path).await.is_ok()
+fn device_recording_probe_args(
+    media_path: &std::path::Path,
+    requires_video: bool,
+    requires_audio: bool,
+) -> Result<Vec<String>, String> {
+    if !requires_video && !requires_audio {
+        return Err("No camera or microphone stream was requested".to_string());
+    }
+
+    let mut args = vec![
+        "-hide_banner".to_string(),
+        "-nostdin".to_string(),
+        "-i".to_string(),
+        media_path.to_string_lossy().to_string(),
+    ];
+    if requires_video {
+        args.extend([
+            "-map".to_string(),
+            "0:v:0".to_string(),
+            "-frames:v".to_string(),
+            "1".to_string(),
+        ]);
+    }
+    if requires_audio {
+        args.extend([
+            "-map".to_string(),
+            "0:a:0".to_string(),
+            "-frames:a".to_string(),
+            "1".to_string(),
+        ]);
+    }
+    args.extend(["-f".to_string(), "null".to_string(), "-".to_string()]);
+    Ok(args)
+}
+
+/// Decode one frame from every selected device stream. Mandatory FFmpeg maps
+/// make a camera-only, microphone-only, or combined capture fail when any
+/// requested stream is absent, while keeping validation independent of clip
+/// duration.
+async fn probe_device_recording(
+    media_path: &std::path::Path,
+    requires_video: bool,
+    requires_audio: bool,
+) -> Result<Option<VideoMetadata>, String> {
+    let args = device_recording_probe_args(media_path, requires_video, requires_audio)?;
+    let arg_refs = args.iter().map(String::as_str).collect::<Vec<_>>();
+    let output = run_ffmpeg(&arg_refs)
+        .await
+        .map_err(|error| format!("FFmpeg error: {}", error))?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        let reason = stderr
+            .lines()
+            .rev()
+            .find(|line| !line.trim().is_empty())
+            .unwrap_or("device stream decode failed");
+        return Err(reason.to_string());
+    }
+
+    if requires_video {
+        parse_video_metadata(&stderr).map(Some)
+    } else {
+        Ok(None)
+    }
 }
 
 /// Stop the FFmpeg process gracefully by writing "q" to stdin and waiting for exit.
 /// For window capture: signals capture thread to stop (which drops stdin → EOF).
 /// For screen/area capture: writes "q\n" to stdin of std::process::Child.
+fn wait_for_capture_thread(
+    thread: &std::thread::JoinHandle<()>,
+    timeout: std::time::Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while !thread.is_finished() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    thread.is_finished()
+}
+
 fn kill_ffmpeg(app: &AppHandle) {
     let state = app.state::<Mutex<AppState>>();
 
@@ -2099,8 +3369,38 @@ fn kill_ffmpeg(app: &AppHandle) {
             s.window_capture_thread.take()
         };
         if let Some(thread) = thread {
-            thread.join().ok();
-            log::info!("[kill_ffmpeg] Window capture thread joined");
+            let graceful_timeout = std::time::Duration::from_millis(750);
+            if !wait_for_capture_thread(&thread, graceful_timeout) {
+                log::warn!(
+                    "[kill_ffmpeg] Window capture writer did not stop; terminating FFmpeg to unblock it"
+                );
+                let mut stalled_process = {
+                    let mut state = state.lock().unwrap();
+                    state.ffmpeg_process.take()
+                };
+                if let Some(process) = stalled_process.as_mut() {
+                    let _ = process.kill();
+                } else {
+                    let pid = state.lock().unwrap().ffmpeg_child_id;
+                    if let Some(pid) = pid {
+                        force_kill_ffmpeg(pid);
+                    }
+                }
+                if let Some(process) = stalled_process {
+                    state.lock().unwrap().ffmpeg_process = Some(process);
+                }
+            }
+
+            if wait_for_capture_thread(&thread, graceful_timeout) {
+                thread.join().ok();
+                log::info!("[kill_ffmpeg] Window capture thread joined");
+            } else {
+                // PrintWindow itself can block inside a hung target. FFmpeg is
+                // already terminated, so detach rather than hanging Stop.
+                log::error!(
+                    "[kill_ffmpeg] Window capture thread remained blocked after FFmpeg termination; detaching it"
+                );
+            }
         }
     }
 
@@ -2149,6 +3449,7 @@ fn kill_ffmpeg(app: &AppHandle) {
                 Err(e) => {
                     log::error!("[kill_ffmpeg] Error waiting for FFmpeg: {}", e);
                     process.kill().ok();
+                    process.wait().ok();
                     return;
                 }
             }
@@ -2826,4 +4127,510 @@ pub async fn finalize_camera_file(app: AppHandle) -> AppResult<()> {
         std::io::Write::flush(&mut file)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_directory(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("flowtake-{}-{}", label, uuid::Uuid::new_v4()))
+    }
+
+    #[derive(Debug)]
+    struct RejectCentralDirectoryWriter {
+        inner: std::io::Cursor<Vec<u8>>,
+        reject_next_central_directory: bool,
+    }
+
+    impl Default for RejectCentralDirectoryWriter {
+        fn default() -> Self {
+            Self {
+                inner: std::io::Cursor::new(Vec::new()),
+                reject_next_central_directory: true,
+            }
+        }
+    }
+
+    impl std::io::Write for RejectCentralDirectoryWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            if self.reject_next_central_directory
+                && buffer.windows(4).any(|bytes| bytes == b"PK\x01\x02")
+            {
+                self.reject_next_central_directory = false;
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "injected central-directory failure",
+                ));
+            }
+            std::io::Write::write(&mut self.inner, buffer)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            std::io::Write::flush(&mut self.inner)
+        }
+    }
+
+    impl std::io::Seek for RejectCentralDirectoryWriter {
+        fn seek(&mut self, position: std::io::SeekFrom) -> std::io::Result<u64> {
+            std::io::Seek::seek(&mut self.inner, position)
+        }
+    }
+
+    fn option_value<'a>(args: &'a [String], option: &str) -> Option<&'a str> {
+        args.iter()
+            .position(|arg| arg == option)
+            .and_then(|index| args.get(index + 1))
+            .map(String::as_str)
+    }
+
+    #[test]
+    fn recording_capture_can_only_be_claimed_once_until_released() {
+        let mut state = AppState::new();
+        state.is_recording = true;
+        assert!(try_claim_recording_capture(&mut state));
+        assert!(!try_claim_recording_capture(&mut state));
+
+        state.recording_capture_claimed = false;
+        assert!(try_claim_recording_capture(&mut state));
+    }
+
+    #[test]
+    fn pending_save_token_blocks_a_new_recording_init() {
+        let mut state = AppState::new();
+        state.project_id = Some("open-editor-project".to_string());
+        assert!(!recording_init_is_blocked(&state));
+
+        state.recording_id = Some("recording-retry".to_string());
+        assert!(recording_init_is_blocked(&state));
+    }
+
+    #[test]
+    fn failed_start_cleanup_releases_session_ids_and_retry_guards() {
+        let root = test_directory("failed-start-cleanup");
+        let mut state = AppState::new();
+        state.temp_dir = root.clone();
+        state.is_recording = true;
+        state.recording_capture_claimed = true;
+        state.recording_id = Some("recording-failed".to_string());
+        state.project_id = Some("project-failed".to_string());
+        state.camera_mic_config = Some(serde_json::json!({"ffmpegArgs": ["bad"]}));
+        state.multi_app_finalize_error = Some("old failure".to_string());
+
+        let directories = clear_failed_recording_start(&mut state);
+        assert_eq!(directories.len(), 2);
+        assert!(!state.is_recording);
+        assert!(!state.recording_capture_claimed);
+        assert!(state.recording_id.is_none());
+        assert!(state.project_id.is_none());
+        assert!(state.camera_mic_config.is_none());
+        assert!(state.multi_app_finalize_error.is_none());
+    }
+
+    #[test]
+    fn recording_lifecycle_requires_init_and_makes_stop_idempotent() {
+        let mut state = AppState::new();
+        assert!(!recording_start_prerequisites_met(&state));
+
+        state.is_recording = true;
+        state.recording_id = Some("recording-test".to_string());
+        state.camera_mic_config = Some(serde_json::json!({
+            "ffmpegArgs": ["-f", "lavfi", "-i", "ddagrab=output_idx=0"]
+        }));
+        assert!(recording_start_prerequisites_met(&state));
+
+        state.recording_capture_claimed = true;
+        assert!(try_begin_recording_stop(&mut state));
+        assert!(!state.recording_capture_claimed);
+        assert!(!state.is_recording);
+        assert!(!try_begin_recording_stop(&mut state));
+    }
+
+    #[test]
+    fn failed_project_save_keeps_one_retry_token_until_commit() {
+        let mut state = AppState::new();
+        state.is_recording = true;
+        state.recording_id = Some("recording-retry".to_string());
+        state.project_id = Some("project-retry".to_string());
+
+        assert!(try_begin_recording_stop(&mut state));
+        state.recording_stop_in_progress = false;
+        assert!(try_begin_recording_stop(&mut state));
+
+        state.recording_stop_in_progress = false;
+        state.recording_id = None;
+        assert!(!try_begin_recording_stop(&mut state));
+    }
+
+    #[test]
+    fn recording_output_honors_selected_encoder_and_fps() {
+        let args = recording_video_output_args("libx264", 60, 1920, 1080, "performance", false);
+        assert_eq!(option_value(&args, "-c:v"), Some("libx264"));
+        assert_eq!(option_value(&args, "-r"), Some("60"));
+        assert_eq!(option_value(&args, "-preset"), Some("ultrafast"));
+        assert_eq!(option_value(&args, "-pix_fmt"), Some("yuv420p"));
+
+        let qsv = recording_video_output_args("h264_qsv", 60, 1920, 1080, "balanced", false);
+        assert_eq!(option_value(&qsv, "-pix_fmt"), None);
+        assert_eq!(option_value(&qsv, "-preset"), Some("veryfast"));
+        assert_eq!(option_value(&qsv, "-async_depth"), Some("2"));
+
+        let nvenc = recording_video_output_args("h264_nvenc", 60, 1920, 1080, "balanced", false);
+        assert_eq!(option_value(&nvenc, "-pix_fmt"), None);
+    }
+
+    #[test]
+    fn qsv_performance_tuning_does_not_change_balanced_or_quality() {
+        let performance =
+            recording_video_output_args("h264_qsv", 30, 1920, 1080, "performance", true);
+        assert_eq!(option_value(&performance, "-preset"), Some("veryfast"));
+        assert_eq!(option_value(&performance, "-async_depth"), Some("1"));
+        assert_eq!(option_value(&performance, "-bf"), Some("0"));
+
+        let balanced = recording_video_output_args("h264_qsv", 30, 1920, 1080, "balanced", true);
+        assert_eq!(option_value(&balanced, "-preset"), Some("veryfast"));
+        assert_eq!(option_value(&balanced, "-async_depth"), Some("2"));
+        assert_eq!(option_value(&balanced, "-bf"), None);
+
+        let quality = recording_video_output_args("h264_qsv", 30, 1920, 1080, "quality", true);
+        assert_eq!(option_value(&quality, "-preset"), Some("medium"));
+        assert_eq!(option_value(&quality, "-async_depth"), Some("2"));
+        assert_eq!(option_value(&quality, "-bf"), None);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn qsv_pixel_format_is_hardware_only_for_ddagrab_zero_copy() {
+        let mut dxgi_args = Vec::new();
+        append_recording_output_args(
+            &mut dxgi_args,
+            RecordingOutputConfig {
+                video_filters: &[ddagrab_transfer_filter("h264_qsv").unwrap().to_string()],
+                encoder: "h264_qsv",
+                fps: 30,
+                width: 1920,
+                height: 1080,
+                quality: "balanced",
+                has_system_audio: false,
+                stop_on_video_eof: false,
+            },
+        );
+        assert_eq!(option_value(&dxgi_args, "-pix_fmt"), Some("qsv"));
+
+        let mut gdi_args = Vec::new();
+        append_recording_output_args(
+            &mut gdi_args,
+            RecordingOutputConfig {
+                video_filters: &[],
+                encoder: "h264_qsv",
+                fps: 30,
+                width: 1920,
+                height: 1080,
+                quality: "balanced",
+                has_system_audio: false,
+                stop_on_video_eof: false,
+            },
+        );
+        assert_eq!(option_value(&gdi_args, "-pix_fmt"), None);
+    }
+
+    #[test]
+    fn hardware_bitrate_scales_with_resolution_fps_and_quality() {
+        let hd = target_video_bitrate_kbps(1920, 1080, 30, "balanced");
+        let high_motion_4k = target_video_bitrate_kbps(3840, 2160, 60, "quality");
+        assert_eq!(hd, 9_000);
+        assert!(high_motion_4k > hd);
+        assert!(high_motion_4k <= 60_000);
+
+        let area = serde_json::json!({ "type": "area", "width": 50.0, "height": 50.0 });
+        assert_eq!(
+            estimated_recording_dimensions(&area, "area", 3840, 2160),
+            (1920, 1080)
+        );
+    }
+
+    #[test]
+    fn output_options_follow_all_inputs_and_map_audio_explicitly() {
+        let mut args = vec![
+            "-f".to_string(),
+            "lavfi".to_string(),
+            "-i".to_string(),
+            "ddagrab=output_idx=0".to_string(),
+            "-f".to_string(),
+            "dshow".to_string(),
+            "-i".to_string(),
+            "audio=loopback".to_string(),
+        ];
+        append_recording_output_args(
+            &mut args,
+            RecordingOutputConfig {
+                video_filters: &["hwdownload,format=bgra".to_string()],
+                encoder: "libx264",
+                fps: 30,
+                width: 1920,
+                height: 1080,
+                quality: "balanced",
+                has_system_audio: true,
+                stop_on_video_eof: false,
+            },
+        );
+
+        let last_input = args.iter().rposition(|arg| arg == "-i").unwrap();
+        let video_filter = args.iter().position(|arg| arg == "-vf").unwrap();
+        assert!(video_filter > last_input);
+        assert!(args.windows(2).any(|pair| pair == ["-map", "0:v:0"]));
+        assert!(args.windows(2).any(|pair| pair == ["-map", "1:a:0"]));
+        assert!(!args.iter().any(|arg| arg.contains('?')));
+        assert!(args.windows(2).any(|pair| pair == ["-c:a", "aac"]));
+        assert!(!args.iter().any(|arg| arg == "-shortest"));
+    }
+
+    #[test]
+    fn raw_window_audio_pads_before_using_video_eof_as_stop_signal() {
+        let mut args = Vec::new();
+        append_recording_output_args(
+            &mut args,
+            RecordingOutputConfig {
+                video_filters: &[],
+                encoder: "libx264",
+                fps: 30,
+                width: 1920,
+                height: 1080,
+                quality: "balanced",
+                has_system_audio: true,
+                stop_on_video_eof: true,
+            },
+        );
+        assert_eq!(
+            option_value(&args, "-af"),
+            Some("aresample=async=1000:first_pts=0,apad")
+        );
+        assert!(args.iter().any(|arg| arg == "-shortest"));
+    }
+
+    #[test]
+    fn parses_duration_and_dimensions_from_single_probe_output() {
+        let stderr = r#"
+Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'screen.mp4':
+  Duration: 00:02:03.45, start: 0.000000, bitrate: 8200 kb/s
+  Stream #0:0: Video: h264, yuv420p(progressive), 2560x1440 [SAR 1:1 DAR 16:9], 60 fps
+"#;
+        assert_eq!(
+            parse_video_metadata(stderr),
+            Ok(VideoMetadata {
+                duration_ms: Some(123_450),
+                width: 2560,
+                height: 1440,
+            })
+        );
+    }
+
+    #[test]
+    fn selected_system_audio_is_required_by_screen_validation() {
+        let path = std::path::Path::new("screen.mp4");
+        let with_audio = screen_recording_probe_args(path, true);
+        assert!(with_audio.windows(2).any(|pair| pair == ["-map", "0:v:0"]));
+        assert!(with_audio.windows(2).any(|pair| pair == ["-map", "0:a:0"]));
+        assert!(with_audio.windows(2).any(|pair| pair == ["-frames:a", "1"]));
+        assert!(!with_audio.iter().any(|arg| arg.contains('?')));
+
+        let video_only = screen_recording_probe_args(path, false);
+        assert!(!video_only.iter().any(|arg| arg == "0:a:0"));
+    }
+
+    #[test]
+    fn capture_thread_wait_has_a_hard_timeout() {
+        let thread = std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(120));
+        });
+        assert!(!wait_for_capture_thread(
+            &thread,
+            std::time::Duration::from_millis(5)
+        ));
+        assert!(wait_for_capture_thread(
+            &thread,
+            std::time::Duration::from_secs(1)
+        ));
+        thread.join().unwrap();
+    }
+
+    #[test]
+    fn capture_start_rejects_an_immediate_child_exit() {
+        #[cfg(target_os = "windows")]
+        let mut exited = std::process::Command::new("cmd.exe")
+            .args(["/C", "exit", "7"])
+            .spawn()
+            .unwrap();
+        #[cfg(not(target_os = "windows"))]
+        let mut exited = std::process::Command::new("sh")
+            .args(["-c", "exit 7"])
+            .spawn()
+            .unwrap();
+
+        let error = verify_capture_process_start(
+            &mut exited,
+            std::time::Duration::from_millis(250),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("exited during capture startup"), "{error}");
+    }
+
+    #[test]
+    fn device_probe_requires_every_selected_stream() {
+        let path = std::path::Path::new("camera.webm");
+        let combined = device_recording_probe_args(path, true, true).unwrap();
+        assert!(combined.windows(2).any(|pair| pair == ["-map", "0:v:0"]));
+        assert!(combined.windows(2).any(|pair| pair == ["-map", "0:a:0"]));
+        assert!(!combined.iter().any(|arg| arg.contains('?')));
+
+        let audio_only = device_recording_probe_args(path, false, true).unwrap();
+        assert!(audio_only.windows(2).any(|pair| pair == ["-map", "0:a:0"]));
+        assert!(!audio_only.iter().any(|arg| arg == "0:v:0"));
+        assert!(device_recording_probe_args(path, false, false).is_err());
+    }
+
+    #[test]
+    fn retry_accepts_an_already_staged_required_file() {
+        let root = test_directory("staged-retry");
+        std::fs::create_dir_all(&root).unwrap();
+        let capture = root.join("recording").join("screen.mp4");
+        let staged = root.join("screen.mp4");
+        std::fs::write(&staged, b"screen-bytes").unwrap();
+
+        let source = recording_save_source(&capture, &staged);
+        assert_eq!(source, staged);
+        move_or_copy_recording_file(&source, &staged, "screen recording").unwrap();
+        assert_eq!(std::fs::read(&staged).unwrap(), b"screen-bytes");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn selected_app_layer_cannot_be_silently_omitted() {
+        let root = test_directory("missing-required-app-layer");
+        std::fs::create_dir_all(&root).unwrap();
+        let track = crate::commands::multi_app::CapturedTrack {
+            id: "window-1".to_string(),
+            name: "Required window".to_string(),
+            filename: "extra-0.mp4".to_string(),
+            width: 1280,
+            height: 720,
+            start_offset_ms: 0,
+        };
+
+        let error = successful_extra_tracks(&root, vec![track])
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("selected track is missing"), "{error}");
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn staged_retry_replaces_only_its_unpublished_archive() {
+        let root = test_directory("archive-retry");
+        std::fs::create_dir_all(&root).unwrap();
+        let archive = root.join("project.zip");
+        std::fs::write(&archive, b"old-attempt").unwrap();
+
+        assert!(prepare_project_archive_destination(&archive, false).is_err());
+        assert!(archive.exists());
+        prepare_project_archive_destination(&archive, true).unwrap();
+        assert!(!archive.exists());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn ddagrab_only_downloads_frames_for_software_encoding() {
+        assert_eq!(ddagrab_transfer_filter("h264_nvenc"), None);
+        assert_eq!(
+            ddagrab_transfer_filter("h264_qsv"),
+            Some("hwmap=derive_device=qsv:mode=read+write+direct")
+        );
+        assert_eq!(
+            ddagrab_transfer_filter("libx264"),
+            Some("hwdownload,format=bgra")
+        );
+    }
+
+    #[test]
+    fn project_zip_contains_every_required_entry() {
+        let root = test_directory("zip-success");
+        std::fs::create_dir_all(&root).unwrap();
+        let manifest = root.join("project.json");
+        let screen = root.join("screen.mp4");
+        let extra = root.join("extra-2.mp4");
+        std::fs::write(&manifest, br#"{"version":1}"#).unwrap();
+        std::fs::write(&screen, b"screen-bytes").unwrap();
+        std::fs::write(&extra, b"extra-track-bytes").unwrap();
+        let entries = vec![
+            ProjectArchiveEntry {
+                archive_name: "project.json".to_string(),
+                source_path: manifest,
+            },
+            ProjectArchiveEntry {
+                archive_name: "screen.mp4".to_string(),
+                source_path: screen,
+            },
+            ProjectArchiveEntry {
+                archive_name: "extra-2.mp4".to_string(),
+                source_path: extra,
+            },
+        ];
+
+        let writer = write_project_zip(std::io::Cursor::new(Vec::new()), &entries).unwrap();
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(writer.into_inner())).unwrap();
+        assert_eq!(archive.len(), 3);
+        assert_eq!(archive.by_name("screen.mp4").unwrap().size(), 12);
+        assert_eq!(archive.by_name("extra-2.mp4").unwrap().size(), 17);
+        assert!(archive.by_name("extra-1.mp4").is_err());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn project_zip_propagates_finish_failure() {
+        let root = test_directory("zip-finish-failure");
+        std::fs::create_dir_all(&root).unwrap();
+        let screen = root.join("screen.mp4");
+        std::fs::write(&screen, b"screen-bytes").unwrap();
+        let entries = vec![ProjectArchiveEntry {
+            archive_name: "screen.mp4".to_string(),
+            source_path: screen,
+        }];
+
+        let error = write_project_zip(RejectCentralDirectoryWriter::default(), &entries)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("finalizing the project archive"), "{error}");
+        assert!(
+            error.contains("injected central-directory failure"),
+            "{error}"
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn failed_archive_removes_partial_file_and_never_commits_destination() {
+        let root = test_directory("zip-cleanup");
+        std::fs::create_dir_all(&root).unwrap();
+        let destination = root.join("project.zip");
+        let entries = vec![ProjectArchiveEntry {
+            archive_name: "screen.mp4".to_string(),
+            source_path: root.join("missing-screen.mp4"),
+        }];
+
+        let error = create_project_archive(&destination, &entries)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("screen.mp4"), "{error}");
+        assert!(!destination.exists());
+        assert!(!partial_archive_path(&destination).exists());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -6,8 +6,14 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_store::StoreExt;
 
 /// Read the content-protection preference from the store.
-/// Returns `true` (protected / hidden from capture) when the key is absent.
+/// Release builds default to protected/hidden so Flowtake never appears in a
+/// user's recording. Debug builds are deliberately capturable, which keeps
+/// visual QA possible without weakening production privacy.
 pub fn is_content_protection_enabled(app: &AppHandle) -> bool {
+    if cfg!(debug_assertions) {
+        return false;
+    }
+
     app.store("store.json")
         .ok()
         .and_then(|s| s.get("contentProtectionEnabled"))
@@ -336,10 +342,10 @@ async fn capture_desktop_screenshot(app: &AppHandle) -> AppResult<()> {
     #[cfg(target_os = "windows")]
     {
         let screenshot_path = temp_dir.join("picker_bg.bmp");
-        return tokio::task::spawn_blocking(move || capture_desktop_to_bmp(&screenshot_path))
+        tokio::task::spawn_blocking(move || capture_desktop_to_bmp(&screenshot_path))
             .await
             .map_err(|e| AppError::General(format!("Join error: {e}")))?
-            .map_err(AppError::General);
+            .map_err(AppError::General)
     }
 
     #[cfg(target_os = "macos")]
@@ -454,33 +460,56 @@ pub async fn select_window(app: AppHandle, window: Value) -> AppResult<()> {
     Ok(())
 }
 
+fn intersect_window_with_desktop(
+    x: i64,
+    y: i64,
+    width: i64,
+    height: i64,
+    desktop: (i64, i64, i64, i64),
+) -> Option<(i64, i64, i64, i64)> {
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+
+    let (desktop_left, desktop_top, desktop_right, desktop_bottom) = desktop;
+    let left = x.max(desktop_left);
+    let top = y.max(desktop_top);
+    let right = x.saturating_add(width).min(desktop_right);
+    let bottom = y.saturating_add(height).min(desktop_bottom);
+
+    (right > left && bottom > top).then_some((left, top, right - left, bottom - top))
+}
+
 #[tauri::command]
 pub async fn get_windows(app: AppHandle) -> AppResult<Value> {
-    // Screen dimensions used for clamping enumerated window bounds.
-    // - Windows: bounds come from GetWindowRect in physical pixels, but the PowerShell
-    //   C# host is DPI-unaware so it reports already-scaled-down pixels; divide by scale.
-    // - macOS: enumerate_windows_macos now returns physical pixels (logical points * scale),
-    //   so clamp against physical screen dimensions directly.
-    let (screen_w, screen_h) = if let Some(main_win) = app.get_webview_window("main") {
-        if let Ok(Some(monitor)) = main_win.current_monitor() {
+    // Clamp against the complete virtual desktop, including monitors whose
+    // origins are negative or lie beyond the monitor containing Flowtake.
+    // Every platform enumerator reports physical desktop pixels. The Windows
+    // helper opts its enumeration thread into per-monitor DPI awareness so
+    // GetWindowRect matches Tauri's monitor coordinates on mixed-DPI setups.
+    let desktop_bounds = app
+        .available_monitors()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|monitor| {
+            let position = monitor.position();
             let size = monitor.size();
-            #[cfg(target_os = "macos")]
-            let dims = (size.width as i64, size.height as i64);
-            #[cfg(not(target_os = "macos"))]
-            let dims = {
-                let scale = monitor.scale_factor();
-                (
-                    (size.width as f64 / scale) as i64,
-                    (size.height as f64 / scale) as i64,
-                )
-            };
-            dims
-        } else {
-            (1920, 1080)
-        }
-    } else {
-        (1920, 1080)
-    };
+            (
+                position.x as i64,
+                position.y as i64,
+                position.x as i64 + size.width as i64,
+                position.y as i64 + size.height as i64,
+            )
+        })
+        .reduce(|combined, monitor| {
+            (
+                combined.0.min(monitor.0),
+                combined.1.min(monitor.1),
+                combined.2.max(monitor.2),
+                combined.3.max(monitor.3),
+            )
+        })
+        .unwrap_or((0, 0, 1920, 1080));
 
     // Get our own process ID to filter out our windows
     let our_pid = std::process::id();
@@ -526,14 +555,11 @@ pub async fn get_windows(app: AppHandle) -> AppResult<Value> {
                 let width = obj.get("width").and_then(|v| v.as_i64()).unwrap_or(0);
                 let height = obj.get("height").and_then(|v| v.as_i64()).unwrap_or(0);
 
-                let clamped_x = x.max(0);
-                let clamped_y = y.max(0);
-                let clamped_w = (width - (clamped_x - x)).min(screen_w - clamped_x);
-                let clamped_h = (height - (clamped_y - y)).min(screen_h - clamped_y);
-
-                if clamped_w <= 0 || clamped_h <= 0 {
+                let Some((clamped_x, clamped_y, clamped_w, clamped_h)) =
+                    intersect_window_with_desktop(x, y, width, height, desktop_bounds)
+                else {
                     return Value::Null; // will be filtered
-                }
+                };
 
                 obj.insert("x".to_string(), serde_json::json!(clamped_x));
                 obj.insert("y".to_string(), serde_json::json!(clamped_y));
@@ -774,19 +800,14 @@ pub async fn get_window_at_point(_app: AppHandle, x: i32, y: i32) -> AppResult<V
                 && data.y >= rect.top
                 && data.y < rect.bottom
             {
-                // Clamp to avoid negative coords (invisible window borders)
-                let cx = rect.left.max(0);
-                let cy = rect.top.max(0);
-                let cw = w - (cx - rect.left);
-                let ch = h - (cy - rect.top);
                 let val = serde_json::json!({
                     "name": title,
                     "id": (hwnd.0 as i64).to_string(),
                     "type": "window",
-                    "x": cx,
-                    "y": cy,
-                    "width": cw,
-                    "height": ch
+                    "x": rect.left,
+                    "y": rect.top,
+                    "width": w,
+                    "height": h
                 });
                 *data.result.lock().unwrap() = Some(val);
                 return BOOL(0); // Stop enumeration
@@ -916,10 +937,15 @@ public class WinEnum {
     public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
     [DllImport("user32.dll")]
     public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+    [DllImport("user32.dll")]
+    public static extern IntPtr SetThreadDpiAwarenessContext(IntPtr dpiContext);
     public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
     [StructLayout(LayoutKind.Sequential)]
     public struct RECT { public int Left, Top, Right, Bottom; }
     public static List<Dictionary<string, object>> GetVisibleWindows(uint[] excludePids) {
+        // PER_MONITOR_AWARE_V2 makes GetWindowRect return physical virtual-
+        // desktop coordinates, including negative secondary-monitor origins.
+        IntPtr previousDpiContext = SetThreadDpiAwarenessContext(new IntPtr(-4));
         var pidSet = new HashSet<uint>(excludePids);
         var result = new List<Dictionary<string, object>>();
         EnumWindows((hWnd, lParam) => {
@@ -953,6 +979,9 @@ public class WinEnum {
             result.Add(dict);
             return true;
         }, IntPtr.Zero);
+        if (previousDpiContext != IntPtr.Zero) {
+            SetThreadDpiAwarenessContext(previousDpiContext);
+        }
         return result;
     }
 }
@@ -1375,4 +1404,37 @@ pub async fn close_live_composer(app: AppHandle) -> AppResult<()> {
         win.close().map_err(AppError::Tauri)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::intersect_window_with_desktop;
+
+    #[test]
+    fn window_intersection_keeps_secondary_monitor_coordinates() {
+        let desktop = (-1920, 0, 3840, 1080);
+
+        assert_eq!(
+            intersect_window_with_desktop(-1700, 100, 900, 700, desktop),
+            Some((-1700, 100, 900, 700))
+        );
+        assert_eq!(
+            intersect_window_with_desktop(2200, 80, 1200, 800, desktop),
+            Some((2200, 80, 1200, 800))
+        );
+    }
+
+    #[test]
+    fn window_intersection_clips_only_the_off_desktop_portion() {
+        let desktop = (-1920, -1080, 1920, 1080);
+
+        assert_eq!(
+            intersect_window_with_desktop(-2100, -1200, 500, 500, desktop),
+            Some((-1920, -1080, 320, 380))
+        );
+        assert_eq!(
+            intersect_window_with_desktop(2500, 0, 500, 500, desktop),
+            None
+        );
+    }
 }

--- a/src-tauri/src/keyboard_tracker.rs
+++ b/src-tauri/src/keyboard_tracker.rs
@@ -127,7 +127,10 @@ impl KeyboardTracker {
 
 // ── Windows implementation ──────────────────────────────────────────────────
 #[cfg(target_os = "windows")]
-static KB_EVENTS: std::sync::LazyLock<Mutex<Option<Arc<Mutex<Vec<KeyEvent>>>>>> =
+type SharedKeyEvents = Arc<Mutex<Vec<KeyEvent>>>;
+
+#[cfg(target_os = "windows")]
+static KB_EVENTS: std::sync::LazyLock<Mutex<Option<SharedKeyEvents>>> =
     std::sync::LazyLock::new(|| Mutex::new(None));
 
 #[cfg(target_os = "windows")]
@@ -246,7 +249,7 @@ fn vk_to_name(vk: u32) -> String {
     let v = vk as u16;
 
     // F1..F24
-    if v >= VK_F1.0 && v <= VK_F24.0 {
+    if (VK_F1.0..=VK_F24.0).contains(&v) {
         return format!("F{}", v - VK_F1.0 + 1);
     }
     // 0..9 top row
@@ -258,7 +261,7 @@ fn vk_to_name(vk: u32) -> String {
         return ((v as u8) as char).to_string();
     }
     // Numpad 0..9
-    if v >= VK_NUMPAD0.0 && v <= VK_NUMPAD9.0 {
+    if (VK_NUMPAD0.0..=VK_NUMPAD9.0).contains(&v) {
         return format!("Num{}", v - VK_NUMPAD0.0);
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,10 +5,11 @@
 extern crate objc;
 
 mod commands;
-mod state;
 mod error;
 mod keyboard_tracker;
 mod mouse_tracker;
+mod process_containment;
+mod state;
 
 use state::AppState;
 use std::sync::Mutex;
@@ -69,6 +70,60 @@ fn cleanup_stale_recording_temp_dirs(temp_dir: &std::path::Path) {
     }
 }
 
+fn terminate_owned_recording_children_on_exit(app: &tauri::AppHandle) {
+    use std::io::Write;
+    use std::sync::atomic::Ordering;
+
+    let (main_capture, app_layers, live_stream, window_thread, camera_file) = {
+        let state = app.state::<Mutex<AppState>>();
+        let mut state = state.lock().unwrap();
+        state.window_capture_stop.store(true, Ordering::Relaxed);
+        state.live_stop_flag.store(true, Ordering::Relaxed);
+        state.live_stdin_tx = None;
+        state.is_recording = false;
+        state.recording_capture_claimed = false;
+        state.recording_stop_in_progress = false;
+        state.multi_app_init_in_progress = false;
+        state.multi_app_stop_requested = true;
+        state.ffmpeg_child_id = None;
+        (
+            state.ffmpeg_process.take(),
+            std::mem::take(&mut state.multi_app_children),
+            state.live_ffmpeg_process.take(),
+            state.window_capture_thread.take(),
+            state.camera_file_handle.take(),
+        )
+    };
+
+    if let Some(mut camera_file) = camera_file {
+        camera_file.flush().ok();
+    }
+    if let Some(child) = main_capture {
+        process_containment::terminate_owned_child(child, "screen-capture FFmpeg").ok();
+    }
+    process_containment::terminate_owned_children(app_layers, "App-layer FFmpeg");
+    if let Some(child) = live_stream {
+        process_containment::terminate_owned_child(child, "live-stream FFmpeg").ok();
+    }
+
+    if let Some(thread) = window_thread {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(500);
+        while !thread.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        if thread.is_finished() {
+            thread.join().ok();
+        } else {
+            log::warn!("[shutdown] Window capture thread did not exit before app shutdown");
+        }
+    }
+
+    // Recording can temporarily mute selected application sessions. Restore
+    // them on every normal desktop exit, including macOS/Linux where the
+    // Windows Job Object crash guarantee is unavailable.
+    commands::audio::unmute_all_sessions(app);
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -76,17 +131,28 @@ pub fn run() {
 
     let app_state = AppState::new();
 
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_window_state::Builder::default()
-            .with_denylist(&["recorder", "drawingOverlay", "areaPicker", "windowPicker", "liveComposer"])
-            .build())
-        .plugin(tauri_plugin_autostart::init(tauri_plugin_autostart::MacosLauncher::LaunchAgent, None))
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_denylist(&[
+                    "recorder",
+                    "drawingOverlay",
+                    "areaPicker",
+                    "windowPicker",
+                    "liveComposer",
+                ])
+                .build(),
+        )
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .manage(Mutex::new(app_state))
         // Register video:// protocol for streaming video files to the editor
@@ -120,16 +186,14 @@ pub fn run() {
             let video_type = video_type.trim_start_matches('/');
 
             // Get projectId from query string
-            let project_id = query
-                .split('&')
-                .find_map(|p| {
-                    let mut parts = p.splitn(2, '=');
-                    if parts.next() == Some("projectId") {
-                        parts.next().map(|s| s.to_string())
-                    } else {
-                        None
-                    }
-                });
+            let project_id = query.split('&').find_map(|p| {
+                let mut parts = p.splitn(2, '=');
+                if parts.next() == Some("projectId") {
+                    parts.next().map(|s| s.to_string())
+                } else {
+                    None
+                }
+            });
 
             // Determine file path
             let file_path = {
@@ -151,7 +215,9 @@ pub fn run() {
                     "camera" | "microphone" => state.camera_video_file(pid),
                     v if v.starts_with("extra-") => {
                         let idx: usize = v.trim_start_matches("extra-").parse().unwrap_or(0);
-                        state.project_temp_dir(pid).join(format!("extra-{}.mp4", idx))
+                        state
+                            .project_temp_dir(pid)
+                            .join(format!("extra-{}.mp4", idx))
                     }
                     _ => state.screen_video_file(pid),
                 }
@@ -170,12 +236,13 @@ pub fn run() {
                 file_path,
                 file_path.metadata().map(|m| m.len()).unwrap_or(0)
             );
-            debug_log(&format!("[video://] Serving file: {:?} (size={})", file_path, file_path.metadata().map(|m| m.len()).unwrap_or(0)));
+            debug_log(&format!(
+                "[video://] Serving file: {:?} (size={})",
+                file_path,
+                file_path.metadata().map(|m| m.len()).unwrap_or(0)
+            ));
 
-            let file_size = file_path
-                .metadata()
-                .map(|m| m.len())
-                .unwrap_or(0);
+            let file_size = file_path.metadata().map(|m| m.len()).unwrap_or(0);
 
             // Determine MIME type
             let mime_type = if video_type == "microphone" {
@@ -198,13 +265,7 @@ pub fn run() {
                 let start: u64 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
                 let end: u64 = parts
                     .get(1)
-                    .and_then(|s| {
-                        if s.is_empty() {
-                            None
-                        } else {
-                            s.parse().ok()
-                        }
-                    })
+                    .and_then(|s| if s.is_empty() { None } else { s.parse().ok() })
                     .unwrap_or(file_size.saturating_sub(1));
                 (start, end.min(file_size.saturating_sub(1)))
             } else {
@@ -348,7 +409,10 @@ pub fn run() {
                         };
 
                         // Prevent path traversal
-                        if filename.contains("..") || filename.contains('/') || filename.contains('\\') {
+                        if filename.contains("..")
+                            || filename.contains('/')
+                            || filename.contains('\\')
+                        {
                             return tauri::http::Response::builder()
                                 .status(400)
                                 .body(Vec::<u8>::new())
@@ -357,7 +421,9 @@ pub fn run() {
 
                         let wallpapers_dir = state.app_data_dir.join("wallpapers");
                         let candidate = wallpapers_dir.join(&filename);
-                        if let (Ok(canonical), Ok(base)) = (candidate.canonicalize(), wallpapers_dir.canonicalize()) {
+                        if let (Ok(canonical), Ok(base)) =
+                            (candidate.canonicalize(), wallpapers_dir.canonicalize())
+                        {
                             if !canonical.starts_with(&base) {
                                 return tauri::http::Response::builder()
                                     .status(400)
@@ -615,6 +681,12 @@ pub fn run() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        if matches!(event, tauri::RunEvent::Exit) {
+            terminate_owned_recording_children_on_exit(app_handle);
+        }
+    });
 }

--- a/src-tauri/src/process_containment.rs
+++ b/src-tauri/src/process_containment.rs
@@ -1,0 +1,225 @@
+//! Crash-path containment for long-lived child processes owned by Flowtake.
+//!
+//! On Windows, recorder FFmpeg processes are assigned to a process-lifetime
+//! Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Windows
+//! closes the job handle when Flowtake exits, including abrupt termination,
+//! and terminates every assigned child that is still running.
+
+/// Assign a Flowtake-owned child to the process-lifetime containment group.
+///
+/// Containment is deliberately best-effort. A restrictive parent Job Object
+/// or endpoint policy can reject nested job assignment; that must not make a
+/// recording fail after FFmpeg has already started.
+pub(crate) fn contain_owned_child(child: &std::process::Child, purpose: &str) {
+    #[cfg(target_os = "windows")]
+    if let Err(error) = windows_job::assign(child) {
+        log::warn!(
+            "[process_containment] Could not contain {} (pid {}): {}. \
+             Graceful shutdown remains available, but abrupt app termination \
+             may leave this child running.",
+            purpose,
+            child.id(),
+            error
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    let _ = (child, purpose);
+}
+
+/// Synchronously terminate and reap a child during application shutdown.
+/// Windows Job Objects cover abrupt process death; this explicit path also
+/// gives macOS/Linux normal exits deterministic cleanup and prevents zombies.
+pub(crate) fn terminate_owned_child(
+    mut child: std::process::Child,
+    purpose: &str,
+) -> Result<std::process::ExitStatus, String> {
+    match child.try_wait() {
+        Ok(Some(status)) => return Ok(status),
+        Ok(None) => {}
+        Err(error) => log::warn!(
+            "[process_containment] Could not query {} (pid {}): {}",
+            purpose,
+            child.id(),
+            error
+        ),
+    }
+
+    if let Err(error) = child.kill() {
+        // The child can exit between try_wait and kill. Always attempt wait so
+        // that case is reaped before deciding cleanup failed.
+        log::debug!(
+            "[process_containment] Kill for {} (pid {}) returned: {}",
+            purpose,
+            child.id(),
+            error
+        );
+    }
+    child
+        .wait()
+        .map_err(|error| format!("could not reap {} (pid {}): {}", purpose, child.id(), error))
+}
+
+pub(crate) fn terminate_owned_children(
+    children: Vec<std::process::Child>,
+    purpose: &str,
+) {
+    for child in children {
+        if let Err(error) = terminate_owned_child(child, purpose) {
+            log::warn!("[process_containment] {}", error);
+        }
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn explicit_shutdown_terminates_and_reaps_a_running_child() {
+        #[cfg(target_os = "windows")]
+        let child = Command::new("ping.exe")
+            .args(["-n", "30", "127.0.0.1"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn Windows sleeper");
+
+        #[cfg(not(target_os = "windows"))]
+        let child = Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn Unix sleeper");
+
+        let status = terminate_owned_child(child, "test child").expect("terminate child");
+        assert!(!status.success());
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows_job {
+    use std::ffi::c_void;
+    use std::mem::size_of;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use std::process::Child;
+    use std::sync::OnceLock;
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    static FLOWTAKE_CHILD_JOB: OnceLock<Result<OwnedHandle, String>> = OnceLock::new();
+
+    fn kill_on_close_limits() -> JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        limits
+    }
+
+    fn as_windows_handle(handle: &OwnedHandle) -> HANDLE {
+        HANDLE(handle.as_raw_handle())
+    }
+
+    fn create_kill_on_close_job() -> Result<OwnedHandle, String> {
+        // SAFETY: null security attributes and an unnamed job are valid. The
+        // returned raw handle is transferred exactly once into OwnedHandle.
+        let raw_job = unsafe { CreateJobObjectW(None, PCWSTR::null()) }
+            .map_err(|error| format!("CreateJobObjectW failed: {error}"))?;
+        let job = unsafe { OwnedHandle::from_raw_handle(raw_job.0) };
+
+        let limits = kill_on_close_limits();
+        // SAFETY: the information pointer and byte count describe a live,
+        // correctly aligned JOBOBJECT_EXTENDED_LIMIT_INFORMATION value.
+        unsafe {
+            SetInformationJobObject(
+                as_windows_handle(&job),
+                JobObjectExtendedLimitInformation,
+                &limits as *const JOBOBJECT_EXTENDED_LIMIT_INFORMATION as *const c_void,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        }
+        .map_err(|error| format!("SetInformationJobObject failed: {error}"))?;
+
+        Ok(job)
+    }
+
+    fn process_lifetime_job() -> Result<&'static OwnedHandle, &'static str> {
+        match FLOWTAKE_CHILD_JOB.get_or_init(create_kill_on_close_job) {
+            Ok(job) => Ok(job),
+            Err(error) => Err(error.as_str()),
+        }
+    }
+
+    fn assign_to_job(job: &OwnedHandle, child: &Child) -> Result<(), String> {
+        let child_handle = HANDLE(child.as_raw_handle());
+        // SAFETY: both handles are valid for the duration of the call. The
+        // Child owns its process handle and the static job owns its job handle.
+        unsafe { AssignProcessToJobObject(as_windows_handle(job), child_handle) }
+            .map_err(|error| format!("AssignProcessToJobObject failed: {error}"))
+    }
+
+    pub(super) fn assign(child: &Child) -> Result<(), String> {
+        let job = process_lifetime_job().map_err(str::to_owned)?;
+        assign_to_job(job, child)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::process::{Command, Stdio};
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        #[test]
+        fn job_limits_enable_kill_on_close() {
+            let limits = kill_on_close_limits();
+            assert_eq!(
+                limits.BasicLimitInformation.LimitFlags,
+                JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            );
+        }
+
+        /// Manual Windows integration check:
+        /// `cargo test closing_a_job_terminates_its_child -- --ignored`
+        ///
+        /// It is ignored in regular CI because some hosted runners put tests
+        /// in a restrictive Job Object that rejects nested job assignment.
+        #[test]
+        #[ignore = "requires Windows job-assignment privileges"]
+        fn closing_a_job_terminates_its_child() {
+            let job = create_kill_on_close_job().expect("create kill-on-close job");
+            let mut child = Command::new("ping.exe")
+                .args(["-n", "30", "127.0.0.1"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn test child");
+            assign_to_job(&job, &child).expect("assign test child to job");
+
+            drop(job);
+
+            let deadline = Instant::now() + Duration::from_secs(3);
+            loop {
+                match child.try_wait().expect("query test child") {
+                    Some(_) => break,
+                    None if Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(25));
+                    }
+                    None => {
+                        let _ = child.kill();
+                        panic!("child survived after its kill-on-close job was closed");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,16 +1,16 @@
-use std::collections::HashMap;
-use std::fs::File;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-use std::sync::Mutex;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use tauri_plugin_shell::process::CommandChild;
-use tokio::sync::mpsc;
 use crate::commands::multi_app::CapturedTrack;
 use crate::keyboard_tracker::KeyboardTracker;
 use crate::mouse_tracker::MouseTracker;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tauri_plugin_shell::process::CommandChild;
+use tokio::sync::mpsc;
 
 /// Global application state managed by Tauri
 pub struct AppState {
@@ -26,12 +26,30 @@ pub struct AppState {
     pub camera_file_handle: Option<File>,
     pub renders: HashMap<String, RenderState>,
     pub camera_mic_config: Option<Value>,
+    /// Serializes fallible session setup so double-clicks cannot replace the
+    /// active recording ID while the overlay is being created.
+    pub recording_init_in_progress: bool,
+    /// Guards the transition from the countdown UI to the native capture
+    /// process. It stays claimed for the lifetime of a recording so repeated
+    /// start commands are idempotent and cannot orphan an overwritten child.
+    pub recording_capture_claimed: bool,
+    /// Serializes stop/reset/cancel against a capture process that is still
+    /// crossing the spawn boundary.
+    pub recording_stop_in_progress: bool,
     pub ffmpeg_child_id: Option<u32>,
     pub ffmpeg_child: Option<CommandChild>,
     pub mouse_tracker: MouseTracker,
     pub keyboard_tracker: KeyboardTracker,
     pub multi_app_children: Vec<std::process::Child>,
     pub multi_app_tracks: Vec<CapturedTrack>,
+    /// Serializes App-layer startup with an immediate Stop request so children
+    /// cannot be published after the recording has already finalized.
+    pub multi_app_init_in_progress: bool,
+    pub multi_app_stop_requested: bool,
+    /// A selected App-layer capture that failed finalization is a durable
+    /// session error. Keep it across Stop retries so an empty child list cannot
+    /// silently turn a failed required layer into a successful save.
+    pub multi_app_finalize_error: Option<String>,
     pub recording_start_timestamp: Option<i64>,
     pub export_state_data: Option<Value>,
     pub export_section: Option<String>,
@@ -95,12 +113,18 @@ impl AppState {
             camera_file_handle: None,
             renders: HashMap::new(),
             camera_mic_config: None,
+            recording_init_in_progress: false,
+            recording_capture_claimed: false,
+            recording_stop_in_progress: false,
             ffmpeg_child_id: None,
             ffmpeg_child: None,
             mouse_tracker: MouseTracker::new(),
             keyboard_tracker: KeyboardTracker::new(),
             multi_app_children: Vec::new(),
             multi_app_tracks: Vec::new(),
+            multi_app_init_in_progress: false,
+            multi_app_stop_requested: false,
+            multi_app_finalize_error: None,
             recording_start_timestamp: None,
             export_state_data: None,
             export_section: None,

--- a/test/editorStudioLayout.test.js
+++ b/test/editorStudioLayout.test.js
@@ -64,16 +64,22 @@ test("studio title bar keeps mac-style controls wired to window actions", () => 
     assert.match(titleBarSource, /aria-label="Close window"/)
     assert.match(titleBarSource, /aria-label="Minimize window"/)
     assert.match(titleBarSource, /aria-label="Maximize window"/)
-    assert.match(titleBarSource, /getCurrentWindow\(\)\.close\(\)/)
-    assert.match(titleBarSource, /getCurrentWindow\(\)\.minimize\(\)/)
-    assert.match(titleBarSource, /getCurrentWindow\(\)\.toggleMaximize\(\)/)
+    assert.match(titleBarSource, /getCurrentWindow\(\)\[method\]\(\)/)
+    assert.match(titleBarSource, /callWindow\('close'\)/)
+    assert.match(titleBarSource, /callWindow\('minimize'\)/)
+    assert.match(titleBarSource, /callWindow\('toggleMaximize'\)/)
 })
 
 test("studio theme defines clean, bounded editor surfaces", () => {
+    const studioCss = cssSource.slice(
+        cssSource.indexOf(".flowtake-editor {"),
+        cssSource.indexOf("/* ===== Editorial design system")
+    )
+
     assert.match(cssSource, /name:\s*"flowtake-studio"/)
-    assert.match(cssSource, /\.flowtake-panel,\n\s+\.flowtake-icon-rail,\n\s+\.flowtake-asset-rail,\n\s+\.flowtake-properties-card,\n\s+\.flowtake-timeline-surface/)
+    assert.match(cssSource, /\.flowtake-panel,\r?\n\s+\.flowtake-icon-rail,\r?\n\s+\.flowtake-asset-rail,\r?\n\s+\.flowtake-properties-card,\r?\n\s+\.flowtake-timeline-surface/)
     assert.match(cssSource, /\.flowtake-preview__stage/)
     assert.match(cssSource, /\.flowtake-preview__canvas/)
     assert.match(cssSource, /\.flowtake-timeline-scroll/)
-    assert.doesNotMatch(cssSource, /letter-spacing:\s*-[0-9.]/)
+    assert.doesNotMatch(studioCss, /letter-spacing:\s*-[0-9.]/)
 })

--- a/test/firstRunUx.test.js
+++ b/test/firstRunUx.test.js
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const readSource = file => readFile(new URL(file, import.meta.url), "utf8")
+
+const [mainApp, setupWizard, generalSettings, areaPicker, newRecording, recordButton, appLayers] = await Promise.all([
+    readSource("../app/windows/main/App.jsx"),
+    readSource("../app/windows/main/components/SetupWizard.jsx"),
+    readSource("../app/windows/main/components/settings/GeneralSettings.jsx"),
+    readSource("../app/windows/areaPicker/App.jsx"),
+    readSource("../app/windows/main/components/newRecording/NewRecording.jsx"),
+    readSource("../app/windows/main/components/newRecording/RecordButton.jsx"),
+    readSource("../app/windows/main/components/settings/plugin/features/AppRecordingFeature.jsx"),
+])
+
+test("first-run setup stays focused on readiness and recording", () => {
+    assert.match(setupWizard, /\{ id: "permissions", label: "Readiness" \}/)
+    assert.match(setupWizard, /\{ id: "done", label: "Record" \}/)
+    assert.doesNotMatch(setupWizard, /ExportPathStep|AppearanceStep/)
+    assert.match(generalSettings, /flowtake-run-setup/)
+    assert.match(mainApp, /addEventListener\("flowtake-run-setup"/)
+    assert.doesNotMatch(generalSettings, /location\.reload/)
+})
+
+test("restarted recording tutorial closes settings before it starts", () => {
+    assert.match(
+        generalSettings,
+        /const restartTutorial = useCallback\(async \(\) => \{[\s\S]*?setOpenSettings\(null\)[\s\S]*?resetTutorial\(\)[\s\S]*?startTutorial\(\)/
+    )
+})
+
+test("area selection exposes persistent confirmation and keyboard recovery", () => {
+    assert.match(areaPicker, /Record this area/)
+    assert.match(areaPicker, /event\.key === "Enter"/)
+    assert.match(areaPicker, /event\.key === "Escape"/)
+    assert.doesNotMatch(areaPicker, /group-hover:opacity-100/)
+})
+
+test("record action stays outside the scrolling setup and repairs missing engines", () => {
+    const scrollStart = newRecording.indexOf("overflow-y-auto overflow-x-hidden")
+    const scrollEnd = newRecording.indexOf("data-tutorial=\"record-button\"")
+    assert.ok(scrollStart >= 0 && scrollEnd > scrollStart)
+    assert.match(recordButton, /Set up recorder/)
+    assert.doesNotMatch(recordButton, /isLoading=\{[^}]*!capturers/)
+})
+
+test("extra app layers are capped for predictable resource use", () => {
+    assert.match(appLayers, /const MAX_APP_LAYERS = 2/)
+    assert.match(appLayers, /disabled=\{atLimit\}/)
+})

--- a/test/newRecordingPreview.test.js
+++ b/test/newRecordingPreview.test.js
@@ -8,8 +8,10 @@ const source = await readFile(
 )
 
 test("source preview polling avoids screenshot retry storms", () => {
-    assert.match(source, /retry:\s*false/)
-    assert.match(source, /refetchInterval:\s*screenPermissionDenied \|\| previewUnavailable \? 5000 : 2000/)
+    assert.match(source, /retry:\s*\(failureCount, error\)/)
+    assert.match(source, /failureCount < 1 && !message\.includes\("ScreenPermissionDenied"\)/)
+    assert.match(source, /retryDelay:\s*500/)
+    assert.match(source, /refetchInterval:\s*screenPermissionDenied \|\| previewUnavailable \? 10000 : 5000/)
     assert.match(source, /refetchIntervalInBackground:\s*false/)
     assert.match(source, /previewUnavailable/)
     assert.match(source, /refetch:\s*refetchCaptureSourcePreview/)

--- a/test/pluginPersistence.test.js
+++ b/test/pluginPersistence.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { selectPersistedShape } from "../app/shared/redux/pluginSlice.js"
+
+test("persisted plugin settings keep a stable selector result", () => {
+    const plugin = {
+        enabled: { appRecording: false },
+        config: { appRecording: { windowIds: [] } },
+    }
+    const state = { plugin }
+
+    const first = selectPersistedShape(state)
+    const second = selectPersistedShape(state)
+
+    assert.strictEqual(second, first)
+    assert.deepEqual(first, {
+        enabled: plugin.enabled,
+        config: plugin.config,
+    })
+
+    const changed = selectPersistedShape({
+        plugin: { ...plugin, enabled: { appRecording: true } },
+    })
+    assert.notStrictEqual(changed, first)
+})

--- a/test/recorderShell.test.js
+++ b/test/recorderShell.test.js
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const readSource = file => readFile(new URL(file, import.meta.url), "utf8")
+
+const [
+    mainApp,
+    launcher,
+    newRecording,
+    deviceSelect,
+    cameraPreview,
+    recordButton,
+    generalSettings,
+    recorderSettings,
+    speechSettings,
+    updateSettings,
+    plugins,
+    recorderOverlay,
+    recorderTutorial,
+    tutorialSteps,
+    nativeRecording,
+] = await Promise.all([
+    readSource("../app/windows/main/App.jsx"),
+    readSource("../app/windows/main/components/Launcher.jsx"),
+    readSource("../app/windows/main/components/newRecording/NewRecording.jsx"),
+    readSource("../app/windows/main/components/newRecording/CameraMicrophoneSelect.jsx"),
+    readSource("../app/windows/main/components/newRecording/CameraPreview.jsx"),
+    readSource("../app/windows/main/components/newRecording/RecordButton.jsx"),
+    readSource("../app/windows/main/components/settings/GeneralSettings.jsx"),
+    readSource("../app/windows/main/components/settings/RecorderSettings.jsx"),
+    readSource("../app/windows/main/components/settings/SpeechToTextSettings.jsx"),
+    readSource("../app/windows/main/components/settings/UpdatesSettings.jsx"),
+    readSource("../app/windows/main/components/plugins/Plugins.jsx"),
+    readSource("../app/windows/recorder/App.jsx"),
+    readSource("../app/windows/recorder/components/RecorderTutorial.jsx"),
+    readSource("../app/windows/main/components/tutorial/steps.js"),
+    readSource("../src-tauri/src/commands/recording.rs"),
+])
+
+test("cold hardware encoder probing does not hold the startup splash", () => {
+    const splashIndex = mainApp.indexOf("dismissSplash()", mainApp.indexOf("const earlyData"))
+    const encoderIndex = mainApp.indexOf("const e = await earlyData.encoders")
+
+    assert.ok(splashIndex >= 0, "startup should dismiss the splash after cheap setup checks")
+    assert.ok(encoderIndex > splashIndex, "hardware encoder probing should finish after the launcher is visible")
+})
+
+test("launcher mounts only the active lazy view and separates experimental tools", () => {
+    assert.match(launcher, /const NewRecording = lazy/)
+    assert.match(launcher, /const VIEW_ORDER = \[VIEW_RECORD, VIEW_PROJECTS\]/)
+    assert.match(launcher, /const EXPERIMENTAL_VIEW_ORDER = \[VIEW_PLUGINS\]/)
+    assert.doesNotMatch(launcher, /VIEW_LIVE|import\("\.\/live\/Live"\)/)
+    assert.match(launcher, /activeView === VIEW_RECORD && <NewRecording isOpen/)
+    assert.doesNotMatch(launcher, /flowtake-nav-item/)
+})
+
+test("record setup applies audio processing to preview and captured media", () => {
+    for (const source of [cameraPreview, recordButton]) {
+        assert.match(source, /\.\.\.CONSTRAINTS_AUDIO, \.\.\.audioProcessingSettings, deviceId: \{ exact:/)
+    }
+    assert.match(newRecording, /audioProcessingSettings=\{audioProcessingSettings\}/)
+    assert.match(recordButton, /role="alert"/)
+})
+
+test("device detection stays permission-quiet until a deliberate device action", () => {
+    assert.match(deviceSelect, /One lightweight permission probe/)
+    assert.match(deviceSelect, /await navigator\.mediaDevices\.enumerateDevices\(\)/)
+    assert.match(deviceSelect, /device\.deviceId !== "default" && device\.deviceId !== "communications"/)
+    assert.match(deviceSelect, /id: `mediaSource-\$\{device\.deviceId \|\| device\.groupId \|\| device\.label\}`/)
+    assert.doesNotMatch(deviceSelect, /randomUUID/)
+    assert.doesNotMatch(deviceSelect, /useEffect/)
+    assert.doesNotMatch(deviceSelect, /queryKey: \['devices'/)
+    assert.equal(deviceSelect.match(/\bdetectCameras\(/g)?.length, 2)
+    assert.equal(deviceSelect.match(/\bdetectMicrophones\(/g)?.length, 2)
+    assert.match(deviceSelect, /detectCameras\(\{ selectFirst: true \}\)/)
+    assert.match(deviceSelect, /detectMicrophones\(\{ selectFirst: true \}\)/)
+    assert.match(deviceSelect, /cameras\.some\(device => device\.id === camera\)[\s\S]*?\? camera[\s\S]*?: selectFirst \? cameras\[0\]\?\.id \?\? null : null/)
+    assert.match(deviceSelect, /microphones\.some\(device => device\.id === microphone\)[\s\S]*?\? microphone[\s\S]*?: selectFirst \? microphones\[0\]\?\.id \?\? null : null/)
+    assert.match(deviceSelect, /onClick=\{refreshDevices\}/)
+    assert.match(deviceSelect, /Camera and mic stay off until you choose one\./)
+})
+
+test("record shell exposes responsive readiness and accessible source controls", () => {
+    assert.match(newRecording, /flex flex-col md:flex-row/)
+    assert.match(newRecording, /Recording quality summary/)
+    assert.match(newRecording, /\{screenFps \?\? 30\} FPS/)
+    assert.match(newRecording, /recordingQuality \|\| "balanced"/)
+    assert.match(newRecording, /aria-pressed=\{active\}/)
+    assert.match(newRecording, /refetchInterval: screenPermissionDenied \|\| previewUnavailable \? 10000 : 5000/)
+})
+
+test("settings show only controls backed by working behavior", () => {
+    for (const deadKey of ["defaultResolution", "autoSaveInterval", "notificationsEnabled", "isIssueReportingEnabled"]) {
+        assert.doesNotMatch(generalSettings, new RegExp(deadKey))
+    }
+    assert.doesNotMatch(speechSettings, /sttAutoGenerate/)
+    assert.doesNotMatch(updateSettings, /autoUpdateEnabled/)
+    assert.doesNotMatch(recorderSettings, /value="auto"/)
+    assert.match(recorderSettings, /item\?\.value \?\? item\?\.name/)
+    assert.match(recorderSettings, /Refresh video encoders/)
+    assert.match(recorderSettings, /store-get", "recordingQuality"/)
+    assert.match(recorderSettings, /value="performance"/)
+    assert.match(recorderSettings, /value="quality"/)
+})
+
+test("experimental page exposes runtime-backed built-ins without drop-in claims", () => {
+    assert.doesNotMatch(plugins, /list-plugins|open-plugins-folder|Drop-in plugins/)
+    assert.match(plugins, /\[FEATURE_IDS\.APP_RECORDING\]: AppRecordingFeature/)
+    assert.doesNotMatch(plugins, /\[FEATURE_IDS\.MOUSE_STYLE\]: MouseStyleFeature/)
+    assert.doesNotMatch(plugins, /\[FEATURE_IDS\.KEYBOARD_OVERLAY\]: KeyboardOverlayFeature/)
+    assert.match(plugins, /windowsOnly: true/)
+    assert.match(plugins, /aria-expanded=\{isSettingsOpen\}/)
+})
+
+test("individual app capture reports the tracks that actually started", () => {
+    assert.match(recorderOverlay, /const tracks = await window\.electron\.ipcRenderer\.invoke\("start-multi-app-capture", picked\)/)
+    assert.match(recorderOverlay, /started === 0/)
+    assert.match(recorderOverlay, /status: "partial"/)
+    assert.match(recorderOverlay, /selected app windows are no longer available/i)
+})
+
+test("recording start is guarded against duplicate UI commands", () => {
+    assert.match(recordButton, /startInFlightRef\.current \|\| isRecording/)
+    assert.match(recordButton, /disabled=\{isStarting \|\| isRecording/)
+    assert.match(recorderOverlay, /recordingStartClaimRef\.current/)
+    assert.match(recorderOverlay, /deviceRecorderInitRef\.current/)
+    assert.match(recorderOverlay, /!countdownArmedRef\.current/)
+})
+
+test("recorder actions stay reachable and serialize destructive transitions", () => {
+    const compactStart = recorderOverlay.indexOf("if (!isExpanded && !tutorialActive)")
+    const expandedStart = recorderOverlay.indexOf("role=\"toolbar\"")
+    const compactSource = recorderOverlay.slice(compactStart, expandedStart)
+
+    assert.match(compactSource, /aria-label=\{`Show recording controls\. Recording time/)
+    assert.match(compactSource, /aria-expanded="false"/)
+    assert.match(compactSource, /setIsExpansionPinned\(true\)/)
+    assert.match(compactSource, /title=\{stopActionTitle\}/)
+    assert.match(recorderOverlay, /!tutorialActive && !isExpansionPinned/)
+    assert.match(recorderOverlay, /if \(actionLockRef\.current\) return false/)
+    assert.match(recorderOverlay, /new Set\(\["confirming", "saving", "restarting", "discarding"\]\)/)
+    assert.match(recorderOverlay, /Saving recording/)
+    assert.match(recorderOverlay, /Restarting recording/)
+    assert.match(recorderOverlay, /Discarding recording/)
+    assert.match(recorderOverlay, /status: "error"/)
+    assert.match(recorderOverlay, /aria-live="polite"/)
+})
+
+test("restart and discard require confirmation and restore real device tracks", () => {
+    assert.match(recorderOverlay, /Restart this recording\? The current take will be permanently discarded\./)
+    assert.match(recorderOverlay, /Discard this recording\? This take cannot be recovered\./)
+    assert.match(recorderOverlay, /cancelLabel: "Keep recording"/)
+    assert.match(recorderOverlay, /deviceRecorder\?\.stream\?\.getTracks\(\)\.forEach\(track =>/)
+    assert.match(recorderOverlay, /track\.enabled = true/)
+    assert.match(recorderOverlay, /stop-multi-app-capture/)
+})
+
+test("save keeps retry controls alive and propagates required track failures", () => {
+    assert.match(recorderOverlay, /throw new Error\(`Camera or microphone track could not be finalized\./)
+
+    const normalStop = recorderOverlay.slice(
+        recorderOverlay.indexOf("const onClickStop = async"),
+        recorderOverlay.indexOf("const onClickRestart = async")
+    )
+    assert.match(normalStop, /stopRuntimeFeatures\(\{ stopAppCapture: false \}\)/)
+    assert.doesNotMatch(normalStop, /stop-multi-app-capture/)
+
+    const nativeStop = recorderOverlay.indexOf('invoke("stop-recording")')
+    const deviceDestroy = recorderOverlay.indexOf("deviceRecorder?.destroy()", nativeStop)
+    assert.ok(nativeStop >= 0, "expected the native save command")
+    assert.ok(deviceDestroy > nativeStop, "device resources must remain until native save succeeds")
+
+    assert.match(
+        nativeRecording,
+        /if let Some\(error\) = project_save_failure\.take\(\) \{[\s\S]*?return Err\(error\);[\s\S]*?get_webview_window\("recorder"\)/,
+        "native save failures must return before the recorder window is closed"
+    )
+    assert.match(nativeRecording, /probe_device_recording\(&camera_dest, has_camera, has_mic\)/)
+    assert.match(nativeRecording, /state\.recording_id = None;/)
+    assert.match(nativeRecording, /let project_id = state\.project_id\.take\(\);/)
+
+    assert.match(recorderOverlay, /setIsCaptureFinalized\(true\)[\s\S]*?invoke\("stop-recording"\)/)
+    assert.match(recorderOverlay, /Recording stopped\. Save failed —/)
+    assert.match(recorderOverlay, /isCaptureFinalized \? "Retry save" : "Retry stop and save"/)
+    assert.match(recorderOverlay, /!isCaptureFinalized && \([\s\S]*?title="Restart recording"/)
+})
+
+test("first recording has one truthful tutorial owner", () => {
+    assert.match(recorderTutorial, /if \(main && !rec\)/)
+    assert.doesNotMatch(recorderTutorial, /rec-pause|Pause and resume/)
+    assert.match(recorderTutorial, /Stop and save/)
+    assert.doesNotMatch(tutorialSteps, /keyboard shortcut/i)
+    assert.match(tutorialSteps, /always-visible Stop and save button/)
+})

--- a/test/releaseWorkflow.test.js
+++ b/test/releaseWorkflow.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const workflow = await readFile(
+    new URL("../.github/workflows/main.yml", import.meta.url),
+    "utf8"
+)
+
+test("release publication fails closed across every supported platform", () => {
+    assert.match(
+        workflow,
+        /if: always\(\) && needs\.build-windows\.result == 'success' && needs\.build-linux\.result == 'success' && needs\.build-macos\.result == 'success'/
+    )
+    assert.doesNotMatch(
+        workflow,
+        /needs\.build-(?:windows|linux|macos)\.result == 'success'\s*\|\|/
+    )
+})
+
+test("platform jobs and the publisher reject missing release artifacts", () => {
+    assert.equal(
+        workflow.match(/if-no-files-found: error/g)?.length,
+        3,
+        "each platform upload must reject an empty artifact set"
+    )
+    assert.match(workflow, /- name: Verify complete release payload/)
+    assert.match(workflow, /fail_on_unmatched_files: true/)
+
+    for (const requiredArtifact of [
+        "Flowtake-windows-x64-portable.zip",
+        "Flowtake-macos-universal.zip",
+        "Flowtake-linux-x64-portable.tar.gz",
+        "*.exe",
+        "*.msi",
+        "*.dmg",
+        "*.deb",
+        "*.AppImage",
+        "*.rpm",
+    ]) {
+        assert.ok(workflow.includes(requiredArtifact), `missing release assertion for ${requiredArtifact}`)
+    }
+
+    assert.doesNotMatch(
+        workflow,
+        /cp src-tauri\/(?:target|binaries)\/[^\n]+\|\| true/,
+        "required platform artifacts must never be copied best-effort"
+    )
+})

--- a/test/renderState.test.js
+++ b/test/renderState.test.js
@@ -35,11 +35,12 @@ test("renderable project state omits app state and undo history", () => {
 
     const renderState = createRenderableProjectState(state, { x: 854, y: 480 })
 
-    assert.deepEqual(Object.keys(renderState).sort(), ["animator", "panCoords", "undoableState"])
+    assert.deepEqual(Object.keys(renderState).sort(), ["animator", "panCoords", "plugin", "undoableState"])
     assert.equal(renderState.undoableState.present, present)
     assert.equal(renderState.panCoords, panCoords)
     assert.deepEqual(renderState.animator.rendererDims, { x: 854, y: 480 })
     assert.equal(renderState.animator.backgroundAlpha, 1)
+    assert.deepEqual(renderState.plugin, { enabled: {}, config: {} })
     assert.equal("past" in renderState.undoableState, false)
     assert.equal("future" in renderState.undoableState, false)
     assert.equal("app" in renderState, false)

--- a/test/systemAudio.test.js
+++ b/test/systemAudio.test.js
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+import {
+    getSystemAudioSources,
+    isLikelySystemAudioSource,
+} from "../app/shared/systemAudio.js"
+
+const settingsSource = await readFile(
+    new URL("../app/windows/main/components/settings/SystemAudio.jsx", import.meta.url),
+    "utf8"
+)
+
+test("system audio accepts loopback devices and rejects normal microphones", () => {
+    assert.equal(isLikelySystemAudioSource("Stereo Mix (Realtek Audio)"), true)
+    assert.equal(isLikelySystemAudioSource("BlackHole 2ch"), true)
+    assert.equal(isLikelySystemAudioSource("Monitor of Built-in Audio"), true)
+    assert.equal(isLikelySystemAudioSource("CABLE Output (VB-Audio Virtual Cable)"), true)
+    assert.equal(isLikelySystemAudioSource("VoiceMeeter Output (VB-Audio VoiceMeeter VAIO)"), true)
+    assert.equal(isLikelySystemAudioSource("Microphone Array (Intel Smart Sound)"), false)
+    assert.equal(isLikelySystemAudioSource("USB Webcam Microphone"), false)
+})
+
+test("system audio source list is filtered and deduplicated", () => {
+    const devices = [
+        { kind: "audioinput", label: "Microphone Array" },
+        { kind: "audioinput", label: "Stereo Mix" },
+        { kind: "audioinput", label: "Stereo Mix" },
+        { kind: "audioinput", label: "" },
+        { kind: "videoinput", label: "Loopback Camera" },
+    ]
+
+    assert.deepEqual(getSystemAudioSources(devices), ["Stereo Mix"])
+})
+
+test("system audio permission probe only runs from explicit refresh", () => {
+    assert.doesNotMatch(settingsSource, /useEffect/)
+    assert.match(settingsSource, /const refreshDevices = useCallback\(async \(\) =>/)
+    assert.match(settingsSource, /getUserMedia\(\{ audio: true, video: false \}\)/)
+    assert.match(settingsSource, /permissionStream\?\.getTracks\(\)\.forEach\(track => track\.stop\(\)\)/)
+    assert.match(settingsSource, /onClick=\{refreshDevices\}/)
+})

--- a/test/updatesSettings.test.js
+++ b/test/updatesSettings.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+    new URL("../app/windows/main/components/settings/UpdatesSettings.jsx", import.meta.url),
+    "utf8"
+)
+
+test("update progress listener uses explicit IPC cleanup", () => {
+    assert.match(source, /const handleProgress = \(_event, data\) =>/)
+    assert.match(source, /ipcRenderer\.on\("update-download-progress", handleProgress\)/)
+    assert.match(source, /ipcRenderer\.removeListener\("update-download-progress", handleProgress\)/)
+    assert.doesNotMatch(
+        source,
+        /unlistenRef\.current\s*=\s*window\.electron\.ipcRenderer\.on/
+    )
+})

--- a/test/versionConsistency.test.js
+++ b/test/versionConsistency.test.js
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const readRepoFile = file => readFile(path.join(repoRoot, file), "utf8")
 
 function readCargoPackageVersion(source, packageName) {
-    const packageMatch = source.match(new RegExp(`\\[\\[package\\]\\]\\nname = "${packageName}"\\nversion = "([^"]+)"`))
+    const packageMatch = source.match(new RegExp(`\\[\\[package\\]\\]\\r?\\nname = "${packageName}"\\r?\\nversion = "([^"]+)"`))
     assert.ok(packageMatch, `Expected ${packageName} package version in Cargo.lock`)
     return packageMatch[1]
 }

--- a/tests/device-recorder.test.mjs
+++ b/tests/device-recorder.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { getRecorderOptions } from "../app/windows/main/DeviceRecorder.js"
+
+const track = settings => ({ getSettings: () => settings })
+
+test("device recorder negotiates a supported WebM codec", () => {
+    globalThis.MediaRecorder = {
+        isTypeSupported: mimeType => mimeType.includes("vp8")
+    }
+
+    const options = getRecorderOptions({
+        getVideoTracks: () => [track({ width: 1920, height: 1080, frameRate: 30 })],
+        getAudioTracks: () => [{}],
+    })
+
+    assert.equal(options.mimeType, "video/webm;codecs=vp8,opus")
+    assert.equal(options.audioBitsPerSecond, 96_000)
+    assert.ok(options.videoBitsPerSecond > 1_500_000)
+    assert.ok(options.videoBitsPerSecond <= 12_000_000)
+})
+
+test("device recorder keeps low-resolution streams inside a safe bitrate floor", () => {
+    globalThis.MediaRecorder = { isTypeSupported: () => false }
+
+    const options = getRecorderOptions({
+        getVideoTracks: () => [track({ width: 640, height: 360, frameRate: 15 })],
+        getAudioTracks: () => [],
+    })
+
+    assert.equal(options.mimeType, undefined)
+    assert.equal(options.videoBitsPerSecond, 1_500_000)
+    assert.equal(options.audioBitsPerSecond, undefined)
+})
+
+test("device recorder chooses an audio-only container when no camera is active", () => {
+    globalThis.MediaRecorder = {
+        isTypeSupported: mimeType => mimeType === "audio/webm;codecs=opus"
+    }
+
+    const options = getRecorderOptions({
+        getVideoTracks: () => [],
+        getAudioTracks: () => [{}],
+    })
+
+    assert.deepEqual(options, {
+        mimeType: "audio/webm;codecs=opus",
+        audioBitsPerSecond: 96_000,
+    })
+})

--- a/tests/recording-diagnostics.test.mjs
+++ b/tests/recording-diagnostics.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { deriveReport, parseArgs } from "../scripts/recording-diagnostics.mjs"
+
+test("recording diagnostics parse safe defaults and explicit flags", () => {
+    assert.deepEqual(parseArgs([]), {
+        sampleMs: 2_000,
+        json: false,
+        failOnOrphan: false,
+        help: false,
+    })
+    assert.deepEqual(parseArgs(["--sample-ms", "5000", "--json", "--fail-on-orphan"]), {
+        sampleMs: 5_000,
+        json: true,
+        failOnOrphan: true,
+        help: false,
+    })
+    assert.throws(() => parseArgs(["--sample-ms", "100"]), /250 to 10000/)
+    assert.throws(() => parseArgs(["--unknown"]), /Unknown option/)
+})
+
+test("recording diagnostics calculates machine CPU and memory totals", () => {
+    const startedAt = "2026-07-14T00:00:00.000Z"
+    const before = {
+        timestamp: "2026-07-14T00:00:02.000Z",
+        logicalProcessors: 8,
+        processes: [
+            { pid: 10, parentPid: 1, name: "Flowtake.exe", cpuSeconds: 4, startedAt },
+            { pid: 20, parentPid: 10, name: "ffmpeg.exe", cpuSeconds: 8, startedAt },
+        ],
+    }
+    const after = {
+        timestamp: "2026-07-14T00:00:04.000Z",
+        logicalProcessors: 8,
+        processes: [
+            {
+                pid: 10, parentPid: 1, name: "Flowtake.exe", cpuSeconds: 4.8, startedAt,
+                workingSetBytes: 100 * 1_048_576, privateBytes: 80 * 1_048_576,
+            },
+            {
+                pid: 20, parentPid: 10, name: "ffmpeg-x86_64-pc-windows-msvc.exe", cpuSeconds: 9.6, startedAt,
+                commandLine: "ffmpeg -i recording-demo.mp4", workingSetBytes: 50 * 1_048_576,
+                privateBytes: 40 * 1_048_576,
+            },
+        ],
+    }
+
+    const report = deriveReport(before, after, 2_000)
+
+    assert.equal(report.processes[0].cpuPercentOneCore, 40)
+    assert.equal(report.processes[0].cpuPercent, 5)
+    assert.equal(report.processes[1].cpuPercentOneCore, 80)
+    assert.equal(report.processes[1].cpuPercent, 10)
+    assert.equal(report.totals.flowtake.workingSetBytes, 100 * 1_048_576)
+    assert.equal(report.totals.ffmpeg.privateBytes, 40 * 1_048_576)
+    assert.deepEqual(report.orphanCandidates, [])
+})
+
+test("recording diagnostics only flags Flowtake-like detached FFmpeg processes", () => {
+    const after = {
+        timestamp: "2026-07-14T00:00:02.000Z",
+        logicalProcessors: 4,
+        processes: [
+            { pid: 10, parentPid: 1, name: "Flowtake.exe", cpuSeconds: 1 },
+            { pid: 20, parentPid: 10, name: "ffmpeg.exe", commandLine: "ffmpeg recording-active.mp4", cpuSeconds: 1 },
+            { pid: 30, parentPid: 999, name: "ffmpeg.exe", commandLine: "ffmpeg recording-detached.mp4", cpuSeconds: 1 },
+            { pid: 40, parentPid: 999, name: "ffmpeg.exe", commandLine: "ffmpeg vacation.mov", cpuSeconds: 1 },
+        ],
+    }
+
+    const report = deriveReport({ ...after, processes: [] }, after, 1_000)
+
+    assert.deepEqual(report.orphanCandidates.map(candidate => candidate.pid), [30])
+})

--- a/tests/recording-preview-regression.test.mjs
+++ b/tests/recording-preview-regression.test.mjs
@@ -49,6 +49,20 @@ test("preview worker loads webworker adapter before scene modules", async () => 
     assert.match(source, /await import\(["']\.\.\/scene\/PreviewScene["']\)/)
 })
 
+test("Vite scans lazy scene workers before the first editor handoff", async () => {
+    const source = await readRepoFile("vite.config.mjs")
+
+    for (const entry of [
+        "index.html",
+        "app/windows/**/index.html",
+        "app/shared/workers/previewWorker.js",
+        "app/shared/workers/renderWorker.js",
+    ]) {
+        const escapedEntry = entry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        assert.match(source, new RegExp(`["']${escapedEntry}["']`))
+    }
+})
+
 test("macOS recording restores cursor visibility without hiding it", async () => {
     const mouseTracker = await readRepoFile("src-tauri/src/mouse_tracker.rs")
     const recording = await readRepoFile("src-tauri/src/commands/recording.rs")
@@ -76,12 +90,14 @@ test("macOS recording errors only report permission denial after probing TCC", a
     )
 })
 
-test("new recording preview retries after transient permission failures", async () => {
+test("new recording preview retries one transient failure but not permission denial", async () => {
     const source = await readRepoFile("app/windows/main/components/newRecording/NewRecording.jsx")
 
     assert.doesNotMatch(source, /enabled:\s*isOpen && !!previewSource && !screenPermissionDenied/)
     assert.match(source, /refetch:\s*refetchCaptureSourcePreview/)
-    assert.match(source, /refetchInterval:\s*screenPermissionDenied \|\| previewUnavailable \? 5000 : 2000/)
+    assert.match(source, /failureCount < 1 && !message\.includes\("ScreenPermissionDenied"\)/)
+    assert.match(source, /retryDelay:\s*500/)
+    assert.match(source, /refetchInterval:\s*screenPermissionDenied \|\| previewUnavailable \? 10000 : 5000/)
     assert.match(source, /Enable this exact Flowtake app/)
     assert.doesNotMatch(source, /enable this app, then restart/)
 })
@@ -129,16 +145,35 @@ test("capture error toast is not GPU-specific", async () => {
     assert.doesNotMatch(settings, /GPU drivers/i)
 })
 
-test("recording output is frame-rate clamped and validated before opening editor", async () => {
+test("recording output honors a clamped persisted frame rate and validates one frame", async () => {
     const recording = await readRepoFile("src-tauri/src/commands/recording.rs")
 
     assert.match(recording, /"-r"\.to_string\(\)/)
-    assert.match(recording, /"30"\.to_string\(\)/)
-    assert.match(recording, /fn recording_video_is_readable/)
-    assert.match(recording, /get_video_duration_ms\(app, video_path\)/)
-    assert.match(recording, /get_video_dimensions\(video_path\)/)
-    assert.match(recording, /Recording video exists but is not readable/)
+    assert.match(recording, /Some\(60\) => 60/)
+    assert.match(recording, /fps\.to_string\(\)/)
+    assert.match(recording, /async fn probe_video_metadata/)
+    assert.match(recording, /"-frames:v"/)
+    assert.match(recording, /probe_video_metadata\(path, requires_system_audio\)\.await/)
+    assert.match(recording, /screen_recording_probe_args/)
+    assert.match(recording, /"0:a:0"\.to_string\(\)/)
+    assert.doesNotMatch(recording, /fn recording_video_is_readable/)
+    assert.doesNotMatch(recording, /get_video_duration_ms/)
+    assert.doesNotMatch(recording, /get_video_dimensions/)
+    assert.match(recording, /first frame is not readable/)
     assert.match(recording, /Frames were captured, but FFmpeg did not produce a readable MP4/)
+})
+
+test("automatic recorder engines remain selectable and fall back for remote sessions", async () => {
+    const encoding = await readRepoFile("src-tauri/src/commands/encoding.rs")
+    const recording = await readRepoFile("src-tauri/src/commands/recording.rs")
+
+    assert.match(encoding, /if encoder == "auto"/)
+    assert.match(encoding, /"encoderMode"/)
+    assert.match(encoding, /if capturer == "auto"/)
+    assert.match(encoding, /"capturerMode"/)
+    assert.match(encoding, /SM_REMOTESESSION/)
+    assert.match(recording, /automatic_encoder/)
+    assert.match(recording, /automatic_capturer/)
 })
 
 test("preview scene falls back when worker font asset loading fails", async () => {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -46,6 +46,19 @@ export default defineConfig({
     dedupe: ['react', 'react-dom', 'react/jsx-runtime', 'react/jsx-dev-runtime']
   },
 
+  // Vite's default scan does not discover worker-only scene dependencies until
+  // the first recording opens. Scan both workers up front so dependency
+  // optimization stays in one generation and cannot force a reload behind the
+  // editor's unsaved-work guard during that first handoff.
+  optimizeDeps: {
+    entries: [
+      'index.html',
+      'app/windows/**/index.html',
+      'app/shared/workers/previewWorker.js',
+      'app/shared/workers/renderWorker.js',
+    ],
+  },
+
   assetsInclude: ['**/*.tflite', '**/*.frag', '**/*.vert', '**/*.wgsl'],
 
   // Vite options tailored for Tauri development


### PR DESCRIPTION
## Summary

- harden recording startup, hardware-encoder fallback, system-audio truthfulness, transactional project saves, app-layer finalization, and owned FFmpeg cleanup
- redesign the first-run record shell, recorder controls, settings, and experimental plugin surfaces around working capabilities
- add cross-platform capture safeguards, release artifact fail-closed checks, process diagnostics, regression coverage, and audited dependency overrides
- pre-scan worker-only Pixi dependencies so the first saved recording opens without a Vite optimizer reload or mixed worker modules

## Validation

- npm test: 66 passed
- npm run lint: 0 errors; warning-only output remains in editor/live modules outside this recorder-focused scope
- npm run build:frontend: passed
- npm audit: 0 vulnerabilities
- cargo test --lib --locked: 39 passed, 1 privilege-dependent test ignored
- Windows Job Object integration test: passed when run explicitly
- cargo check --locked: passed
- cargo clippy --locked -- -D warnings --allow dead_code: passed
- clean-cache Windows user journey: launched Flowtake, recorded, stopped, saved, and opened a working preview without reload prompts or worker errors
- latest QA archive: 17.87 seconds, 2,485,593-byte ZIP, 2,484,092-byte screen.mp4, one-frame FFmpeg decode passed
- post-run diagnostics: no Flowtake or FFmpeg processes and no orphan candidates

## Notes

The editor implementation itself is intentionally left to the separate editor workstream. This PR only verifies the recorder-to-editor handoff. macOS and Linux build coverage remains enforced by the GitHub OS matrix.