### PR TITLE
Patch website Vite security advisories

### DIFF
--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -54,6 +54,12 @@ The branch originally retained vulnerable `anyhow`, `quick-xml`, `quinn-proto`, 
 
 The audit runner downloads the official `cargo-audit 0.22.2` x86_64 Linux asset over HTTPS with bounded retries, verifies the pinned SHA-256 before extracting exactly the expected member, and runs from an empty working directory and `CARGO_HOME` so repository or runner advisory-ignore configuration cannot be inherited. It has no advisory ignores or best-effort fallback. The gate is mandatory in pull-request CI and the exact validated release commit, and a minimal-permission workflow audits the current `main` branch every day and on every manual dispatch. A fresh local audit scanned 601 lockfile dependencies with zero vulnerabilities and 18 visible unsound/unmaintained warnings; no warning or advisory is suppressed.
 
+## Fixed — website Vite Windows path-handling advisories (high)
+
+**Evidence:** `website/package.json`, `website/package-lock.json`, GitHub advisories `GHSA-fx2h-pf6j-xcff` and `GHSA-v6wh-96g9-6wx3`.
+
+The marketing-site toolchain resolved Vite 6.4.2, which is affected by a Windows alternate-path bypass of `server.fs.deny` and an NTLMv2 hash-disclosure path through `launch-editor`. The deployed Pages artifact is static and does not run the Vite development server, but maintainer workstations remained exposed. The website now pins the first patched release, Vite 6.4.3. A clean website install, production build, and package-specific npm audit complete with zero vulnerabilities.
+
 ## Fixed — arbitrary native URL-handler invocation (medium)
 
 **Evidence:** `src-tauri/src/commands/exporter.rs` and its unit tests.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,9 +12,8 @@
         "@vitejs/plugin-react": "5.0.4",
         "react": "19.2.0",
         "react-dom": "19.2.0",
-        "vite": "6.4.2"
-      },
-      "devDependencies": {}
+        "vite": "6.4.3"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -1594,9 +1593,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,6 @@
     "@vitejs/plugin-react": "5.0.4",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "vite": "6.4.2"
+    "vite": "6.4.3"
   }
 }


### PR DESCRIPTION
## What changed

- pins the marketing-site toolchain to Vite 6.4.3, the first patched release for both active advisories
- refreshes the website lockfile
- records the fixed Windows path-handling boundary in the security report

## Why

After PR #161 merged, Dependabot surfaced `GHSA-fx2h-pf6j-xcff` (high) and `GHSA-v6wh-96g9-6wx3` (moderate) against Vite 6.4.2 in `website/package-lock.json`. The public Pages output is static, but the vulnerable development server remained part of maintainer workflows.

## Validation

- clean website install
- website production build: 354 modules on Vite 6.4.3
- website npm audit: 0 vulnerabilities
- `git diff --check`

## Release gate

Merge before tagging v1.6.0 so the release and Pages launch contain the patched toolchain.