### PR TITLE
Correct security policy and issue intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,40 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: ''
-labels: ''
+about: Report a reproducible Flowtake problem
+title: '[Bug] '
+labels: 'bug'
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+Before filing, search existing issues and use the latest published Flowtake release.
+Do not include passwords, stream keys, OAuth tokens, private project names, customer
+footage, or other sensitive data. Report security vulnerabilities privately as
+described in the [security policy](https://github.com/JNX03/Flowtake/security/policy).
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**What happened?**
+Describe the problem and what you were trying to do.
+
+**Steps to reproduce**
+1. Open ...
+2. Select ...
+3. Start ...
+4. Observe ...
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What did you expect instead?
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Flowtake and system details**
+- Flowtake version and installer type (for example, `v1.6.0` / MSI):
+- Operating system and version:
+- Capture type (display, window, region, camera, or audio):
+- Display setup and scaling, if relevant:
+- Does the problem reproduce in a new disposable project?
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Evidence**
+Attach a redacted screenshot, short sanitized recording, or the smallest relevant
+log excerpt if it helps. Do not upload a full project archive unless a maintainer
+asks for it and you have confirmed it contains no sensitive data.
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context, including a workaround if you found one.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/JNX03/Flowtake/security/policy
+    about: Read the private reporting instructions before sharing vulnerability details.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,10 +1,26 @@
 ---
-name: Custom issue template
-about: Describe this issue template's purpose here.
-title: ''
-labels: ''
+name: Support or setup question
+about: Ask a public, non-sensitive Flowtake usage question
+title: '[Question] '
+labels: 'question'
 assignees: ''
 
 ---
 
+Before posting, search the README, documentation, and existing issues. Do not
+include credentials, private footage, customer data, or security vulnerability
+details. Use the private route in the [security policy](https://github.com/JNX03/Flowtake/security/policy) for security
+reports.
 
+**What are you trying to accomplish?**
+Describe the recording, editing, export, or integration goal.
+
+**Where are you blocked?**
+Include the exact step and any redacted error text.
+
+**Environment**
+- Flowtake version and installer type:
+- Operating system and version:
+
+**What have you already tried?**
+List the relevant documentation or troubleshooting steps you checked.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,24 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: '[Feature] '
+labels: 'enhancement'
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Before filing, search existing issues. Do not include private footage, credentials,
+customer data, or security vulnerability details.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**What problem would this solve?**
+Describe the recording, editing, export, or developer-demo workflow that is difficult today.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**What outcome would you like?**
+Describe the result rather than only a specific interface.
+
+**What alternatives have you tried?**
+Include any workaround and why it is insufficient.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add redacted screenshots or examples if useful. Note the operating system when the
+request depends on capture or media behavior.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,14 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 1.23.x  | Yes       |
-| < 1.23  | No        |
+| Release channel | Supported |
+|-----------------|-----------|
+| Latest published release | Yes |
+| Earlier releases | No |
 
-Only the latest release receives security updates. We recommend always running the most recent version.
+Only the latest published release receives security updates. Download it from the
+[official GitHub Releases page](https://github.com/JNX03/Flowtake/releases/latest) and verify it against the
+published `SHA256SUMS.txt` when that asset is available.
 
 ## Reporting a Vulnerability
 
@@ -26,6 +28,8 @@ If you discover a security vulnerability in Flowtake, please report it responsib
    - Suggested fix (if you have one)
 
 ### What to Expect
+
+These are response targets, not guaranteed resolution times:
 
 | Step | Timeline |
 |------|----------|
@@ -49,12 +53,12 @@ If you discover a security vulnerability in Flowtake, please report it responsib
 
 Flowtake is a desktop application built with Tauri v2 and processes content locally. Key security considerations:
 
-- **FFmpeg Sidecar** — Flowtake bundles FFmpeg as an external binary. All FFmpeg commands are constructed server-side in Rust to prevent command injection.
-- **IPC Boundary** — Frontend-to-backend communication uses Tauri's typed command system. All inputs are validated on the Rust side.
-- **File Access** — The application accesses the filesystem for project files, recordings, and exports. File paths are validated and scoped.
-- **No Network by Default** — Core recording/editing functionality works entirely offline. Network access is used only for update checks and connected services that the user explicitly starts, such as social publishing.
-- **Content Security Policy** — The frontend enforces a strict CSP to prevent XSS attacks.
-- **Video Protocol** — The custom `video://` protocol handler validates and scopes all file access to known recording paths.
+- **FFmpeg Sidecar** — Flowtake bundles FFmpeg as an external binary. Commands and arguments are constructed in Rust, and project/render paths are canonicalized and scoped before use.
+- **IPC Boundary** — Frontend-to-backend communication uses Tauri commands and least-privilege window capabilities. Security-sensitive input is validated in Rust.
+- **File Access** — Project files, recordings, and exports are restricted to validated project/render roots and explicitly configured asset scopes.
+- **Network Behavior** — Core recording and editing work locally. The app may perform a metadata-only update check after startup; network access is also used by connected services a user explicitly starts.
+- **Content Security Policy** — A CSP limits allowed sources. The current policy still permits inline styles/scripts and broad HTTPS/WebSocket connections for compatibility, so CSP reduction remains an active hardening area.
+- **Video Protocol** — The custom `video://` protocol validates project identity, media kind, and file location before serving a recording.
 
 ### What We Consider In Scope
 
@@ -71,7 +75,7 @@ Flowtake is a desktop application built with Tauri v2 and processes content loca
 - Vulnerabilities requiring physical access to the device
 - Social engineering attacks
 - Denial of service against the local application
-- Issues in third-party dependencies (report upstream; notify us if it affects Flowtake)
+- Vulnerabilities that exist only in a third-party dependency and cannot affect a supported Flowtake release (report upstream; notify us if you believe Flowtake is affected)
 - Vulnerabilities in outdated versions
 
 ## Security Best Practices for Contributors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,7 +53,7 @@ These are response targets, not guaranteed resolution times:
 
 Flowtake is a desktop application built with Tauri v2 and processes content locally. Key security considerations:
 
-- **FFmpeg Sidecar** — Flowtake bundles FFmpeg as an external binary. Commands and arguments are constructed in Rust, and project/render paths are canonicalized and scoped before use.
+- **FFmpeg Sidecar** — Flowtake bundles FFmpeg as an external binary. Commands and arguments are constructed in Rust, and paths are derived from validated project/render identifiers and backend-owned roots.
 - **IPC Boundary** — Frontend-to-backend communication uses Tauri commands and least-privilege window capabilities. Security-sensitive input is validated in Rust.
 - **File Access** — Project files, recordings, and exports are restricted to validated project/render roots and explicitly configured asset scopes.
 - **Network Behavior** — Core recording and editing work locally. The app may perform a metadata-only update check after startup; network access is also used by connected services a user explicitly starts.

--- a/test/versionConsistency.test.js
+++ b/test/versionConsistency.test.js
@@ -53,7 +53,17 @@ test("security policy describes the configured CSP without overstating it", asyn
         readRepoFile("src-tauri/tauri.conf.json").then(JSON.parse)
     ])
 
-    assert.match(tauriConfig.app.security.csp, /'unsafe-inline'/)
-    assert.doesNotMatch(securityPolicy, /enforces a strict CSP/i)
+    const directives = Object.fromEntries(tauriConfig.app.security.csp
+        .split(";")
+        .map(directive => directive.trim().split(/\s+/))
+        .filter(parts => parts[0])
+        .map(([name, ...sources]) => [name, sources]))
+
+    assert.ok(directives["script-src"].includes("'unsafe-inline'"))
+    assert.ok(directives["style-src"].includes("'unsafe-inline'"))
+    assert.ok(directives["connect-src"].includes("https:"))
+    assert.ok(directives["connect-src"].includes("wss:"))
+    assert.doesNotMatch(securityPolicy, /\bstrict\s+(?:content security policy|CSP)\b|\bCSP\b.{0,40}\bstrict\b/is)
+    assert.match(securityPolicy, /inline styles\/scripts and broad HTTPS\/WebSocket connections/i)
     assert.match(securityPolicy, /CSP reduction remains an active hardening area/i)
 })

--- a/test/versionConsistency.test.js
+++ b/test/versionConsistency.test.js
@@ -38,3 +38,22 @@ test("release manifests share the same app version", async () => {
     assert.match(cargoToml, new RegExp(`^version = "${releaseVersion}"$`, "m"))
     assert.equal(readCargoPackageVersion(cargoLock, "flowtake"), releaseVersion)
 })
+
+test("security support guidance cannot drift to a stale app version", async () => {
+    const securityPolicy = await readRepoFile("SECURITY.md")
+    const supportedVersions = securityPolicy.split("## Reporting a Vulnerability")[0]
+
+    assert.match(supportedVersions, /Latest published release/)
+    assert.doesNotMatch(supportedVersions, /\b\d+\.\d+(?:\.\d+|\.x)?\b/)
+})
+
+test("security policy describes the configured CSP without overstating it", async () => {
+    const [securityPolicy, tauriConfig] = await Promise.all([
+        readRepoFile("SECURITY.md"),
+        readRepoFile("src-tauri/tauri.conf.json").then(JSON.parse)
+    ])
+
+    assert.match(tauriConfig.app.security.csp, /'unsafe-inline'/)
+    assert.doesNotMatch(securityPolicy, /enforces a strict CSP/i)
+    assert.match(securityPolicy, /CSP reduction remains an active hardening area/i)
+})


### PR DESCRIPTION
## Summary
- replace the stale hard-coded supported version with a latest-published-release policy
- describe current CSP and network behavior without overstating the trust boundary
- replace generic mobile/browser issue prompts with Flowtake-specific, privacy-safe bug, feature, and support intake
- disable blank issues and route vulnerability reports to the private security policy
- add regressions preventing version and CSP claims from drifting again

## Why
The public security policy still named an unrelated 1.23.x support line and called the current CSP strict even though compatibility allowances remain. The default issue templates also requested smartphone/browser details that do not fit the desktop product and gave no warning against posting sensitive footage or credentials.

## Validation
- npm test: 119/119 passed
- npm run lint: 0 errors, 41 existing warnings
- issue-template config YAML parsed successfully
- git diff --check passed

## Release impact
Documentation and issue-intake only. The immutable v1.6.0 tag and its in-progress release workflow are unchanged.