### PR TITLE
Clarify platform release boundaries on product site

### DIFF
--- a/test/versionConsistency.test.js
+++ b/test/versionConsistency.test.js
@@ -67,3 +67,18 @@ test("security policy describes the configured CSP without overstating it", asyn
     assert.match(securityPolicy, /inline styles\/scripts and broad HTTPS\/WebSocket connections/i)
     assert.match(securityPolicy, /CSP reduction remains an active hardening area/i)
 })
+
+test("launch copy keeps signing and preview support boundaries separate", async () => {
+    const website = await readRepoFile("website/src/App.jsx")
+    const heroNote = website.match(
+        /<p className="honest-note">\s*(Windows artifacts[\s\S]*?)\s*<\/p>/,
+    )
+
+    assert.ok(heroNote, "expected the hero release-boundary note")
+
+    const note = heroNote[1].replace(/\s+/g, " ").trim()
+    assert.match(note, /Windows artifacts are unsigned/i)
+    assert.match(note, /macOS is ad-hoc signed but not notarized/i)
+    assert.match(note, /macOS and Linux remain preview builds/i)
+    assert.doesNotMatch(note, /release artifacts are unsigned|unsigned preview builds/i)
+})

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -235,7 +235,7 @@ export function App() {
             </div>
 
             <p className="honest-note">
-              Current release artifacts are unsigned preview builds. Review the platform notes and checksums on GitHub before installing.
+              Windows artifacts are unsigned. macOS is ad-hoc signed but not notarized; macOS and Linux remain preview builds. Review the platform notes and checksums on GitHub before installing.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- make the hero release note platform-specific
- state that Windows is unsigned and macOS is ad-hoc signed but not notarized
- keep macOS/Linux preview status separate from signing status
- add a regression scoped to the visible hero note

## Validation
- `node --test test/versionConsistency.test.js` (4/4)
- `npm --prefix website run build -- --mode pages`
- `git diff --check`
- independent read-only review: approved

## Risk
Copy and regression-test only. No release artifacts, application binaries, pricing, analytics, or checkout behavior change.