### PR TITLE
Activate private Release Studio intake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,22 @@ jobs:
       - name: Build frontend
         run: npm run build:frontend
 
+      - name: Install marketing-site dependencies
+        run: npm ci --prefix website --no-audit --no-fund
+
+      - name: Test marketing-site intake contract
+        run: npm test --prefix website
+
+      - name: Build marketing site for GitHub Pages
+        run: npm run build --prefix website -- --mode pages
+
+      - name: Require production intake endpoints in the built site
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -R --quiet --fixed-strings 'https://flowtake.72-62-41-174.sslip.io/v1/leads' website/dist/assets
+          grep -R --quiet --fixed-strings 'https://flowtake.72-62-41-174.sslip.io/v1/events' website/dist/assets
+
   rust-security-audit:
     name: Rust Security Audit
     runs-on: ubuntu-22.04

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -74,6 +74,13 @@ jobs:
       - name: Build for the repository Pages base path
         run: npm run build -- --mode pages
 
+      - name: Require production intake endpoints in the built site
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -R --quiet --fixed-strings 'https://flowtake.72-62-41-174.sslip.io/v1/leads' dist/assets
+          grep -R --quiet --fixed-strings 'https://flowtake.72-62-41-174.sslip.io/v1/events' dist/assets
+
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/website/.env.example
+++ b/website/.env.example
@@ -1,3 +1,4 @@
-# Public browser configuration. Never put secrets in VITE_ variables.
-VITE_LEAD_ENDPOINT=
-VITE_EVENT_ENDPOINT=
+# Production intake URLs are intentionally pinned in src/intake.js so a build
+# environment cannot silently redirect lead or event traffic. Changing either
+# public endpoint requires a reviewed source change and a new Pages deployment.
+# Never place credentials or private tokens in VITE_ variables.

--- a/website/DEPLOYMENT.md
+++ b/website/DEPLOYMENT.md
@@ -14,6 +14,15 @@ No repository setting, custom domain, or DNS change is performed by this configu
 
 Public images used from React are joined to `import.meta.env.BASE_URL`. Vite rewrites the favicon and CSS font URLs during the Pages-mode build. This prevents requests from escaping to the domain root when the site is hosted below `/Flowtake/`.
 
+## Public intake endpoints
+
+The production build defaults to the public, non-secret HTTPS endpoints below:
+
+- `https://flowtake.72-62-41-174.sslip.io/v1/leads`
+- `https://flowtake.72-62-41-174.sslip.io/v1/events`
+
+These endpoints are intentionally pinned in `src/intake.js`; build-environment variables cannot redirect lead or event traffic. Changing either public endpoint requires a reviewed source change and a new Pages deployment. The intake service accepts browser requests only from `https://jnx03.github.io`, so direct form submission from localhost intentionally exercises the email/copy fallback instead of creating a lead. Run `npm test` in `website/` to validate the payload, event, CORS-client, timeout, and failure contracts before a Pages build.
+
 ## Prepared workflow
 
 `.github/workflows/pages.yml` is manual-only. After the matching hardened GitHub Release is published, an administrator must dispatch the workflow from the `main` branch. The workflow rejects non-`main` dispatches, then confirms that GitHub's latest release matches the root package version and includes `SHA256SUMS.txt` before it builds `website/dist` or deploys to the `github-pages` environment.

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --test src/intake.test.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -13,9 +13,8 @@ import {
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createLeadPayload, describeLeadFailure, sendEvent, submitLead } from "./intake.js";
 
-const LEAD_ENDPOINT = import.meta.env.VITE_LEAD_ENDPOINT?.trim() || "";
-const EVENT_ENDPOINT = import.meta.env.VITE_EVENT_ENDPOINT?.trim() || "";
 const CONTACT_EMAIL = "jnxstartup@gmail.com";
 const RELEASE_VERSION = "1.6.0";
 const RELEASE_URL = `https://github.com/JNX03/Flowtake/releases/tag/v${RELEASE_VERSION}`;
@@ -90,26 +89,8 @@ const faqs = [
   },
 ];
 
-function track(name, detail = {}) {
-  if (!EVENT_ENDPOINT) return;
-  const payload = JSON.stringify({
-    name,
-    detail,
-    path: window.location.pathname,
-    timestamp: new Date().toISOString(),
-  });
-
-  if (navigator.sendBeacon) {
-    navigator.sendBeacon(EVENT_ENDPOINT, new Blob([payload], { type: "application/json" }));
-    return;
-  }
-
-  fetch(EVENT_ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: payload,
-    keepalive: true,
-  }).catch(() => {});
+function track(name) {
+  void sendEvent(name);
 }
 
 export function App() {
@@ -117,16 +98,16 @@ export function App() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const briefTriggerRef = useRef(null);
 
-  const openBrief = (source, trigger) => {
-    track("brief_opened", { source });
+  const openBrief = (trigger) => {
+    track("brief_opened");
     briefTriggerRef.current = trigger instanceof HTMLElement ? trigger : document.activeElement;
     setMobileOpen(false);
     setBriefOpen(true);
   };
 
-  const reserve = (source, trigger) => {
-    track("founding_cta_clicked", { source, checkoutMode: "qualification_first" });
-    openBrief(source, trigger);
+  const reserve = (trigger) => {
+    track("founding_cta_clicked");
+    openBrief(trigger);
   };
 
   useEffect(() => {
@@ -169,7 +150,7 @@ export function App() {
             href="https://github.com/JNX03/Flowtake"
             target="_blank"
             rel="noreferrer"
-            onClick={() => track("github_clicked", { source: "header" })}
+            onClick={() => track("github_clicked")}
           >
             GitHub
           </a>
@@ -178,7 +159,7 @@ export function App() {
             href="https://github.com/JNX03/Flowtake/releases/latest"
             target="_blank"
             rel="noreferrer"
-            onClick={() => track("download_clicked", { source: "header" })}
+            onClick={() => track("download_clicked")}
           >
             Download free
           </a>
@@ -228,7 +209,7 @@ export function App() {
                 href="https://github.com/JNX03/Flowtake/releases/latest"
                 target="_blank"
                 rel="noreferrer"
-                onClick={() => track("download_clicked", { source: "hero" })}
+                onClick={() => track("download_clicked")}
               >
                 Download Flowtake free
                 <ArrowRightIcon aria-hidden="true" />
@@ -337,7 +318,7 @@ export function App() {
               ))}
             </ul>
             <div className="plan-action">
-              <button className="button button-primary" type="button" onClick={(event) => reserve("plan", event.currentTarget)}>
+              <button className="button button-primary" type="button" onClick={(event) => reserve(event.currentTarget)}>
                 Request a founding slot
                 <ArrowRightIcon aria-hidden="true" />
               </button>
@@ -391,7 +372,8 @@ export function App() {
             </article>
             <article id="privacy">
               <h3>Privacy and business contact</h3>
-              <p>The request form uses name, work email, company, optional URL/date, and release story only to assess and reply to the request. Declined or inactive lead data is deleted within 90 days. No nonessential cookies are used while analytics is unconfigured.</p>
+              <p>Lead requests send your name, work email, company, optional public URL and target date, release story, and consent record to Flowtake's HTTPS intake service so we can assess and reply. Lead records are encrypted at rest and declined or inactive leads are deleted within 90 days.</p>
+              <p>This page also sends cookie-free aggregate counts for a short allowlist of actions. The service stores only UTC day, action name, and count - not event details, page URLs, device identifiers, or form content. IP addresses are used in server memory for abuse-rate limiting and are not written to lead or event files. No nonessential cookies are used.</p>
               <p>Flowtake is operated from Thailand. Formal contracting identity and address will be disclosed before payment. Contact <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>; expected reply time is two business days. Thailand PDPA and customer-specific data terms will be reviewed before private footage is accepted.</p>
             </article>
           </div>
@@ -421,7 +403,7 @@ export function App() {
             <p className="eyebrow"><span className="eyebrow-line" aria-hidden="true" /> Cue the next release</p>
             <h2>Show us the workflow. We’ll frame the take.</h2>
           </div>
-          <button className="button button-primary" type="button" onClick={(event) => openBrief("footer", event.currentTarget)}>
+          <button className="button button-primary" type="button" onClick={(event) => openBrief(event.currentTarget)}>
             Request a sample storyboard <ArrowRightIcon aria-hidden="true" />
           </button>
         </section>
@@ -456,6 +438,8 @@ function BriefDialog({ onClose, restoreFocusTo }) {
   const [status, setStatus] = useState("idle");
   const [error, setError] = useState("");
   const [briefText, setBriefText] = useState("");
+  const [briefSubject, setBriefSubject] = useState("");
+  const [fallbackAllowed, setFallbackAllowed] = useState(false);
   const firstInput = useRef(null);
   const dialogRef = useRef(null);
 
@@ -499,47 +483,53 @@ function BriefDialog({ onClose, restoreFocusTo }) {
   const sendBrief = async (event) => {
     event.preventDefault();
     setError("");
+    setBriefText("");
+    setBriefSubject("");
+    setFallbackAllowed(false);
     setStatus("sending");
 
-    const data = Object.fromEntries(new FormData(event.currentTarget).entries());
+    let payload;
+    try {
+      payload = createLeadPayload(new FormData(event.currentTarget));
+    } catch (payloadError) {
+      setError(payloadError.message || "Please check the entered fields and try again.");
+      setStatus("idle");
+      return;
+    }
     const text = [
-      `Name: ${data.name}`,
-      `Work email: ${data.email}`,
-      `Company: ${data.company}`,
-      `Launch URL: ${data.url || "Not provided"}`,
-      `Target date: ${data.deadline || "Not provided"}`,
+      `Name: ${payload.name}`,
+      `Work email: ${payload.email}`,
+      `Company: ${payload.company}`,
+      `Launch URL: ${payload.url || "Not provided"}`,
+      `Target date: ${payload.deadline || "Not provided"}`,
       "",
       "Release story:",
-      data.story,
+      payload.story,
     ].join("\n");
     setBriefText(text);
+    setBriefSubject(`Flowtake Release Studio brief - ${payload.company}`);
 
     try {
-      if (LEAD_ENDPOINT) {
-        const response = await fetch(LEAD_ENDPOINT, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ ...data, source: "release-studio-website" }),
-        });
-        if (!response.ok) throw new Error("The brief endpoint did not accept the request.");
-        track("brief_submitted", { method: "endpoint" });
-        setStatus("submitted");
-        return;
-      }
-
-      const subject = encodeURIComponent(`Flowtake Release Studio brief · ${data.company}`);
-      const body = encodeURIComponent(text);
-      track("brief_handoff_started", { method: "email" });
-      window.location.href = `mailto:${CONTACT_EMAIL}?subject=${subject}&body=${body}`;
-      setStatus("email");
+      await submitLead(payload);
+      track("brief_submitted");
+      setStatus("submitted");
     } catch (submissionError) {
-      setError(submissionError.message || "We could not send the brief. Please copy it and email us directly.");
+      const failure = describeLeadFailure(submissionError);
+      setFallbackAllowed(failure.fallbackAllowed);
+      setError(failure.message);
       setStatus("idle");
     }
   };
 
+  const openEmailFallback = () => {
+    if (!fallbackAllowed || !briefText) return;
+    track("brief_handoff_started");
+    window.location.href = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(briefSubject)}&body=${encodeURIComponent(briefText)}`;
+    setStatus("email");
+  };
+
   const copyBrief = async () => {
-    if (!briefText) return;
+    if (!briefText || (status === "idle" && !fallbackAllowed)) return;
     try {
       await navigator.clipboard.writeText(briefText);
       setError("");
@@ -597,23 +587,26 @@ function BriefDialog({ onClose, restoreFocusTo }) {
             <button className="text-link" type="button" onClick={onClose}>Close</button>
           </div>
         ) : (
-          <form onSubmit={sendBrief}>
+          <form onSubmit={sendBrief} onInput={() => {
+            if (error) setError("");
+            if (fallbackAllowed) setFallbackAllowed(false);
+          }}>
             <div className="form-grid">
               <label>
                 Your name <span>required</span>
-                <input ref={firstInput} name="name" autoComplete="name" required />
+                <input ref={firstInput} name="name" autoComplete="name" maxLength="80" required />
               </label>
               <label>
                 Work email <span>required</span>
-                <input name="email" type="email" autoComplete="email" required />
+                <input name="email" type="email" autoComplete="email" maxLength="254" required />
               </label>
               <label>
                 Company or project <span>required</span>
-                <input name="company" autoComplete="organization" required />
+                <input name="company" autoComplete="organization" maxLength="100" required />
               </label>
               <label>
                 Launch or product URL <span>optional</span>
-                <input name="url" type="url" inputMode="url" placeholder="https://" />
+                <input name="url" type="url" inputMode="url" placeholder="https://" maxLength="500" />
               </label>
             </div>
             <label>
@@ -622,19 +615,40 @@ function BriefDialog({ onClose, restoreFocusTo }) {
             </label>
             <label>
               What should a viewer understand after 45 seconds? <span>required</span>
-              <textarea name="story" rows="4" minLength="20" required aria-describedby="brief-safety" />
+              <textarea name="story" rows="4" minLength="20" maxLength="2000" required aria-describedby="brief-safety" />
             </label>
             <p className="form-safety" id="brief-safety">
               Do not include passwords, API keys, customer data, or access to a production environment.
             </p>
             <label className="consent-row">
               <input name="privacyAccepted" type="checkbox" required />
-              <span>I agree to the <a href="#privacy" target="_blank" rel="noreferrer">privacy disclosure</a> and understand this is a qualification request, not a purchase.</span>
+              <span>I've read the <a href="#privacy" target="_blank" rel="noreferrer">privacy disclosure</a> and agree to Flowtake using this brief to assess and reply. I understand this is not a purchase.</span>
             </label>
+            <div className="form-honeypot" aria-hidden="true" inert={true}>
+              <label>
+                Website
+                <input
+                  name="website"
+                  type="text"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  maxLength="500"
+                  data-1p-ignore="true"
+                  data-lpignore="true"
+                  data-bwignore="true"
+                />
+              </label>
+            </div>
             {error && <p className="form-error" role="alert">{error}</p>}
-            <p className="form-status" aria-live="polite">{status === "sending" ? "Preparing your request…" : ""}</p>
+            {error && fallbackAllowed && briefText && (
+              <div className="form-fallback-actions">
+                <button className="button button-quiet" type="button" onClick={openEmailFallback}>Open email draft instead</button>
+                <button className="text-link" type="button" onClick={copyBrief}>Copy brief</button>
+              </div>
+            )}
+            <p className="form-status" aria-live="polite">{status === "sending" ? "Sending your brief..." : ""}</p>
             <button className="button button-primary form-submit" type="submit" disabled={status === "sending"}>
-              {status === "sending" ? "Preparing…" : LEAD_ENDPOINT ? "Send the brief" : "Open email draft"}
+              {status === "sending" ? "Sending..." : error ? "Try again" : "Send the brief"}
               <ArrowRightIcon aria-hidden="true" />
             </button>
           </form>

--- a/website/src/intake.js
+++ b/website/src/intake.js
@@ -1,0 +1,138 @@
+export const INTAKE_ORIGIN = "https://flowtake.72-62-41-174.sslip.io";
+export const LEAD_ENDPOINT = "https://flowtake.72-62-41-174.sslip.io/v1/leads";
+export const EVENT_ENDPOINT = "https://flowtake.72-62-41-174.sslip.io/v1/events";
+export const LEAD_TIMEOUT_MS = 12_000;
+
+const EVENT_NAMES = new Set([
+  "page_viewed",
+  "brief_opened",
+  "founding_cta_clicked",
+  "github_clicked",
+  "download_clicked",
+  "brief_submitted",
+  "brief_handoff_started",
+  "brief_copied",
+]);
+
+export class LeadSubmissionError extends Error {
+  constructor(message, status = 0) {
+    super(message);
+    this.name = "LeadSubmissionError";
+    this.status = status;
+  }
+}
+
+export class LeadPayloadError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "LeadPayloadError";
+  }
+}
+
+export function describeLeadFailure(error) {
+  if (error?.status === 400 || error?.status === 413) {
+    return { fallbackAllowed: false, message: "Please check the entered fields and try again." };
+  }
+  if (error?.status === 429) {
+    return {
+      fallbackAllowed: true,
+      message: "Too many attempts from this network. Wait 15 minutes or use email instead.",
+    };
+  }
+  return {
+    fallbackAllowed: true,
+    message: "We couldn't confirm that your brief was received. Try again or use email instead.",
+  };
+}
+
+function normalizePublicUrl(value) {
+  const raw = value.trim();
+  if (!raw) return "";
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new LeadPayloadError("Enter a valid public http or https URL.");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password) {
+    throw new LeadPayloadError("Use a public http or https URL without a username or password. Query parameters and fragments are removed.");
+  }
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString();
+}
+
+export function createLeadPayload(formData) {
+  const value = (name) => String(formData.get(name) ?? "");
+  return {
+    name: value("name").trim(),
+    email: value("email").trim(),
+    company: value("company").trim(),
+    url: normalizePublicUrl(value("url")),
+    deadline: value("deadline"),
+    story: value("story").trim(),
+    privacyAccepted: value("privacyAccepted") === "on",
+    website: value("website"),
+    source: "release-studio-website",
+  };
+}
+
+export async function sendEvent(name, { endpoint = EVENT_ENDPOINT, fetchImpl = fetch } = {}) {
+  if (!endpoint || !EVENT_NAMES.has(name)) return undefined;
+  try {
+    return await fetchImpl(endpoint, {
+      method: "POST",
+      mode: "cors",
+      credentials: "omit",
+      referrerPolicy: "no-referrer",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+      keepalive: true,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+export async function submitLead(
+  payload,
+  { endpoint = LEAD_ENDPOINT, fetchImpl = fetch, timeoutMs = LEAD_TIMEOUT_MS } = {},
+) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    let response;
+    try {
+      response = await fetchImpl(endpoint, {
+        method: "POST",
+        mode: "cors",
+        credentials: "omit",
+        referrerPolicy: "no-referrer",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        keepalive: true,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      throw new LeadSubmissionError(
+        error?.name === "AbortError" || controller.signal.aborted ? "request_timeout" : "network_error",
+      );
+    }
+
+    let result = null;
+    try {
+      result = await response.json();
+    } catch (error) {
+      if (error?.name === "AbortError" || controller.signal.aborted) {
+        throw new LeadSubmissionError("request_timeout");
+      }
+      // A malformed success response must never be shown as received.
+    }
+    if (response.status !== 201 || result?.accepted !== true) {
+      throw new LeadSubmissionError("request_not_accepted", response.status);
+    }
+    return result;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/website/src/intake.test.mjs
+++ b/website/src/intake.test.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import {
+  EVENT_ENDPOINT,
+  INTAKE_ORIGIN,
+  LEAD_ENDPOINT,
+  LEAD_TIMEOUT_MS,
+  LeadPayloadError,
+  LeadSubmissionError,
+  createLeadPayload,
+  describeLeadFailure,
+  sendEvent,
+  submitLead,
+} from "./intake.js";
+
+test("production endpoint defaults are exact and HTTPS", () => {
+  assert.equal(INTAKE_ORIGIN, "https://flowtake.72-62-41-174.sslip.io");
+  assert.equal(LEAD_ENDPOINT, `${INTAKE_ORIGIN}/v1/leads`);
+  assert.equal(EVENT_ENDPOINT, `${INTAKE_ORIGIN}/v1/events`);
+});
+
+test("lead payload allowlists fields, trims text, includes honeypot, and normalizes consent", () => {
+  const formData = new FormData();
+  formData.set("name", "  Avery Demo  ");
+  formData.set("email", "  avery@example.dev ");
+  formData.set("company", " Synthetic Tools ");
+  formData.set("url", " https://example.dev/launch?token=discard#private ");
+  formData.set("deadline", "2026-08-01");
+  formData.set("story", "  Show the release workflow clearly and safely.  ");
+  formData.set("privacyAccepted", "on");
+  formData.set("website", "");
+  formData.set("unexpected", "must-not-send");
+
+  assert.deepEqual(createLeadPayload(formData), {
+    name: "Avery Demo",
+    email: "avery@example.dev",
+    company: "Synthetic Tools",
+    url: "https://example.dev/launch",
+    deadline: "2026-08-01",
+    story: "Show the release workflow clearly and safely.",
+    privacyAccepted: true,
+    website: "",
+    source: "release-studio-website",
+  });
+
+  formData.set("url", "https://user:password@example.dev/launch");
+  assert.throws(() => createLeadPayload(formData), LeadPayloadError);
+});
+
+test("events send only the allowlisted name with credential-free keepalive fetch", async () => {
+  let captured;
+  const response = { status: 202 };
+  const result = await sendEvent("brief_opened", {
+    fetchImpl: async (...args) => {
+      captured = args;
+      return response;
+    },
+  });
+  assert.equal(result, response);
+  assert.equal(captured[0], EVENT_ENDPOINT);
+  assert.deepEqual(JSON.parse(captured[1].body), { name: "brief_opened" });
+  assert.equal(captured[1].credentials, "omit");
+  assert.equal(captured[1].referrerPolicy, "no-referrer");
+  assert.equal(captured[1].keepalive, true);
+  assert.equal(await sendEvent("not-allowlisted", { fetchImpl: async () => assert.fail() }), undefined);
+  assert.equal(await sendEvent("brief_opened", { fetchImpl: async () => { throw new Error("offline"); } }), undefined);
+});
+
+test("lead submission requires an explicit 201 accepted response", async () => {
+  const payload = createLeadPayload(new FormData());
+  let captured;
+  const accepted = await submitLead(payload, {
+    fetchImpl: async (...args) => {
+      captured = args;
+      return { status: 201, json: async () => ({ accepted: true, id: "synthetic" }) };
+    },
+  });
+  assert.equal(accepted.id, "synthetic");
+  assert.equal(captured[0], LEAD_ENDPOINT);
+  assert.deepEqual(JSON.parse(captured[1].body), payload);
+  assert.equal(captured[1].credentials, "omit");
+  assert.equal(captured[1].referrerPolicy, "no-referrer");
+
+  for (const status of [400, 429, 500]) {
+    await assert.rejects(
+      submitLead(payload, { fetchImpl: async () => ({ status, json: async () => ({ accepted: false }) }) }),
+      (error) => error instanceof LeadSubmissionError && error.status === status,
+    );
+  }
+  await assert.rejects(
+    submitLead(payload, { fetchImpl: async () => { throw new Error("offline"); } }),
+    (error) => error instanceof LeadSubmissionError && error.status === 0,
+  );
+  await assert.rejects(
+    submitLead(payload, { fetchImpl: async () => ({ status: 201, json: async () => { throw new Error("bad json"); } }) }),
+    (error) => error instanceof LeadSubmissionError && error.status === 201,
+  );
+});
+
+test("lead submission aborts a stalled request within the configured deadline", async () => {
+  assert.equal(LEAD_TIMEOUT_MS, 12_000);
+  const payload = createLeadPayload(new FormData());
+  await assert.rejects(
+    submitLead(payload, {
+      timeoutMs: 5,
+      fetchImpl: async (_url, options) => new Promise((_resolve, reject) => {
+        options.signal.addEventListener("abort", () => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          reject(error);
+        });
+      }),
+    }),
+    (error) => error instanceof LeadSubmissionError && error.message === "request_timeout" && error.status === 0,
+  );
+
+  await assert.rejects(
+    submitLead(payload, {
+      timeoutMs: 5,
+      fetchImpl: async (_url, options) => ({
+        status: 201,
+        json: async () => new Promise((_resolve, reject) => {
+          options.signal.addEventListener("abort", () => {
+            const error = new Error("aborted while reading response");
+            error.name = "AbortError";
+            reject(error);
+          }, { once: true });
+        }),
+      }),
+    }),
+    (error) => error instanceof LeadSubmissionError && error.message === "request_timeout" && error.status === 0,
+  );
+});
+
+test("only recoverable transport and rate failures expose email or copy fallback", () => {
+  assert.deepEqual(describeLeadFailure({ status: 400 }), {
+    fallbackAllowed: false,
+    message: "Please check the entered fields and try again.",
+  });
+  assert.equal(describeLeadFailure({ status: 413 }).fallbackAllowed, false);
+  assert.equal(describeLeadFailure({ status: 429 }).fallbackAllowed, true);
+  assert.equal(describeLeadFailure({ status: 500 }).fallbackAllowed, true);
+  assert.equal(describeLeadFailure({ status: 0 }).fallbackAllowed, true);
+});
+
+test("the request form exposes privacy-safe limits and explicit failure fallbacks", async () => {
+  const source = await readFile(new URL("./App.jsx", import.meta.url), "utf8");
+  for (const required of [
+    'name="website"',
+    'maxLength="2000"',
+    "Open email draft instead",
+    "Copy brief",
+    "Try again",
+    "stores only UTC day, action name, and count",
+    "setFallbackAllowed(failure.fallbackAllowed)",
+    "error && fallbackAllowed && briefText",
+  ]) {
+    assert.equal(source.includes(required), true, `missing ${required}`);
+  }
+  assert.equal(source.includes("sendBeacon"), false);
+  assert.equal(source.includes("analytics is unconfigured"), false);
+
+  const intakeSource = await readFile(new URL("./intake.js", import.meta.url), "utf8");
+  assert.equal(intakeSource.includes("import.meta.env"), false);
+  assert.equal(intakeSource.includes("Too many attempts from this network."), true);
+});

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1055,6 +1055,35 @@ button.text-link {
   border-color: #ff7675;
 }
 
+.form-honeypot {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.form-fallback-actions {
+  margin: -4px 0 18px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.form-fallback-actions .button {
+  min-height: 42px;
+}
+
+.form-fallback-actions .text-link {
+  min-height: 42px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
 .form-submit {
   width: 100%;
 }


### PR DESCRIPTION
Activates the privacy-minimized Release Studio brief funnel against the pinned HTTPS intake service. Adds explicit allowlisted lead and event payloads, encrypted-intake disclosure, recoverable failure actions, timeout coverage, and CI/Pages checks that require the exact production endpoints. Verified locally with 136 root tests, 7 website contract tests, 11 workflow tests, focused ESLint, a Pages-mode build, responsive Browser QA, and an independent merge review.