### PR TITLE
Prioritize the Release Studio conversion path

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Flowtake is a free, MIT-licensed desktop recorder and editor for turning IDE, terminal, browser, and desktop captures into polished developer demos." />
+    <meta name="description" content="Flowtake is a free MIT desktop recorder and editor. Optional $99/month Release Studio turns approved developer workflows into four polished demos each month." />
     <meta name="theme-color" content="#0a0a18" />
     <link rel="canonical" href="https://jnx03.github.io/Flowtake/" />
-    <meta property="og:title" content="Flowtake — open-source studio for developer demos" />
-    <meta property="og:description" content="Record IDE, terminal, browser, and desktop sources locally, then shape the real workflow into a polished developer-product demo." />
+    <meta property="og:title" content="Flowtake — free recorder and developer demo studio" />
+    <meta property="og:description" content="Use the free local recorder, or request $99/month Release Studio help for four polished developer demos each month." />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Flowtake" />
     <meta property="og:url" content="https://jnx03.github.io/Flowtake/" />
@@ -16,8 +16,8 @@
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Flowtake — open-source studio for developer demos" />
-    <meta name="twitter:description" content="Capture the real developer workflow locally and keep every source editable." />
+    <meta name="twitter:title" content="Flowtake — free recorder and developer demo studio" />
+    <meta name="twitter:description" content="Use the free local recorder, or request $99/month Release Studio help for four polished developer demos each month." />
     <meta name="twitter:image" content="https://jnx03.github.io/Flowtake/assets/logo.png" />
     <link rel="icon" type="image/png" href="%BASE_URL%assets/logo.png" />
     <script type="application/ld+json">
@@ -38,7 +38,7 @@
         }
       }
     </script>
-    <title>Flowtake — open-source studio for developer demos</title>
+    <title>Flowtake — free recorder and developer demo studio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -105,11 +105,6 @@ export function App() {
     setBriefOpen(true);
   };
 
-  const reserve = (trigger) => {
-    track("founding_cta_clicked");
-    openBrief(trigger);
-  };
-
   useEffect(() => {
     track("page_viewed");
   }, []);
@@ -193,19 +188,29 @@ export function App() {
           <div className="hero-copy">
             <p className="eyebrow">
               <span className="eyebrow-line" aria-hidden="true" />
-              Free MIT desktop app · optional production help
+              Free MIT recorder · optional $99/month production
             </p>
             <h1>
               Record the build.
               <span>Ship a clear <em>demo.</em></span>
             </h1>
             <p className="hero-lede">
-              Capture IDE, terminal, browser, and desktop sources locally, then shape the real workflow into a polished developer-product story.
+              Capture IDE, terminal, browser, and desktop sources locally with the free app. Release Studio turns approved workflows into polished launch demos.
             </p>
 
+            <div className="price-line">
+              <span className="price">$99</span>
+              <span className="price-period">/ month</span>
+              <span className="price-note">Four 30–90 second demos · 16:9 masters + social cutdowns</span>
+            </div>
+
             <div className="hero-actions">
+              <button className="button button-primary" type="button" onClick={(event) => openBrief(event.currentTarget)}>
+                Request a sample storyboard
+                <ArrowRightIcon aria-hidden="true" />
+              </button>
               <a
-                className="button button-primary"
+                className="button button-quiet"
                 href="https://github.com/JNX03/Flowtake/releases/latest"
                 target="_blank"
                 rel="noreferrer"
@@ -214,7 +219,6 @@ export function App() {
                 Download Flowtake free
                 <ArrowRightIcon aria-hidden="true" />
               </a>
-              <a className="button button-quiet" href="#founding-plan">See Release Studio</a>
             </div>
 
             <p className="honest-note">
@@ -318,8 +322,8 @@ export function App() {
               ))}
             </ul>
             <div className="plan-action">
-              <button className="button button-primary" type="button" onClick={(event) => reserve(event.currentTarget)}>
-                Request a founding slot
+              <button className="button button-primary" type="button" onClick={(event) => openBrief(event.currentTarget)}>
+                Request a sample storyboard
                 <ArrowRightIcon aria-hidden="true" />
               </button>
               <p>$99 recurring monthly after written scope confirmation. Cancel before renewal. Checkout stays private until timing, safe capture, and terms are accepted.</p>

--- a/website/src/intake.test.mjs
+++ b/website/src/intake.test.mjs
@@ -165,3 +165,21 @@ test("the request form exposes privacy-safe limits and explicit failure fallback
   assert.equal(intakeSource.includes("import.meta.env"), false);
   assert.equal(intakeSource.includes("Too many attempts from this network."), true);
 });
+
+test("the hero leads with the qualification-first paid offer and keeps the free app secondary", async () => {
+  const source = await readFile(new URL("./App.jsx", import.meta.url), "utf8");
+  const hero = source.slice(source.indexOf('<section className="hero section"'), source.indexOf('<div className="hero-visual"'));
+  const requestIndex = hero.indexOf("Request a sample storyboard");
+  const downloadIndex = hero.indexOf("Download Flowtake free");
+
+  assert.equal(hero.includes("$99"), true);
+  assert.equal(hero.includes("Four 30–90 second demos"), true);
+  assert.ok(requestIndex >= 0 && requestIndex < downloadIndex, "paid request must precede the free download");
+  assert.equal(source.includes("Request a founding slot"), false);
+  assert.equal(source.match(/onClick=\{\(event\) => openBrief\(event\.currentTarget\)\}/gu)?.length, 3);
+  assert.equal(source.includes('track("founding_cta_clicked")'), false);
+
+  const metadata = await readFile(new URL("../index.html", import.meta.url), "utf8");
+  assert.equal(metadata.includes("free recorder and developer demo studio"), true);
+  assert.equal(metadata.includes("$99/month Release Studio"), true);
+});

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -267,7 +267,7 @@ button.text-link {
 
 .hero-lede {
   max-width: 520px;
-  margin: 0 0 32px;
+  margin: 0;
 }
 
 .hero-actions {
@@ -338,7 +338,7 @@ button.text-link {
 }
 
 .price-line {
-  margin-top: 34px;
+  margin: 30px 0 22px;
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- surface the truthful `$99/month` Release Studio offer above the fold
- make the no-obligation sample storyboard request the primary landing-page action
- keep the free MIT download visible as the secondary path
- align page and social metadata with the free recorder plus optional production service
- keep conversion analytics truthful by tracking brief opens without recording a founding-plan click

## Validation
- `npm test` — 139/139 passing
- `npm --prefix website run build`
- targeted ESLint for the changed website files
- `git diff --check`
- Browser QA at 1280px plus DOM overflow checks at 390/768/1280/1440
- primary CTA opens the brief modal and closing restores focus
- candidate page reports no console warnings or errors
- independent review: merge approved after correcting the CTA analytics event

## Scope
No checkout, new asset, customer claim, or pricing commitment beyond the existing `$99/month` founding offer is added.