### PR TITLE
Link the public storyboard prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ For vulnerability reporting, follow the private process in [SECURITY.md](SECURIT
 
 Teams that want human-assisted production for a technical launch can visit [Flowtake Release Studio](https://jnx03.github.io/Flowtake/). It is a separate, optional service; Flowtake's desktop recorder and editor remain the primary open-source product.
 
+Through July 23, 2026, Flowtake will publicly reply with a no-obligation six-beat storyboard to up to the first three maintainers who [share a complete, publicly documented developer-tool workflow](https://github.com/JNX03/Flowtake/discussions/169). No separate Flowtake signup, footage, or payment is required.
+
 ## Development
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- link the live public storyboard prompt from the README's optional Release Studio section
- state the July 23 deadline, first-three cap, public-reply format, and no-separate-signup/footage/payment boundary
- keep the free MIT recorder/editor as the primary open-source product

## Validation
- `npm test` — 139/139 passing
- `node --test test/versionConsistency.test.js` — 5/5 passing after final copy correction
- `git diff --check`
- independent review: initial no-merge caught the missing first-three cap and GitHub sign-in nuance; corrected copy received MERGE

## Scope
README-only. The linked GitHub Discussion is already live and exactly supports the bounded promise.