### PR TITLE
Add truthful Screen Studio alternative for Windows page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build marketing site for GitHub Pages
         run: npm run build --prefix website -- --mode pages
 
+      - name: Verify marketing-site Pages artifacts
+        run: npm run verify:build --prefix website
+
       - name: Require production intake endpoints in the built site
         shell: bash
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Build for the repository Pages base path
         run: npm run build -- --mode pages
 
+      - name: Verify Pages routes and metadata
+        run: npm run verify:build
+
       - name: Require production intake endpoints in the built site
         shell: bash
         run: |

--- a/website/DEPLOYMENT.md
+++ b/website/DEPLOYMENT.md
@@ -4,6 +4,10 @@ The marketing site is prepared for the repository Pages URL:
 
 `https://jnx03.github.io/Flowtake/`
 
+The physical comparison entry is served at:
+
+`https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/`
+
 No repository setting, custom domain, or DNS change is performed by this configuration.
 
 ## Build modes
@@ -11,6 +15,7 @@ No repository setting, custom domain, or DNS change is performed by this configu
 - `npm run dev` and `npm run build` use `/` as the asset base for normal local work.
 - `npm run build -- --mode pages` uses `/Flowtake/`, matching GitHub project Pages.
 - After a Pages-mode build, `npm run preview -- --mode pages` serves the generated site locally at `http://localhost:4173/Flowtake/` by default.
+- `npm run verify:build` requires both `dist/index.html` and `dist/screen-studio-alternative-windows/index.html`, validates their distinct metadata, parses the comparison JSON-LD, and checks the sitemap entry.
 
 Public images used from React are joined to `import.meta.env.BASE_URL`. Vite rewrites the favicon and CSS font URLs during the Pages-mode build. This prevents requests from escaping to the domain root when the site is hosted below `/Flowtake/`.
 

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node --test src/intake.test.mjs"
+    "test": "node --test src/*.test.mjs",
+    "verify:build": "node scripts/verify-built-site.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -4,4 +4,8 @@
     <loc>https://jnx03.github.io/Flowtake/</loc>
     <lastmod>2026-07-16</lastmod>
   </url>
+  <url>
+    <loc>https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/</loc>
+    <lastmod>2026-07-16</lastmod>
+  </url>
 </urlset>

--- a/website/screen-studio-alternative-windows/index.html
+++ b/website/screen-studio-alternative-windows/index.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Need Screen Studio-style auto zoom on Windows? Flowtake is a free, MIT-licensed recorder and timeline editor for Windows 10/11, with local MP4 export." />
+    <meta name="theme-color" content="#0a0a18" />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <link rel="canonical" href="https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Flowtake" />
+    <meta property="og:title" content="Screen Studio Alternative for Windows: Flowtake" />
+    <meta property="og:description" content="Compare Flowtake and Screen Studio by platform, licensing, export access, and workflow fit." />
+    <meta property="og:url" content="https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/" />
+    <meta property="og:image" content="https://jnx03.github.io/Flowtake/assets/logo.png" />
+    <meta property="og:image:alt" content="Flowtake app icon" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Screen Studio Alternative for Windows: Flowtake" />
+    <meta name="twitter:description" content="A factual comparison for Windows users who need auto zoom, timeline editing, and local MP4 export." />
+    <meta name="twitter:image" content="https://jnx03.github.io/Flowtake/assets/logo.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%assets/logo.png" />
+    <link rel="stylesheet" href="/src/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Screen Studio Alternative for Windows: Flowtake",
+        "url": "https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/",
+        "description": "A factual comparison of Flowtake and Screen Studio for Windows users.",
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "Flowtake",
+          "url": "https://jnx03.github.io/Flowtake/"
+        },
+        "about": {
+          "@type": "SoftwareApplication",
+          "name": "Flowtake",
+          "applicationCategory": "MultimediaApplication",
+          "operatingSystem": "Windows 10, Windows 11",
+          "isAccessibleForFree": true,
+          "license": "https://opensource.org/license/mit",
+          "url": "https://jnx03.github.io/Flowtake/",
+          "downloadUrl": "https://github.com/JNX03/Flowtake/releases/tag/v1.6.0"
+        }
+      }
+    </script>
+    <title>Screen Studio Alternative for Windows: Flowtake</title>
+  </head>
+  <body>
+    <div class="site-shell comparison-page">
+      <a class="skip-link" href="#main-content">Skip to main content</a>
+
+      <header class="site-header" data-modal-region>
+        <a class="brand" href="%BASE_URL%" aria-label="Flowtake home">
+          <img src="%BASE_URL%assets/logo.svg" alt="" />
+          <span>Flowtake</span>
+          <span class="brand-edition">Windows comparison</span>
+        </a>
+
+        <nav class="desktop-nav" aria-label="Primary navigation">
+          <a href="#compare">Compare</a>
+          <a href="#windows-workflow">Windows workflow</a>
+          <a href="#limits">Honest limits</a>
+          <a href="#faq">FAQ</a>
+        </nav>
+
+        <div class="header-actions">
+          <a class="text-link desktop-only" href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer" data-track="github_clicked">GitHub</a>
+          <a class="button button-small" href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Download free</a>
+          <button class="menu-button" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="comparison-mobile-navigation" data-menu-button>
+            <span data-menu-label>Menu</span>
+          </button>
+        </div>
+
+        <nav class="mobile-nav" id="comparison-mobile-navigation" aria-label="Mobile navigation" hidden data-mobile-nav>
+          <a href="#compare">Compare</a>
+          <a href="#windows-workflow">Windows workflow</a>
+          <a href="#limits">Honest limits</a>
+          <a href="#faq">FAQ</a>
+          <a href="%BASE_URL%">Flowtake home</a>
+          <a href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Download v1.6.0</a>
+        </nav>
+      </header>
+
+      <main id="main-content" data-modal-region>
+        <section class="hero section comparison-hero" id="top">
+          <div class="hero-copy">
+            <p class="eyebrow"><span class="eyebrow-line" aria-hidden="true"></span> Windows 10/11 · free and MIT-licensed</p>
+            <h1>
+              A Screen Studio
+              <span>alternative built for <em>Windows.</em></span>
+            </h1>
+            <p class="hero-lede">
+              Screen Studio currently offers macOS builds. Flowtake gives Windows 10/11 users automatic cursor-driven zoom and pan, an editable timeline, and local MP4 export in a free, MIT-licensed desktop app.
+            </p>
+            <div class="price-line comparison-price-line">
+              <span class="price">Free</span>
+              <span class="price-period">MIT license</span>
+              <span class="price-note">No software subscription required for Flowtake recording or export</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button button-primary" href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Download Flowtake for Windows</a>
+              <a class="button button-quiet" href="#compare">Compare the tradeoffs</a>
+            </div>
+            <p class="honest-note comparison-warning">
+              Flowtake v1.6.0 Windows files are unsigned, so Microsoft SmartScreen may warn. Download only from the official GitHub release and verify <a href="https://github.com/JNX03/Flowtake/releases/download/v1.6.0/SHA256SUMS.txt" target="_blank" rel="noreferrer">SHA256SUMS.txt</a> before running a file.
+            </p>
+          </div>
+
+          <aside class="comparison-hero-panel" aria-label="Current platform fit summary">
+            <div class="comparison-panel-head">
+              <img src="%BASE_URL%assets/logo.png" alt="" />
+              <div>
+                <p>Current platform fit</p>
+                <strong>Choose by constraint</strong>
+              </div>
+              <span>July 16, 2026</span>
+            </div>
+            <article class="fit-card fit-card-primary">
+              <div>
+                <p>Flowtake</p>
+                <strong>Windows 10/11 x64</strong>
+              </div>
+              <span class="fit-label">Primary target</span>
+              <ul>
+                <li>Cursor-driven zoom and pan</li>
+                <li>Editable timeline and local MP4 export</li>
+                <li>Free source under the MIT License</li>
+              </ul>
+            </article>
+            <article class="fit-card">
+              <div>
+                <p>Screen Studio</p>
+                <strong>macOS Ventura 13.1+</strong>
+              </div>
+              <span class="fit-label fit-label-muted">No current Windows build</span>
+              <p>More mature Mac-specific polish, hosted share links, GIF and up-to-4K60 export, and other features Flowtake does not promise.</p>
+            </article>
+            <p class="comparison-disclosure">Screen Studio is a product of its respective owner. Flowtake is independent and is not affiliated with or endorsed by Screen Studio.</p>
+          </aside>
+        </section>
+
+        <div class="signal-bar comparison-signal" aria-label="Flowtake facts">
+          <span>Windows is the primary tested target</span>
+          <span>EXE, MSI, and portable ZIP</span>
+          <span>Projects and exports stay local by default</span>
+        </div>
+
+        <section class="section comparison-section" id="compare">
+          <header class="section-heading">
+            <p class="kicker">Side-by-side, without the sales fog</p>
+            <h2>Choose on platform, workflow, and limits—not imitation.</h2>
+            <p>
+              Flowtake is not a feature-for-feature Screen Studio clone. It is the practical open-source option when Windows support, editable zooms, local projects, and a zero-dollar app license matter most.
+            </p>
+          </header>
+
+          <div class="comparison-table-wrap" tabindex="0" role="region" aria-label="Flowtake and Screen Studio comparison">
+            <table class="comparison-table">
+              <caption>Flowtake and Screen Studio, based on official product information checked July 16, 2026.</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Question</th>
+                  <th scope="col">Flowtake</th>
+                  <th scope="col">Screen Studio</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row">Primary platform</th>
+                  <td>Windows 10/11 x64; macOS and Linux builds are previews</td>
+                  <td>macOS only; Ventura 13.1 or later</td>
+                </tr>
+                <tr>
+                  <th scope="row">App price</th>
+                  <td>Free and MIT-licensed</td>
+                  <td>$29 monthly, or $9/month billed yearly, observed July 16, 2026</td>
+                </tr>
+                <tr>
+                  <th scope="row">Automatic zoom</th>
+                  <td>Cursor-driven zoom and pan, editable on the timeline</td>
+                  <td>Click-driven automatic zoom plus manual zoom controls</td>
+                </tr>
+                <tr>
+                  <th scope="row">Core editor</th>
+                  <td>Trim and split, cursor and click effects, masks, backgrounds, overlays, audio, and subtitles</td>
+                  <td>Mac-focused editing with cursor polish, branding, captions, and vertical layouts</td>
+                </tr>
+                <tr>
+                  <th scope="row">Export</th>
+                  <td>Configurable local MP4 rendering</td>
+                  <td>MP4 and GIF up to 4K60, plus hosted share links</td>
+                </tr>
+                <tr>
+                  <th scope="row">Recording privacy</th>
+                  <td>Ordinary recordings, projects, and exports stay local; no cloud project sync</td>
+                  <td>Recordings are local unless a shareable link is created</td>
+                </tr>
+                <tr>
+                  <th scope="row">Important limitation</th>
+                  <td>Current Windows artifacts are unsigned and may trigger SmartScreen</td>
+                  <td>No current Windows build; export requires an active plan</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="source-note">
+            Verify changing details at the official <a href="https://screen.studio/guide/system-requirements" target="_blank" rel="noreferrer">Screen Studio system requirements</a>, <a href="https://screen.studio/#pricing" target="_blank" rel="noreferrer">Screen Studio pricing</a>, and <a href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer">Flowtake v1.6.0 release</a>.
+          </p>
+        </section>
+
+        <section class="section comparison-section comparison-section-bordered" id="windows-workflow">
+          <header class="section-heading compact">
+            <p class="kicker">What the Windows workflow includes</p>
+            <h2>Capture, reframe, and finish in one editable project.</h2>
+            <p>Flowtake focuses on the recording and editing loop Windows developers, educators, and product teams need for concise demos.</p>
+          </header>
+          <div class="comparison-card-grid">
+            <article class="comparison-card">
+              <p class="comparison-card-label">Capture</p>
+              <h3>Choose the real source</h3>
+              <p>Record a full display, one window, or a selected area. Add camera, microphone, and supported system audio when the story needs them.</p>
+            </article>
+            <article class="comparison-card">
+              <p class="comparison-card-label">Edit</p>
+              <h3>Tune the motion after recording</h3>
+              <p>Adjust generated zoom and pan, trim or split clips, style cursor and clicks, and add backgrounds, masks, overlays, audio, or subtitles.</p>
+            </article>
+            <article class="comparison-card">
+              <p class="comparison-card-label">Export</p>
+              <h3>Render a local MP4</h3>
+              <p>Keep ordinary projects and exports on your device, then render a configurable MP4 without requiring a Flowtake software subscription.</p>
+            </article>
+          </div>
+          <p class="network-boundary">Local-first does not mean every feature is offline. Release checks and explicit YouTube, RTMP, or model-asset features can make network requests.</p>
+        </section>
+
+        <section class="section comparison-section honesty-section" id="limits">
+          <div class="honesty-copy">
+            <p class="kicker">The honest boundary</p>
+            <h2>Where Screen Studio is still stronger.</h2>
+            <p>
+              Screen Studio is the more mature Mac-specific product and advertises features Flowtake does not currently promise, including hosted share links, GIF and 4K60 export, iPhone and iPad capture, and automatic vertical-output adjustments.
+            </p>
+            <p>
+              Choose Flowtake when Windows support, open source, local projects, and no software subscription matter more than those features. Choose Screen Studio when its macOS-specific polish and broader sharing or export workflow fit your work better.
+            </p>
+          </div>
+          <aside class="download-card" aria-label="Flowtake Windows download guidance">
+            <p class="comparison-card-label">Flowtake v1.6.0</p>
+            <h3>Start with the official release.</h3>
+            <p>The setup EXE is the simplest starting point. An MSI and portable ZIP are available on the same release page.</p>
+            <a class="button button-primary" href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Open Windows downloads</a>
+            <a class="text-link checksum-link" href="https://github.com/JNX03/Flowtake/releases/download/v1.6.0/SHA256SUMS.txt" target="_blank" rel="noreferrer">Verify SHA-256 checksums</a>
+            <p class="download-warning">Unsigned build: expect a possible SmartScreen warning. Do not use mirrors.</p>
+          </aside>
+        </section>
+
+        <section class="section faq-section comparison-faq" id="faq">
+          <header class="section-heading compact">
+            <p class="kicker">Questions before installing</p>
+            <h2>Compatibility, cost, privacy, and files.</h2>
+          </header>
+          <div class="faq-list">
+            <details>
+              <summary>Does Screen Studio work on Windows?</summary>
+              <p>Screen Studio’s current installation guide describes the app as exclusive to macOS. Flowtake’s primary tested target is Windows 10/11 x64, with EXE, MSI, and portable ZIP downloads.</p>
+            </details>
+            <details>
+              <summary>Does Flowtake include automatic zoom?</summary>
+              <p>Yes. Flowtake generates zoom and pan motion from cursor activity, then lets you tune zooms, clips, cursor styling, and click effects on its timeline.</p>
+            </details>
+            <details>
+              <summary>Is Flowtake free?</summary>
+              <p>Yes. The published Flowtake desktop recorder and editor are free to use, inspect, modify, and redistribute under the MIT License. The optional Flowtake Release Studio is a separate paid production service.</p>
+            </details>
+            <details>
+              <summary>Are recordings uploaded to the cloud?</summary>
+              <p>Ordinary Flowtake recordings, project files, and exports stay on your device, and Flowtake has no cloud project sync. Some explicit features can make network requests, including release checks, YouTube upload, RTMP streaming, and model-asset downloads.</p>
+            </details>
+            <details>
+              <summary>How does the price compare with Screen Studio?</summary>
+              <p>Flowtake’s desktop app is free and MIT-licensed. On July 16, 2026, Screen Studio displayed $29/month billed monthly or $9/month billed yearly, and its download page said video export requires an active plan. Check Screen Studio’s current pricing before deciding.</p>
+            </details>
+            <details>
+              <summary>Which Flowtake file should Windows users download?</summary>
+              <p>The Flowtake 1.6.0 x64 setup EXE is the simplest starting point. An MSI and portable ZIP are also available. The current Windows files are unsigned, so verify SHA256SUMS.txt and expect a possible SmartScreen warning.</p>
+            </details>
+            <details>
+              <summary>Is Flowtake affiliated with Screen Studio?</summary>
+              <p>No. Flowtake is an independent open-source project and is not affiliated with or endorsed by Screen Studio. “Screen Studio” is used only to help Windows users compare relevant options.</p>
+            </details>
+          </div>
+        </section>
+
+        <section class="section final-cta comparison-final-cta">
+          <div>
+            <p class="eyebrow"><span class="eyebrow-line" aria-hidden="true"></span> Need the finished release story?</p>
+            <h2>Record free—or ask for a sample storyboard.</h2>
+            <p>Release Studio is an optional $99/month production service. It does not change the free MIT app.</p>
+          </div>
+          <div class="comparison-final-actions">
+            <a class="button button-primary" href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Download Flowtake</a>
+            <button class="button button-quiet" type="button" data-open-brief>Request a sample storyboard</button>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer comparison-footer" data-modal-region>
+        <div class="brand footer-brand">
+          <img src="%BASE_URL%assets/logo.svg" alt="" />
+          <span>Flowtake</span>
+        </div>
+        <p>Independent, open-source, and not endorsed by Screen Studio.</p>
+        <div>
+          <a href="%BASE_URL%">Home</a>
+          <a href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="https://github.com/JNX03/Flowtake/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT License</a>
+          <a href="%BASE_URL%#privacy">Privacy</a>
+          <a href="mailto:jnxstartup@gmail.com">Contact</a>
+        </div>
+      </footer>
+
+      <div id="comparison-enhancements"></div>
+    </div>
+    <script type="module" src="/src/screenStudioAlternative.main.jsx"></script>
+  </body>
+</html>

--- a/website/scripts/verify-built-site.mjs
+++ b/website/scripts/verify-built-site.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { preview } from "vite";
 
 const comparisonUrl = "https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/";
 const distUrl = new URL("../dist/", import.meta.url);
@@ -32,5 +34,37 @@ assert.equal(jsonLdBlocks.length, 1, "comparison must have one JSON-LD block");
 for (const block of jsonLdBlocks) JSON.parse(block[1]);
 
 assert.equal(count(sitemap, `<loc>${comparisonUrl}</loc>`), 1, "comparison sitemap entry must be unique");
+
+const previewServer = await preview({
+  root: fileURLToPath(new URL("../", import.meta.url)),
+  mode: "pages",
+  preview: {
+    host: "127.0.0.1",
+    port: 4174,
+    strictPort: true,
+  },
+});
+
+try {
+  const previewOrigin = "http://127.0.0.1:4174";
+  const [homeResponse, comparisonResponse, unknownResponse] = await Promise.all([
+    fetch(`${previewOrigin}/Flowtake/`),
+    fetch(`${previewOrigin}/Flowtake/screen-studio-alternative-windows/`),
+    fetch(`${previewOrigin}/Flowtake/not-a-real-page/`),
+  ]);
+
+  assert.equal(homeResponse.status, 200, "preview homepage must return 200");
+  assert.equal(comparisonResponse.status, 200, "preview comparison route must return 200");
+  assert.equal(unknownResponse.status, 404, "preview unknown route must remain a real 404");
+  assert.equal(
+    (await comparisonResponse.text()).includes("A Screen Studio"),
+    true,
+    "preview comparison response must contain its static body",
+  );
+} finally {
+  await new Promise((resolve, reject) => {
+    previewServer.httpServer.close((error) => (error ? reject(error) : resolve()));
+  });
+}
 
 process.stdout.write("Verified root and Screen Studio alternative Pages artifacts.\n");

--- a/website/scripts/verify-built-site.mjs
+++ b/website/scripts/verify-built-site.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const comparisonUrl = "https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/";
+const distUrl = new URL("../dist/", import.meta.url);
+
+const [home, comparison, sitemap] = await Promise.all([
+  readFile(new URL("index.html", distUrl), "utf8"),
+  readFile(new URL("screen-studio-alternative-windows/index.html", distUrl), "utf8"),
+  readFile(new URL("sitemap.xml", distUrl), "utf8"),
+]);
+
+const count = (value, needle) => value.split(needle).length - 1;
+
+assert.equal(home.includes('href="https://jnx03.github.io/Flowtake/"'), true, "homepage canonical changed");
+assert.equal(home.includes("free recorder and developer demo studio"), true, "homepage metadata changed");
+
+assert.equal(comparison.includes("A Screen Studio"), true, "comparison H1 content missing");
+assert.equal(comparison.includes("Where Screen Studio is still stronger"), true, "honesty section missing");
+assert.equal(comparison.includes("Flowtake is not a feature-for-feature Screen Studio clone"), true, "comparison boundary missing");
+assert.equal(count(comparison, "<title>"), 1, "comparison title must be unique");
+assert.equal(count(comparison, 'name="description"'), 1, "comparison description must be unique");
+assert.equal(count(comparison, 'rel="canonical"'), 1, "comparison canonical must be unique");
+assert.equal(count(comparison, 'property="og:url"'), 1, "comparison og:url must be unique");
+assert.equal(comparison.includes(`href="${comparisonUrl}"`), true, "comparison canonical is wrong");
+assert.equal(comparison.includes(`content="${comparisonUrl}"`), true, "comparison og:url is wrong");
+assert.equal(comparison.includes("/Flowtake/assets/"), true, "Pages asset base is missing");
+
+const jsonLdBlocks = [...comparison.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/gu)];
+assert.equal(jsonLdBlocks.length, 1, "comparison must have one JSON-LD block");
+for (const block of jsonLdBlocks) JSON.parse(block[1]);
+
+assert.equal(count(sitemap, `<loc>${comparisonUrl}</loc>`), 1, "comparison sitemap entry must be unique");
+
+process.stdout.write("Verified root and Screen Studio alternative Pages artifacts.\n");

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -347,6 +347,9 @@ export function App() {
             <a className="button button-quiet" href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer">
               View the repository <ArrowRightIcon aria-hidden="true" />
             </a>
+            <a className="text-link comparison-context-link" href={`${import.meta.env.BASE_URL}screen-studio-alternative-windows/`}>
+              Compare Flowtake with Screen Studio on Windows
+            </a>
           </div>
         </section>
 
@@ -421,6 +424,7 @@ export function App() {
         <p>Open-source recorder. Optional release production.</p>
         <div>
           <a href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer">GitHub</a>
+          <a href={`${import.meta.env.BASE_URL}screen-studio-alternative-windows/`}>Windows comparison</a>
           <a href="#service-terms">Terms</a>
           <a href="#privacy">Privacy</a>
           <a href="#cancellation-policy">Cancellation</a>
@@ -438,7 +442,7 @@ export function App() {
   );
 }
 
-function BriefDialog({ onClose, restoreFocusTo }) {
+export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" }) {
   const [status, setStatus] = useState("idle");
   const [error, setError] = useState("");
   const [briefText, setBriefText] = useState("");
@@ -480,7 +484,7 @@ function BriefDialog({ onClose, restoreFocusTo }) {
     return () => {
       document.body.style.overflow = previousOverflow;
       window.removeEventListener("keydown", onKeyDown);
-      restoreFocusTo?.focus?.();
+      queueMicrotask(() => restoreFocusTo?.focus?.());
     };
   }, [onClose, restoreFocusTo]);
 
@@ -626,7 +630,7 @@ function BriefDialog({ onClose, restoreFocusTo }) {
             </p>
             <label className="consent-row">
               <input name="privacyAccepted" type="checkbox" required />
-              <span>I've read the <a href="#privacy" target="_blank" rel="noreferrer">privacy disclosure</a> and agree to Flowtake using this brief to assess and reply. I understand this is not a purchase.</span>
+              <span>I've read the <a href={privacyHref} target="_blank" rel="noreferrer">privacy disclosure</a> and agree to Flowtake using this brief to assess and reply. I understand this is not a purchase.</span>
             </label>
             <div className="form-honeypot" aria-hidden="true" inert={true}>
               <label>

--- a/website/src/screenStudioAlternative.main.jsx
+++ b/website/src/screenStudioAlternative.main.jsx
@@ -1,0 +1,92 @@
+import { StrictMode, useEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { BriefDialog } from "./App.jsx";
+import { sendEvent } from "./intake.js";
+
+const BASE_URL = import.meta.env.BASE_URL;
+
+function track(name) {
+  void sendEvent(name);
+}
+
+export function ComparisonEnhancements() {
+  const [briefOpen, setBriefOpen] = useState(false);
+  const briefTriggerRef = useRef(null);
+
+  useEffect(() => {
+    track("page_viewed");
+  }, []);
+
+  useEffect(() => {
+    const menuButton = document.querySelector("[data-menu-button]");
+    const menuLabel = document.querySelector("[data-menu-label]");
+    const mobileNav = document.querySelector("[data-mobile-nav]");
+
+    const setMenuOpen = (open) => {
+      if (!menuButton || !mobileNav) return;
+      menuButton.setAttribute("aria-expanded", String(open));
+      menuButton.setAttribute("aria-label", open ? "Close navigation" : "Open navigation");
+      mobileNav.hidden = !open;
+      if (menuLabel) menuLabel.textContent = open ? "Close" : "Menu";
+    };
+
+    const onMenuClick = () => setMenuOpen(menuButton?.getAttribute("aria-expanded") !== "true");
+    const onDocumentClick = (event) => {
+      const openBriefButton = event.target.closest("[data-open-brief]");
+      if (openBriefButton) {
+        event.preventDefault();
+        briefTriggerRef.current = openBriefButton;
+        track("brief_opened");
+        setMenuOpen(false);
+        setBriefOpen(true);
+        return;
+      }
+
+      const trackedLink = event.target.closest("[data-track]");
+      if (trackedLink) track(trackedLink.dataset.track);
+      if (event.target.closest("[data-mobile-nav] a")) setMenuOpen(false);
+    };
+    const onKeyDown = (event) => {
+      if (event.key === "Escape") setMenuOpen(false);
+    };
+
+    menuButton?.addEventListener("click", onMenuClick);
+    document.addEventListener("click", onDocumentClick);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      menuButton?.removeEventListener("click", onMenuClick);
+      document.removeEventListener("click", onDocumentClick);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, []);
+
+  useEffect(() => {
+    const regions = document.querySelectorAll("[data-modal-region]");
+    regions.forEach((region) => {
+      region.inert = briefOpen;
+      if (briefOpen) region.setAttribute("aria-hidden", "true");
+      else region.removeAttribute("aria-hidden");
+    });
+    return () => {
+      regions.forEach((region) => {
+        region.inert = false;
+        region.removeAttribute("aria-hidden");
+      });
+    };
+  }, [briefOpen]);
+
+  if (!briefOpen) return null;
+  return (
+    <BriefDialog
+      onClose={() => setBriefOpen(false)}
+      restoreFocusTo={briefTriggerRef.current}
+      privacyHref={`${BASE_URL}#privacy`}
+    />
+  );
+}
+
+createRoot(document.getElementById("comparison-enhancements")).render(
+  <StrictMode>
+    <ComparisonEnhancements />
+  </StrictMode>,
+);

--- a/website/src/siteRoutes.test.mjs
+++ b/website/src/siteRoutes.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const comparisonUrl = "https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/";
+
+async function source(relativePath) {
+  return readFile(new URL(relativePath, import.meta.url), "utf8");
+}
+
+function occurrences(value, needle) {
+  return value.split(needle).length - 1;
+}
+
+test("the Windows comparison is a physical Vite MPA route", async () => {
+  const [config, page] = await Promise.all([
+    source("../vite.config.mjs"),
+    source("../screen-studio-alternative-windows/index.html"),
+  ]);
+
+  assert.equal(config.includes('appType: "mpa"'), true);
+  assert.equal(config.includes('"screen-studio-alternative-windows/index.html"'), true);
+  assert.equal(page.includes('<h1>\n              A Screen Studio'), true);
+  assert.equal(page.includes("Flowtake is not a feature-for-feature Screen Studio clone."), true);
+  assert.equal(page.includes('<div id="root"></div>'), false);
+});
+
+test("comparison metadata is unique, self-canonical, and conservative", async () => {
+  const page = await source("../screen-studio-alternative-windows/index.html");
+
+  assert.equal(occurrences(page, "<title>"), 1);
+  assert.equal(occurrences(page, 'name="description"'), 1);
+  assert.equal(occurrences(page, 'rel="canonical"'), 1);
+  assert.equal(occurrences(page, 'property="og:url"'), 1);
+  assert.equal(page.includes(`<link rel="canonical" href="${comparisonUrl}" />`), true);
+  assert.equal(page.includes(`<meta property="og:url" content="${comparisonUrl}" />`), true);
+  assert.equal(page.includes("Screen Studio Alternative for Windows: Flowtake"), true);
+  assert.equal(page.includes('"@type": "Review"'), false);
+  assert.equal(page.includes("AggregateRating"), false);
+
+  const blocks = [...page.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/gu)];
+  assert.equal(blocks.length, 1);
+  assert.doesNotThrow(() => JSON.parse(blocks[0][1]));
+});
+
+test("comparison copy preserves the product and security boundaries", async () => {
+  const page = await source("../screen-studio-alternative-windows/index.html");
+
+  const normalizedPage = page.toLowerCase();
+  for (const required of [
+    "Windows 10/11",
+    "free, MIT-licensed",
+    "unsigned",
+    "SmartScreen",
+    "SHA256SUMS.txt",
+    "ordinary recordings, projects, and exports stay local",
+    "not affiliated with or endorsed by Screen Studio",
+    "observed July 16, 2026",
+    "macOS and Linux builds are previews",
+  ]) {
+    assert.equal(normalizedPage.includes(required.toLowerCase()), true, `missing comparison boundary: ${required}`);
+  }
+
+  for (const prohibited of ["best Screen Studio", "drop-in replacement", "completely offline", "feature parity"] ) {
+    assert.equal(page.toLowerCase().includes(prohibited.toLowerCase()), false, `unsafe claim: ${prohibited}`);
+  }
+});
+
+test("the comparison route is discoverable and uses root privacy for the shared form", async () => {
+  const [app, enhancements, sitemap] = await Promise.all([
+    source("./App.jsx"),
+    source("./screenStudioAlternative.main.jsx"),
+    source("../public/sitemap.xml"),
+  ]);
+
+  assert.equal(app.includes("screen-studio-alternative-windows/"), true);
+  assert.equal(app.includes('privacyHref = "#privacy"'), true);
+  assert.equal(enhancements.includes('privacyHref={`${BASE_URL}#privacy`}'), true);
+  assert.equal(occurrences(sitemap, `<loc>${comparisonUrl}</loc>`), 1);
+});

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -802,6 +802,14 @@ button.text-link {
   margin-top: 15px;
 }
 
+.open-source-actions .comparison-context-link {
+  margin-top: 18px;
+  display: block;
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
 .trust-section {
   padding: 118px 0;
   border-bottom: 1px solid var(--line);
@@ -931,6 +939,370 @@ button.text-link {
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 20px;
+}
+
+.mobile-nav[hidden] {
+  display: none;
+}
+
+.comparison-hero {
+  padding-top: 72px;
+  padding-bottom: 96px;
+  grid-template-columns: minmax(0, 0.95fr) minmax(500px, 1.05fr);
+}
+
+.comparison-hero h1 {
+  font-size: clamp(50px, 5.1vw, 76px);
+}
+
+.comparison-price-line {
+  margin-top: 28px;
+}
+
+.comparison-warning a,
+.source-note a,
+.network-boundary a {
+  color: var(--text);
+}
+
+.comparison-hero-panel {
+  position: relative;
+  padding: 20px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.26);
+}
+
+.comparison-panel-head {
+  padding: 4px 4px 18px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 13px;
+  border-bottom: 1px solid var(--line);
+}
+
+.comparison-panel-head img {
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+}
+
+.comparison-panel-head p,
+.fit-card p,
+.comparison-disclosure,
+.source-note,
+.network-boundary,
+.download-card p,
+.comparison-final-cta > div > p:last-child {
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.comparison-panel-head p {
+  margin: 0 0 2px;
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.comparison-panel-head strong {
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+  font-size: 24px;
+  font-weight: 470;
+}
+
+.comparison-panel-head > span {
+  color: var(--text-dim);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fit-card {
+  margin-top: 14px;
+  padding: 23px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 18px;
+  background: var(--ink-soft);
+  border: 1px solid var(--line);
+  border-radius: 15px;
+}
+
+.fit-card-primary {
+  background: rgba(100, 81, 206, 0.13);
+  border-color: rgba(155, 140, 255, 0.32);
+  box-shadow: inset 3px 0 0 var(--primary);
+}
+
+.fit-card > div p {
+  margin: 0 0 3px;
+  color: var(--text-dim);
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.fit-card > div strong {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.fit-card > p,
+.fit-card ul {
+  grid-column: 1 / -1;
+}
+
+.fit-card > p {
+  margin: 0;
+}
+
+.fit-card ul {
+  margin: 0;
+  padding: 0 0 0 18px;
+  color: #d3d0dc;
+  font-size: 11px;
+  line-height: 1.75;
+}
+
+.fit-label {
+  align-self: start;
+  padding: 5px 8px;
+  color: var(--accent);
+  background: rgba(77, 215, 207, 0.09);
+  border: 1px solid rgba(77, 215, 207, 0.22);
+  border-radius: 999px;
+  font-size: 8px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fit-label-muted {
+  color: var(--text-muted);
+  background: rgba(244, 241, 232, 0.04);
+  border-color: var(--line);
+}
+
+.comparison-disclosure {
+  margin: 16px 4px 2px;
+  font-size: 9px;
+}
+
+.comparison-section {
+  padding: 132px 0;
+}
+
+.comparison-section-bordered {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.comparison-table-wrap {
+  max-width: 100%;
+  margin-top: 58px;
+  overflow-x: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 18px;
+  background: var(--surface);
+}
+
+.comparison-table-wrap:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 3px;
+}
+
+.comparison-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.comparison-table caption {
+  padding: 16px 20px;
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--line);
+  font-size: 10px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 20px 22px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  vertical-align: top;
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.comparison-table th:last-child,
+.comparison-table td:last-child {
+  border-right: 0;
+}
+
+.comparison-table tbody tr:last-child th,
+.comparison-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.comparison-table thead th {
+  color: var(--text);
+  background: var(--ink-soft);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.comparison-table thead th:nth-child(2) {
+  color: var(--primary-bright);
+}
+
+.comparison-table tbody th {
+  width: 20%;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.comparison-table tbody td {
+  width: 40%;
+  color: var(--text-muted);
+}
+
+.source-note {
+  max-width: 920px;
+  margin: 20px 0 0;
+  font-size: 10px;
+}
+
+.comparison-card-grid {
+  margin-top: 58px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.comparison-card {
+  min-height: 250px;
+  padding: 30px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+}
+
+.comparison-card-label {
+  margin: 0 0 28px;
+  color: var(--accent) !important;
+  font-size: 9px !important;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.comparison-card h3,
+.download-card h3 {
+  margin: 0 0 14px;
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+  font-size: 27px;
+  font-weight: 460;
+  line-height: 1.08;
+}
+
+.comparison-card > p:last-child {
+  margin-bottom: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.75;
+}
+
+.network-boundary {
+  max-width: 780px;
+  margin: 24px 0 0;
+  padding-left: 14px;
+  border-left: 2px solid var(--accent);
+}
+
+.honesty-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+  align-items: center;
+  gap: clamp(48px, 7vw, 100px);
+}
+
+.honesty-copy > p:not(.kicker) {
+  max-width: 680px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.8;
+}
+
+.download-card {
+  padding: 32px;
+  background: var(--surface);
+  border: 1px solid rgba(155, 140, 255, 0.28);
+  border-radius: 18px;
+  box-shadow: inset 3px 0 0 var(--primary);
+}
+
+.download-card .button {
+  width: 100%;
+  margin-top: 12px;
+}
+
+.checksum-link {
+  margin-top: 18px;
+  display: inline-block;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.download-card .download-warning {
+  margin: 18px 0 0;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  color: #c8c5d3;
+  font-size: 10px;
+}
+
+.comparison-faq {
+  border-top: 1px solid var(--line);
+}
+
+.comparison-page .faq-list summary {
+  list-style: disclosure-closed;
+}
+
+.comparison-page .faq-list summary::-webkit-details-marker {
+  display: initial;
+}
+
+.comparison-page .faq-list details[open] summary {
+  list-style: disclosure-open;
+}
+
+.comparison-final-cta {
+  align-items: flex-end;
+}
+
+.comparison-final-cta > div > p:last-child {
+  margin: 16px 0 0;
+}
+
+.comparison-final-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 12px;
+}
+
+.comparison-footer p {
+  line-height: 1.55;
 }
 
 .dialog-backdrop {
@@ -1240,6 +1612,35 @@ button.text-link {
   .trust-grid {
     grid-template-columns: 1fr;
   }
+
+  .comparison-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .comparison-hero-panel {
+    max-width: 850px;
+  }
+
+  .comparison-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .comparison-card {
+    min-height: 0;
+  }
+
+  .honesty-section {
+    grid-template-columns: 1fr;
+  }
+
+  .download-card {
+    max-width: 640px;
+  }
+
+  .comparison-final-cta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 @media (max-width: 720px) {
@@ -1274,6 +1675,10 @@ button.text-link {
   .hero h1 {
     margin-top: 20px;
     font-size: clamp(48px, 14vw, 66px);
+  }
+
+  .comparison-hero h1 {
+    font-size: clamp(43px, 12.5vw, 58px);
   }
 
   .hero-lede {
@@ -1339,10 +1744,39 @@ button.text-link {
     justify-content: flex-start;
   }
 
+  .comparison-hero-panel {
+    padding: 12px;
+    border-radius: 17px;
+  }
+
+  .comparison-panel-head {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .comparison-panel-head img {
+    width: 38px;
+    height: 38px;
+  }
+
+  .comparison-panel-head > span {
+    display: none;
+  }
+
+  .fit-card {
+    padding: 20px 18px;
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .fit-label {
+    justify-self: start;
+  }
+
   .workflow-section,
   .founding-section,
   .trust-section,
-  .faq-section {
+  .faq-section,
+  .comparison-section {
     padding: 94px 0;
   }
 
@@ -1416,10 +1850,37 @@ button.text-link {
     margin-top: 42px;
   }
 
+  .comparison-table-wrap {
+    margin-top: 42px;
+  }
+
+  .comparison-table th,
+  .comparison-table td {
+    padding: 17px 18px;
+  }
+
+  .comparison-card-grid {
+    margin-top: 42px;
+  }
+
+  .comparison-card,
+  .download-card {
+    padding: 25px 22px;
+  }
+
   .final-cta {
     padding: 70px 0;
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .comparison-final-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .comparison-final-actions .button {
+    width: 100%;
   }
 
   .site-footer {

--- a/website/vite.config.mjs
+++ b/website/vite.config.mjs
@@ -1,12 +1,27 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const pagesBase = "/Flowtake/";
 
 export default defineConfig(({ mode }) => ({
+  appType: "mpa",
   // GitHub project Pages serves this repository below /Flowtake/. Keep the
   // default root base for local development and ordinary local previews.
   base: mode === "pages" ? pagesBase : "/",
+  build: {
+    rollupOptions: {
+      input: {
+        home: resolve(__dirname, "index.html"),
+        screenStudioAlternativeWindows: resolve(
+          __dirname,
+          "screen-studio-alternative-windows/index.html",
+        ),
+      },
+    },
+  },
   optimizeDeps: {
     include: ["react", "react-dom/client"],
   },
@@ -14,7 +29,7 @@ export default defineConfig(({ mode }) => ({
     host: "0.0.0.0",
     allowedHosts: ["terminal.local"],
     warmup: {
-      clientFiles: ["./src/main.jsx"],
+      clientFiles: ["./src/main.jsx", "./src/screenStudioAlternative.main.jsx"],
     },
   },
   plugins: [react()],


### PR DESCRIPTION
## Summary
- add a physical, crawler-visible `/screen-studio-alternative-windows/` Vite MPA route with unique metadata, conservative schema, sitemap discovery, and a homepage link
- compare Flowtake and Screen Studio using dated first-party facts, explicit non-affiliation language, and prominent unsigned Windows / SmartScreen guidance
- preserve the existing visual system and lead form while adding responsive navigation, focus restoration, and fail-closed Pages artifact checks

## Truth boundaries
- Windows 10/11 x64 remains Flowtake's primary tested target; macOS and Linux remain previews
- Flowtake is not presented as a feature-for-feature replacement or as completely offline
- Screen Studio pricing is date-stamped July 16, 2026 and linked to its official pricing page
- the primary CTA goes to the exact v1.6.0 GitHub release; Release Studio remains secondary

## Verification
- `npm test --prefix website` — 12/12 pass
- `npm run build --prefix website -- --mode pages` — pass
- `npm run verify:build --prefix website` — pass
- focused ESLint on all changed JavaScript/JSX — pass
- preview HTTP: root 200, comparison route 200 with static body, unknown route 404
- in-app Browser: no console errors; no horizontal overflow at 390, 768, 1280, or 1440; mobile menu and Escape pass; dialog focus, privacy link, Escape close, and trigger focus restoration pass
- independent diff review: no actionable findings