### PR TITLE
ci: prove Windows MSI lifecycle before WinGet submission

### DIFF
--- a/.github/workflows/windows-msi-lifecycle.yml
+++ b/.github/workflows/windows-msi-lifecycle.yml
@@ -51,18 +51,6 @@ jobs:
           $expectedVersion = "v$env:WINGET_BOOTSTRAP_VERSION"
 
           $command = Get-Command winget -ErrorAction SilentlyContinue
-          if (-not $command) {
-            try {
-              Add-AppxPackage -RegisterByFamilyName `
-                -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe `
-                -ErrorAction Stop
-            }
-            catch {
-              Write-Host "The provisioned App Installer family was not immediately registrable: $($_.Exception.Message)"
-            }
-            $command = Get-Command winget -ErrorAction SilentlyContinue
-          }
-
           $actualVersion = if ($command) { ((& $command.Source --version 2>&1) -join " ").Trim() } else { "" }
           if ($actualVersion -ne $expectedVersion) {
             $moduleArchive = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client.$env:WINGET_BOOTSTRAP_VERSION.zip"
@@ -143,18 +131,6 @@ jobs:
           $expectedVersion = "v$env:WINGET_BOOTSTRAP_VERSION"
 
           $command = Get-Command winget -ErrorAction SilentlyContinue
-          if (-not $command) {
-            try {
-              Add-AppxPackage -RegisterByFamilyName `
-                -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe `
-                -ErrorAction Stop
-            }
-            catch {
-              Write-Host "The provisioned App Installer family was not immediately registrable: $($_.Exception.Message)"
-            }
-            $command = Get-Command winget -ErrorAction SilentlyContinue
-          }
-
           $actualVersion = if ($command) { ((& $command.Source --version 2>&1) -join " ").Trim() } else { "" }
           if ($actualVersion -ne $expectedVersion) {
             $moduleArchive = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client.$env:WINGET_BOOTSTRAP_VERSION.zip"

--- a/.github/workflows/windows-msi-lifecycle.yml
+++ b/.github/workflows/windows-msi-lifecycle.yml
@@ -1,0 +1,216 @@
+name: Windows MSI Lifecycle Proof
+
+"on":
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "packaging/winget/**"
+      - "scripts/test-windows-msi-lifecycle.ps1"
+      - "test/windowsMsiLifecycle.test.js"
+      - ".github/workflows/windows-msi-lifecycle.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-msi-lifecycle-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  FLOWTAKE_MANIFEST_DIR: packaging/winget/JNX03.Flowtake/1.6.0
+  WINGET_BOOTSTRAP_VERSION: "1.29.280"
+  WINGET_MODULE_URL: https://www.powershellgallery.com/api/v2/package/Microsoft.WinGet.Client/1.29.280
+  WINGET_MODULE_SIZE: "20883488"
+  WINGET_MODULE_SHA512: DE5818DA64D4362904FFE35737A2D7DFC7179CB4D248E5816CE89AFE7E08C0A8AC63012F5489095F49724E1BEC0EAA2E53A90593AEF204979DE6CB27534A91A6
+
+jobs:
+  validate-manifest:
+    name: Validate WinGet manifest
+    runs-on: windows-2025
+    timeout-minutes: 15
+    steps:
+      - name: Require main for a lifecycle dispatch
+        if: github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -ne "refs/heads/main") {
+            throw "Lifecycle dispatches must use refs/heads/main."
+          }
+
+      - name: Checkout the reviewed source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Provision the pinned Microsoft WinGet client
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $expectedVersion = "v$env:WINGET_BOOTSTRAP_VERSION"
+
+          $command = Get-Command winget -ErrorAction SilentlyContinue
+          if (-not $command) {
+            try {
+              Add-AppxPackage -RegisterByFamilyName `
+                -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe `
+                -ErrorAction Stop
+            }
+            catch {
+              Write-Host "The provisioned App Installer family was not immediately registrable: $($_.Exception.Message)"
+            }
+            $command = Get-Command winget -ErrorAction SilentlyContinue
+          }
+
+          $actualVersion = if ($command) { ((& $command.Source --version 2>&1) -join " ").Trim() } else { "" }
+          if ($actualVersion -ne $expectedVersion) {
+            $moduleArchive = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client.$env:WINGET_BOOTSTRAP_VERSION.zip"
+            $moduleRoot = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client-$env:WINGET_BOOTSTRAP_VERSION"
+            if (Test-Path -LiteralPath $moduleRoot) {
+              throw "The isolated WinGet module directory already exists: $moduleRoot"
+            }
+            Invoke-WebRequest `
+              -UseBasicParsing `
+              -MaximumRetryCount 3 `
+              -RetryIntervalSec 2 `
+              -Uri $env:WINGET_MODULE_URL `
+              -OutFile $moduleArchive
+            if ((Get-Item -LiteralPath $moduleArchive).Length -ne [int64]$env:WINGET_MODULE_SIZE) {
+              throw "The Microsoft.WinGet.Client archive size did not match the reviewed package."
+            }
+            $moduleHash = (Get-FileHash -LiteralPath $moduleArchive -Algorithm SHA512).Hash.ToUpperInvariant()
+            if ($moduleHash -ne $env:WINGET_MODULE_SHA512) {
+              throw "The Microsoft.WinGet.Client archive SHA-512 did not match the reviewed package."
+            }
+            Expand-Archive -LiteralPath $moduleArchive -DestinationPath $moduleRoot
+            $moduleManifest = Join-Path $moduleRoot "Microsoft.WinGet.Client.psd1"
+            $module = Test-ModuleManifest -Path $moduleManifest
+            if (
+              $module.Name -ne "Microsoft.WinGet.Client" -or
+              $module.Version.ToString() -ne $env:WINGET_BOOTSTRAP_VERSION -or
+              $module.Author -ne "Microsoft Corporation"
+            ) {
+              throw "The hash-verified Microsoft.WinGet.Client module identity could not be verified."
+            }
+            Import-Module -Name $moduleManifest -Force
+            $repairExit = Repair-WinGetPackageManager `
+              -Version $env:WINGET_BOOTSTRAP_VERSION `
+              -AllUsers `
+              -Force
+            if ([int]$repairExit -ne 0) {
+              throw "Repair-WinGetPackageManager exited with code $repairExit."
+            }
+          }
+
+          $command = Get-Command winget -ErrorAction SilentlyContinue
+          if (-not $command) {
+            throw "The WinGet bootstrap did not expose winget.exe."
+          }
+          $actualVersion = ((& $command.Source --version 2>&1) -join " ").Trim()
+          if ($actualVersion -ne $expectedVersion) {
+            throw "Expected WinGet $expectedVersion, found $actualVersion."
+          }
+          & $command.Source --info
+          if ($LASTEXITCODE -ne 0) {
+            throw "winget --info failed."
+          }
+
+      - name: Validate immutable package metadata
+        shell: pwsh
+        run: |
+          ./scripts/test-windows-msi-lifecycle.ps1 `
+            -Mode ValidateManifest `
+            -ManifestDirectory $env:FLOWTAKE_MANIFEST_DIR
+
+  installer-lifecycle:
+    name: Install, scan, launch, and uninstall exact MSI
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs:
+      - validate-manifest
+    runs-on: windows-2025
+    timeout-minutes: 45
+    steps:
+      - name: Checkout exact main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Provision the pinned Microsoft WinGet client
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $expectedVersion = "v$env:WINGET_BOOTSTRAP_VERSION"
+
+          $command = Get-Command winget -ErrorAction SilentlyContinue
+          if (-not $command) {
+            try {
+              Add-AppxPackage -RegisterByFamilyName `
+                -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe `
+                -ErrorAction Stop
+            }
+            catch {
+              Write-Host "The provisioned App Installer family was not immediately registrable: $($_.Exception.Message)"
+            }
+            $command = Get-Command winget -ErrorAction SilentlyContinue
+          }
+
+          $actualVersion = if ($command) { ((& $command.Source --version 2>&1) -join " ").Trim() } else { "" }
+          if ($actualVersion -ne $expectedVersion) {
+            $moduleArchive = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client.$env:WINGET_BOOTSTRAP_VERSION.zip"
+            $moduleRoot = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client-$env:WINGET_BOOTSTRAP_VERSION"
+            if (Test-Path -LiteralPath $moduleRoot) {
+              throw "The isolated WinGet module directory already exists: $moduleRoot"
+            }
+            Invoke-WebRequest `
+              -UseBasicParsing `
+              -MaximumRetryCount 3 `
+              -RetryIntervalSec 2 `
+              -Uri $env:WINGET_MODULE_URL `
+              -OutFile $moduleArchive
+            if ((Get-Item -LiteralPath $moduleArchive).Length -ne [int64]$env:WINGET_MODULE_SIZE) {
+              throw "The Microsoft.WinGet.Client archive size did not match the reviewed package."
+            }
+            $moduleHash = (Get-FileHash -LiteralPath $moduleArchive -Algorithm SHA512).Hash.ToUpperInvariant()
+            if ($moduleHash -ne $env:WINGET_MODULE_SHA512) {
+              throw "The Microsoft.WinGet.Client archive SHA-512 did not match the reviewed package."
+            }
+            Expand-Archive -LiteralPath $moduleArchive -DestinationPath $moduleRoot
+            $moduleManifest = Join-Path $moduleRoot "Microsoft.WinGet.Client.psd1"
+            $module = Test-ModuleManifest -Path $moduleManifest
+            if (
+              $module.Name -ne "Microsoft.WinGet.Client" -or
+              $module.Version.ToString() -ne $env:WINGET_BOOTSTRAP_VERSION -or
+              $module.Author -ne "Microsoft Corporation"
+            ) {
+              throw "The hash-verified Microsoft.WinGet.Client module identity could not be verified."
+            }
+            Import-Module -Name $moduleManifest -Force
+            $repairExit = Repair-WinGetPackageManager `
+              -Version $env:WINGET_BOOTSTRAP_VERSION `
+              -AllUsers `
+              -Force
+            if ([int]$repairExit -ne 0) {
+              throw "Repair-WinGetPackageManager exited with code $repairExit."
+            }
+          }
+
+          $command = Get-Command winget -ErrorAction SilentlyContinue
+          if (-not $command) {
+            throw "The WinGet bootstrap did not expose winget.exe."
+          }
+          $actualVersion = ((& $command.Source --version 2>&1) -join " ").Trim()
+          if ($actualVersion -ne $expectedVersion) {
+            throw "Expected WinGet $expectedVersion, found $actualVersion."
+          }
+          & $command.Source --info
+          if ($LASTEXITCODE -ne 0) {
+            throw "winget --info failed."
+          }
+
+      - name: Prove the exact published MSI lifecycle
+        shell: pwsh
+        run: |
+          ./scripts/test-windows-msi-lifecycle.ps1 `
+            -Mode Lifecycle `
+            -ManifestDirectory $env:FLOWTAKE_MANIFEST_DIR

--- a/.github/workflows/windows-msi-lifecycle.yml
+++ b/.github/workflows/windows-msi-lifecycle.yml
@@ -49,9 +49,10 @@ jobs:
           persist-credentials: false
 
       - name: Provision the pinned Microsoft WinGet client
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
           $expectedVersion = "v$env:WINGET_BOOTSTRAP_VERSION"
 
           $command = Get-Command winget -ErrorAction SilentlyContinue
@@ -67,14 +68,10 @@ jobs:
             $dependenciesRoot = Join-Path $bootstrapRoot "dependencies"
             Invoke-WebRequest `
               -UseBasicParsing `
-              -MaximumRetryCount 3 `
-              -RetryIntervalSec 2 `
               -Uri $env:WINGET_BUNDLE_URL `
               -OutFile $bundlePath
             Invoke-WebRequest `
               -UseBasicParsing `
-              -MaximumRetryCount 3 `
-              -RetryIntervalSec 2 `
               -Uri $env:WINGET_DEPENDENCIES_URL `
               -OutFile $dependenciesArchive
             if ((Get-Item -LiteralPath $bundlePath).Length -ne [int64]$env:WINGET_BUNDLE_SIZE) {
@@ -157,9 +154,10 @@ jobs:
           persist-credentials: false
 
       - name: Provision the pinned Microsoft WinGet client
-        shell: pwsh
+        shell: powershell
         run: |
           $ErrorActionPreference = "Stop"
+          $ProgressPreference = "SilentlyContinue"
           $expectedVersion = "v$env:WINGET_BOOTSTRAP_VERSION"
 
           $command = Get-Command winget -ErrorAction SilentlyContinue
@@ -175,14 +173,10 @@ jobs:
             $dependenciesRoot = Join-Path $bootstrapRoot "dependencies"
             Invoke-WebRequest `
               -UseBasicParsing `
-              -MaximumRetryCount 3 `
-              -RetryIntervalSec 2 `
               -Uri $env:WINGET_BUNDLE_URL `
               -OutFile $bundlePath
             Invoke-WebRequest `
               -UseBasicParsing `
-              -MaximumRetryCount 3 `
-              -RetryIntervalSec 2 `
               -Uri $env:WINGET_DEPENDENCIES_URL `
               -OutFile $dependenciesArchive
             if ((Get-Item -LiteralPath $bundlePath).Length -ne [int64]$env:WINGET_BUNDLE_SIZE) {

--- a/.github/workflows/windows-msi-lifecycle.yml
+++ b/.github/workflows/windows-msi-lifecycle.yml
@@ -21,9 +21,13 @@ concurrency:
 env:
   FLOWTAKE_MANIFEST_DIR: packaging/winget/JNX03.Flowtake/1.6.0
   WINGET_BOOTSTRAP_VERSION: "1.29.280"
-  WINGET_MODULE_URL: https://www.powershellgallery.com/api/v2/package/Microsoft.WinGet.Client/1.29.280
-  WINGET_MODULE_SIZE: "20883488"
-  WINGET_MODULE_SHA512: DE5818DA64D4362904FFE35737A2D7DFC7179CB4D248E5816CE89AFE7E08C0A8AC63012F5489095F49724E1BEC0EAA2E53A90593AEF204979DE6CB27534A91A6
+  WINGET_PACKAGE_VERSION: "1.29.280.0"
+  WINGET_BUNDLE_URL: https://github.com/microsoft/winget-cli/releases/download/v1.29.280/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+  WINGET_BUNDLE_SIZE: "216775738"
+  WINGET_BUNDLE_SHA256: 0809FA9F52E395D6E7DE692331DCE847AC991952675116BB4D8AAE2DDCC20946
+  WINGET_DEPENDENCIES_URL: https://github.com/microsoft/winget-cli/releases/download/v1.29.280/DesktopAppInstaller_Dependencies.zip
+  WINGET_DEPENDENCIES_SIZE: "97760717"
+  WINGET_DEPENDENCIES_SHA256: 3BBFCAA5CB011C48FAC48D896D64A5C7C6898859A9F3D01555C8CD000F4E2962
 
 jobs:
   validate-manifest:
@@ -53,45 +57,73 @@ jobs:
           $command = Get-Command winget -ErrorAction SilentlyContinue
           $actualVersion = if ($command) { ((& $command.Source --version 2>&1) -join " ").Trim() } else { "" }
           if ($actualVersion -ne $expectedVersion) {
-            $moduleArchive = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client.$env:WINGET_BOOTSTRAP_VERSION.zip"
-            $moduleRoot = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client-$env:WINGET_BOOTSTRAP_VERSION"
-            if (Test-Path -LiteralPath $moduleRoot) {
-              throw "The isolated WinGet module directory already exists: $moduleRoot"
+            $bootstrapRoot = Join-Path $env:RUNNER_TEMP "winget-$env:WINGET_BOOTSTRAP_VERSION"
+            if (Test-Path -LiteralPath $bootstrapRoot) {
+              throw "The isolated WinGet bootstrap directory already exists: $bootstrapRoot"
             }
+            New-Item -ItemType Directory -Path $bootstrapRoot | Out-Null
+            $bundlePath = Join-Path $bootstrapRoot "Microsoft.DesktopAppInstaller.msixbundle"
+            $dependenciesArchive = Join-Path $bootstrapRoot "DesktopAppInstaller_Dependencies.zip"
+            $dependenciesRoot = Join-Path $bootstrapRoot "dependencies"
             Invoke-WebRequest `
               -UseBasicParsing `
               -MaximumRetryCount 3 `
               -RetryIntervalSec 2 `
-              -Uri $env:WINGET_MODULE_URL `
-              -OutFile $moduleArchive
-            if ((Get-Item -LiteralPath $moduleArchive).Length -ne [int64]$env:WINGET_MODULE_SIZE) {
-              throw "The Microsoft.WinGet.Client archive size did not match the reviewed package."
+              -Uri $env:WINGET_BUNDLE_URL `
+              -OutFile $bundlePath
+            Invoke-WebRequest `
+              -UseBasicParsing `
+              -MaximumRetryCount 3 `
+              -RetryIntervalSec 2 `
+              -Uri $env:WINGET_DEPENDENCIES_URL `
+              -OutFile $dependenciesArchive
+            if ((Get-Item -LiteralPath $bundlePath).Length -ne [int64]$env:WINGET_BUNDLE_SIZE) {
+              throw "The WinGet MSIX bundle size did not match the reviewed release asset."
             }
-            $moduleHash = (Get-FileHash -LiteralPath $moduleArchive -Algorithm SHA512).Hash.ToUpperInvariant()
-            if ($moduleHash -ne $env:WINGET_MODULE_SHA512) {
-              throw "The Microsoft.WinGet.Client archive SHA-512 did not match the reviewed package."
+            if ((Get-Item -LiteralPath $dependenciesArchive).Length -ne [int64]$env:WINGET_DEPENDENCIES_SIZE) {
+              throw "The WinGet dependencies archive size did not match the reviewed release asset."
             }
-            Expand-Archive -LiteralPath $moduleArchive -DestinationPath $moduleRoot
-            $moduleManifest = Join-Path $moduleRoot "Microsoft.WinGet.Client.psd1"
-            $module = Test-ModuleManifest -Path $moduleManifest
-            if (
-              $module.Name -ne "Microsoft.WinGet.Client" -or
-              $module.Version.ToString() -ne $env:WINGET_BOOTSTRAP_VERSION -or
-              $module.Author -ne "Microsoft Corporation"
-            ) {
-              throw "The hash-verified Microsoft.WinGet.Client module identity could not be verified."
+            $bundleHash = (Get-FileHash -LiteralPath $bundlePath -Algorithm SHA256).Hash.ToUpperInvariant()
+            $dependenciesHash = (Get-FileHash -LiteralPath $dependenciesArchive -Algorithm SHA256).Hash.ToUpperInvariant()
+            if ($bundleHash -ne $env:WINGET_BUNDLE_SHA256) {
+              throw "The WinGet MSIX bundle SHA-256 did not match the reviewed release asset."
             }
-            Import-Module -Name $moduleManifest -Force
-            $repairExit = Repair-WinGetPackageManager `
-              -Version $env:WINGET_BOOTSTRAP_VERSION `
-              -AllUsers `
-              -Force
-            if ([int]$repairExit -ne 0) {
-              throw "Repair-WinGetPackageManager exited with code $repairExit."
+            if ($dependenciesHash -ne $env:WINGET_DEPENDENCIES_SHA256) {
+              throw "The WinGet dependencies archive SHA-256 did not match the reviewed release asset."
+            }
+            Expand-Archive -LiteralPath $dependenciesArchive -DestinationPath $dependenciesRoot
+            $dependencyPaths = @(Get-ChildItem -LiteralPath (Join-Path $dependenciesRoot "x64") -Filter "*.appx" -File | Select-Object -ExpandProperty FullName)
+            $expectedDependencyNames = @(
+              "Microsoft.VCLibs.140.00_14.0.33519.0_x64.appx",
+              "Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx",
+              "Microsoft.WindowsAppRuntime.1.8_8000.616.304.0_x64.appx"
+            )
+            $actualDependencyNames = @($dependencyPaths | ForEach-Object { [System.IO.Path]::GetFileName($_) })
+            $missingDependencies = @($expectedDependencyNames | Where-Object { $actualDependencyNames -notcontains $_ })
+            if ($actualDependencyNames.Count -ne 3 -or $missingDependencies.Count -ne 0) {
+              throw "The WinGet x64 dependency set did not match the reviewed release asset."
+            }
+            Add-AppxPackage `
+              -Path $bundlePath `
+              -DependencyPath $dependencyPaths `
+              -ForceApplicationShutdown `
+              -ErrorAction Stop
+            $appInstaller = @(Get-AppxPackage -Name Microsoft.DesktopAppInstaller | Where-Object {
+              $_.Version.ToString() -eq $env:WINGET_PACKAGE_VERSION -and
+              $_.Architecture.ToString() -eq "X64" -and
+              $_.PackageFamilyName -eq "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe" -and
+              $_.PublisherId -eq "8wekyb3d8bbwe"
+            })
+            if ($appInstaller.Count -ne 1) {
+              throw "The exact x64 Microsoft Desktop App Installer bundle was not registered."
             }
           }
 
-          $command = Get-Command winget -ErrorAction SilentlyContinue
+          for ($attempt = 0; $attempt -lt 10; $attempt++) {
+            $command = Get-Command winget -ErrorAction SilentlyContinue
+            if ($command) { break }
+            Start-Sleep -Seconds 1
+          }
           if (-not $command) {
             throw "The WinGet bootstrap did not expose winget.exe."
           }
@@ -133,45 +165,73 @@ jobs:
           $command = Get-Command winget -ErrorAction SilentlyContinue
           $actualVersion = if ($command) { ((& $command.Source --version 2>&1) -join " ").Trim() } else { "" }
           if ($actualVersion -ne $expectedVersion) {
-            $moduleArchive = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client.$env:WINGET_BOOTSTRAP_VERSION.zip"
-            $moduleRoot = Join-Path $env:RUNNER_TEMP "Microsoft.WinGet.Client-$env:WINGET_BOOTSTRAP_VERSION"
-            if (Test-Path -LiteralPath $moduleRoot) {
-              throw "The isolated WinGet module directory already exists: $moduleRoot"
+            $bootstrapRoot = Join-Path $env:RUNNER_TEMP "winget-$env:WINGET_BOOTSTRAP_VERSION"
+            if (Test-Path -LiteralPath $bootstrapRoot) {
+              throw "The isolated WinGet bootstrap directory already exists: $bootstrapRoot"
             }
+            New-Item -ItemType Directory -Path $bootstrapRoot | Out-Null
+            $bundlePath = Join-Path $bootstrapRoot "Microsoft.DesktopAppInstaller.msixbundle"
+            $dependenciesArchive = Join-Path $bootstrapRoot "DesktopAppInstaller_Dependencies.zip"
+            $dependenciesRoot = Join-Path $bootstrapRoot "dependencies"
             Invoke-WebRequest `
               -UseBasicParsing `
               -MaximumRetryCount 3 `
               -RetryIntervalSec 2 `
-              -Uri $env:WINGET_MODULE_URL `
-              -OutFile $moduleArchive
-            if ((Get-Item -LiteralPath $moduleArchive).Length -ne [int64]$env:WINGET_MODULE_SIZE) {
-              throw "The Microsoft.WinGet.Client archive size did not match the reviewed package."
+              -Uri $env:WINGET_BUNDLE_URL `
+              -OutFile $bundlePath
+            Invoke-WebRequest `
+              -UseBasicParsing `
+              -MaximumRetryCount 3 `
+              -RetryIntervalSec 2 `
+              -Uri $env:WINGET_DEPENDENCIES_URL `
+              -OutFile $dependenciesArchive
+            if ((Get-Item -LiteralPath $bundlePath).Length -ne [int64]$env:WINGET_BUNDLE_SIZE) {
+              throw "The WinGet MSIX bundle size did not match the reviewed release asset."
             }
-            $moduleHash = (Get-FileHash -LiteralPath $moduleArchive -Algorithm SHA512).Hash.ToUpperInvariant()
-            if ($moduleHash -ne $env:WINGET_MODULE_SHA512) {
-              throw "The Microsoft.WinGet.Client archive SHA-512 did not match the reviewed package."
+            if ((Get-Item -LiteralPath $dependenciesArchive).Length -ne [int64]$env:WINGET_DEPENDENCIES_SIZE) {
+              throw "The WinGet dependencies archive size did not match the reviewed release asset."
             }
-            Expand-Archive -LiteralPath $moduleArchive -DestinationPath $moduleRoot
-            $moduleManifest = Join-Path $moduleRoot "Microsoft.WinGet.Client.psd1"
-            $module = Test-ModuleManifest -Path $moduleManifest
-            if (
-              $module.Name -ne "Microsoft.WinGet.Client" -or
-              $module.Version.ToString() -ne $env:WINGET_BOOTSTRAP_VERSION -or
-              $module.Author -ne "Microsoft Corporation"
-            ) {
-              throw "The hash-verified Microsoft.WinGet.Client module identity could not be verified."
+            $bundleHash = (Get-FileHash -LiteralPath $bundlePath -Algorithm SHA256).Hash.ToUpperInvariant()
+            $dependenciesHash = (Get-FileHash -LiteralPath $dependenciesArchive -Algorithm SHA256).Hash.ToUpperInvariant()
+            if ($bundleHash -ne $env:WINGET_BUNDLE_SHA256) {
+              throw "The WinGet MSIX bundle SHA-256 did not match the reviewed release asset."
             }
-            Import-Module -Name $moduleManifest -Force
-            $repairExit = Repair-WinGetPackageManager `
-              -Version $env:WINGET_BOOTSTRAP_VERSION `
-              -AllUsers `
-              -Force
-            if ([int]$repairExit -ne 0) {
-              throw "Repair-WinGetPackageManager exited with code $repairExit."
+            if ($dependenciesHash -ne $env:WINGET_DEPENDENCIES_SHA256) {
+              throw "The WinGet dependencies archive SHA-256 did not match the reviewed release asset."
+            }
+            Expand-Archive -LiteralPath $dependenciesArchive -DestinationPath $dependenciesRoot
+            $dependencyPaths = @(Get-ChildItem -LiteralPath (Join-Path $dependenciesRoot "x64") -Filter "*.appx" -File | Select-Object -ExpandProperty FullName)
+            $expectedDependencyNames = @(
+              "Microsoft.VCLibs.140.00_14.0.33519.0_x64.appx",
+              "Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx",
+              "Microsoft.WindowsAppRuntime.1.8_8000.616.304.0_x64.appx"
+            )
+            $actualDependencyNames = @($dependencyPaths | ForEach-Object { [System.IO.Path]::GetFileName($_) })
+            $missingDependencies = @($expectedDependencyNames | Where-Object { $actualDependencyNames -notcontains $_ })
+            if ($actualDependencyNames.Count -ne 3 -or $missingDependencies.Count -ne 0) {
+              throw "The WinGet x64 dependency set did not match the reviewed release asset."
+            }
+            Add-AppxPackage `
+              -Path $bundlePath `
+              -DependencyPath $dependencyPaths `
+              -ForceApplicationShutdown `
+              -ErrorAction Stop
+            $appInstaller = @(Get-AppxPackage -Name Microsoft.DesktopAppInstaller | Where-Object {
+              $_.Version.ToString() -eq $env:WINGET_PACKAGE_VERSION -and
+              $_.Architecture.ToString() -eq "X64" -and
+              $_.PackageFamilyName -eq "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe" -and
+              $_.PublisherId -eq "8wekyb3d8bbwe"
+            })
+            if ($appInstaller.Count -ne 1) {
+              throw "The exact x64 Microsoft Desktop App Installer bundle was not registered."
             }
           }
 
-          $command = Get-Command winget -ErrorAction SilentlyContinue
+          for ($attempt = 0; $attempt -lt 10; $attempt++) {
+            $command = Get-Command winget -ErrorAction SilentlyContinue
+            if ($command) { break }
+            Start-Sleep -Seconds 1
+          }
           if (-not $command) {
             throw "The WinGet bootstrap did not expose winget.exe."
           }

--- a/packaging/winget/JNX03.Flowtake/1.6.0/JNX03.Flowtake.installer.yaml
+++ b/packaging/winget/JNX03.Flowtake/1.6.0/JNX03.Flowtake.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: JNX03.Flowtake
+PackageVersion: 1.6.0
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+UpgradeBehavior: install
+ProductCode: '{CEB7F435-02D2-41EF-8B21-28D9E7D3E5CB}'
+ReleaseDate: 2026-07-16
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/JNX03/Flowtake/releases/download/v1.6.0/Flowtake_1.6.0_x64_en-US.msi
+  InstallerSha256: 497FE1454687EE1224FC839C2290A44471041DB7490E72F55EE14464ADD61B8D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/packaging/winget/JNX03.Flowtake/1.6.0/JNX03.Flowtake.locale.en-US.yaml
+++ b/packaging/winget/JNX03.Flowtake/1.6.0/JNX03.Flowtake.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: JNX03.Flowtake
+PackageVersion: 1.6.0
+PackageLocale: en-US
+Publisher: Jnx03
+PublisherUrl: https://github.com/JNX03
+PublisherSupportUrl: https://github.com/JNX03/Flowtake/issues
+PackageName: Flowtake
+PackageUrl: https://github.com/JNX03/Flowtake
+License: MIT
+LicenseUrl: https://github.com/JNX03/Flowtake/blob/v1.6.0/LICENSE
+PrivacyUrl: https://github.com/JNX03/Flowtake/blob/v1.6.0/README.md#privacy-and-open-source-boundary
+Copyright: Copyright (c) 2025-present Jnx03
+ShortDescription: Local-first screen recorder and timeline editor for polished developer demos.
+Description: >-
+  Record, arrange, and export developer demos locally with editable screen sources,
+  timeline controls, automatic zoom, and local MP4 export.
+Moniker: flowtake
+Tags:
+- developer-tools
+- devrel
+- screen-recorder
+- screencast
+- video-editor
+ReleaseNotesUrl: https://github.com/JNX03/Flowtake/releases/tag/v1.6.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/packaging/winget/JNX03.Flowtake/1.6.0/JNX03.Flowtake.yaml
+++ b/packaging/winget/JNX03.Flowtake/1.6.0/JNX03.Flowtake.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: JNX03.Flowtake
+PackageVersion: 1.6.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/test-windows-msi-lifecycle.ps1
+++ b/scripts/test-windows-msi-lifecycle.ps1
@@ -1,0 +1,674 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("ValidateManifest", "Lifecycle")]
+    [string]$Mode,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ManifestDirectory,
+
+    [string]$EvidenceDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+if ($null -ne (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue)) {
+    $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$PackageIdentifier = "JNX03.Flowtake"
+$ExpectedVersion = "1.6.0"
+$ExpectedTag = "v1.6.0"
+$ExpectedPublisher = "Jnx03"
+$ExpectedProductName = "Flowtake"
+$ExpectedProductCode = "{CEB7F435-02D2-41EF-8B21-28D9E7D3E5CB}"
+$ExpectedUpgradeCode = "{CE51BD38-DC3B-53D2-881E-5413CF117167}"
+$ExpectedMsiName = "Flowtake_1.6.0_x64_en-US.msi"
+$ExpectedMsiUrl = "https://github.com/JNX03/Flowtake/releases/download/v1.6.0/Flowtake_1.6.0_x64_en-US.msi"
+$ExpectedMsiSha256 = "497FE1454687EE1224FC839C2290A44471041DB7490E72F55EE14464ADD61B8D"
+$ExpectedMsiSize = 92131328L
+$ExpectedChecksumsSha256 = "34DFA1267068590F277E5A172E5538159FF809A94D364812CAF3DA6CFBCB3B16"
+$ExpectedExecutable = "C:\Program Files\Flowtake\flowtake.exe"
+$ExpectedInstallDirectory = "C:\Program Files\Flowtake"
+$ExpectedFileVersion = "1.6.0.0"
+$ExpectedVendorKey = "HKCU:\Software\Jnx03\Flowtake"
+$ExpectedUninstallKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$ExpectedProductCode"
+$UnexpectedWowUninstallKey = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$ExpectedProductCode"
+
+if (-not (Test-Path -LiteralPath $ManifestDirectory -PathType Container)) {
+    throw "Manifest directory does not exist: $ManifestDirectory"
+}
+$ManifestDirectory = (Resolve-Path -LiteralPath $ManifestDirectory).Path
+
+if ([string]::IsNullOrWhiteSpace($EvidenceDirectory)) {
+    $evidenceRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
+    $EvidenceDirectory = Join-Path $evidenceRoot "flowtake-msi-evidence"
+}
+New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null
+$EvidenceDirectory = (Resolve-Path -LiteralPath $EvidenceDirectory).Path
+$EvidenceLog = Join-Path $EvidenceDirectory "evidence.txt"
+
+function Write-Evidence {
+    param([Parameter(Mandatory = $true)][string]$Message)
+
+    $line = "[{0}] {1}" -f ([DateTime]::UtcNow.ToString("o")), $Message
+    Write-Host $line
+    Add-Content -LiteralPath $EvidenceLog -Value $line -Encoding utf8
+}
+
+function Assert-Condition {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Get-UniqueYamlScalar {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Key
+    )
+
+    $pattern = "(?m)^\s*(?:-\s*)?{0}:\s*(?<value>[^\r\n]+?)\s*$" -f [regex]::Escape($Key)
+    $matches = [regex]::Matches($Source, $pattern)
+    Assert-Condition ($matches.Count -eq 1) "Expected exactly one $Key value; found $($matches.Count)."
+    return $matches[0].Groups["value"].Value.Trim().Trim("'", '"')
+}
+
+function Invoke-NativeChecked {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [int[]]$AllowedExitCodes = @(0)
+    )
+
+    $rendered = $Arguments | ForEach-Object {
+        if ($_ -match "\s") { '"{0}"' -f $_ } else { $_ }
+    }
+    Write-Evidence ("Running: {0} {1}" -f $FilePath, ($rendered -join " "))
+    $output = @(& $FilePath @Arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+    $output | ForEach-Object { $_.ToString() } | Set-Content -LiteralPath $LogPath -Encoding utf8
+    $output | ForEach-Object { Write-Host $_ }
+
+    if ($AllowedExitCodes -notcontains $exitCode) {
+        throw "$FilePath exited with code $exitCode."
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output = ($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+    }
+}
+
+function Release-ComObject {
+    param([AllowNull()]$ComObject)
+
+    if ($null -ne $ComObject -and [System.Runtime.InteropServices.Marshal]::IsComObject($ComObject)) {
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($ComObject)
+    }
+}
+
+function Get-MsiProperty {
+    param(
+        [Parameter(Mandatory = $true)]$Database,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    Assert-Condition ($Name -match "^[A-Za-z0-9_]+$") "Unsafe MSI property name: $Name"
+    $query = "SELECT ``Value`` FROM ``Property`` WHERE ``Property``='$Name'"
+    $view = $null
+    $record = $null
+    try {
+        $view = $Database.GetType().InvokeMember("OpenView", "InvokeMethod", $null, $Database, @($query))
+        $view.GetType().InvokeMember("Execute", "InvokeMethod", $null, $view, $null) | Out-Null
+        $record = $view.GetType().InvokeMember("Fetch", "InvokeMethod", $null, $view, $null)
+        Assert-Condition ($null -ne $record) "MSI property is missing: $Name"
+        return $record.GetType().InvokeMember("StringData", "GetProperty", $null, $record, @(1))
+    }
+    finally {
+        Release-ComObject -ComObject $record
+        if ($null -ne $view) {
+            try {
+                $view.GetType().InvokeMember("Close", "InvokeMethod", $null, $view, $null) | Out-Null
+            }
+            finally {
+                Release-ComObject -ComObject $view
+            }
+        }
+    }
+}
+
+function Get-FlowtakeProcesses {
+    $expectedPath = [System.IO.Path]::GetFullPath($ExpectedExecutable)
+    $processes = @(Get-Process -Name "flowtake" -ErrorAction SilentlyContinue)
+    foreach ($process in $processes) {
+        try {
+            $actualPath = [System.IO.Path]::GetFullPath($process.Path)
+        }
+        catch {
+            throw "Could not inspect flowtake process $($process.Id): $($_.Exception.Message)"
+        }
+        Assert-Condition ($actualPath -ieq $expectedPath) "Unexpected flowtake process path for PID $($process.Id): $actualPath"
+    }
+    return $processes
+}
+
+function Get-WinGetAdminSetting {
+    param(
+        [Parameter(Mandatory = $true)][string]$WinGetPath,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$LogPath
+    )
+
+    $result = Invoke-NativeChecked `
+        -FilePath $WinGetPath `
+        -Arguments @("settings", "export", "--disable-interactivity") `
+        -LogPath $LogPath
+    try {
+        $settings = $result.Output | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw "Could not parse WinGet settings export: $($_.Exception.Message)"
+    }
+    Assert-Condition ($null -ne $settings.adminSettings) "WinGet settings export omitted adminSettings."
+    $property = $settings.adminSettings.PSObject.Properties[$Name]
+    Assert-Condition ($null -ne $property) "WinGet settings export omitted admin setting: $Name"
+    return [bool]$property.Value
+}
+
+function Assert-CleanInstallState {
+    param([switch]$AfterUninstall)
+
+    $phase = if ($AfterUninstall) { "after uninstall" } else { "before install" }
+    Assert-Condition (-not (Test-Path -LiteralPath $ExpectedUninstallKey)) "64-bit ARP product key exists $phase."
+    Assert-Condition (-not (Test-Path -LiteralPath $UnexpectedWowUninstallKey)) "WOW6432Node ARP product key exists $phase."
+    Assert-Condition (-not (Test-Path -LiteralPath $ExpectedExecutable)) "Installed executable exists $phase."
+    Assert-Condition (-not (Test-Path -LiteralPath $ExpectedInstallDirectory)) "Install directory exists $phase."
+    Assert-Condition (@(Get-FlowtakeProcesses).Count -eq 0) "A Flowtake process remains $phase."
+
+    $shortcuts = @(
+        (Join-Path $env:USERPROFILE "Desktop\Flowtake.lnk"),
+        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Flowtake\Flowtake.lnk")
+    )
+    Assert-Condition (-not (Test-Path -LiteralPath $ExpectedVendorKey)) "Installer-owned HKCU vendor key exists $phase."
+    foreach ($shortcut in $shortcuts) {
+        Assert-Condition (-not (Test-Path -LiteralPath $shortcut)) "Installer-owned shortcut exists $phase`: $shortcut"
+    }
+
+    if ($AfterUninstall) {
+        Write-Evidence "Installer-owned ARP, HKCU, shortcut, file, directory, and process state is absent after uninstall."
+    }
+}
+
+function Get-CoveringDefenderExclusions {
+    param([Parameter(Mandatory = $true)][string]$TargetPath)
+
+    $target = [System.IO.Path]::GetFullPath($TargetPath).TrimEnd('\')
+    $preference = Get-MpPreference
+    $exclusions = @($preference.ExclusionPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    return @($exclusions | Where-Object {
+        $exclusion = $_
+        $expanded = [Environment]::ExpandEnvironmentVariables($exclusion)
+        try {
+            $normalized = [System.IO.Path]::GetFullPath($expanded).TrimEnd('\')
+            $target -ieq $normalized -or $target.StartsWith("$normalized\", [StringComparison]::OrdinalIgnoreCase)
+        }
+        catch {
+            throw "Could not normalize Defender exclusion '$exclusion': $($_.Exception.Message)"
+        }
+    })
+}
+
+function Get-MpCmdRunPath {
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    $platformRoot = Join-Path $env:ProgramData "Microsoft\Windows Defender\Platform"
+    if (Test-Path -LiteralPath $platformRoot -PathType Container) {
+        foreach ($directory in @(Get-ChildItem -LiteralPath $platformRoot -Directory | Sort-Object Name -Descending)) {
+            $candidates.Add((Join-Path $directory.FullName "MpCmdRun.exe"))
+        }
+    }
+    $candidates.Add((Join-Path $env:ProgramFiles "Windows Defender\MpCmdRun.exe"))
+    $mpCmdRunPath = @($candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1)
+    Assert-Condition ($mpCmdRunPath.Count -eq 1) "MpCmdRun.exe is unavailable."
+    return $mpCmdRunPath[0]
+}
+
+function Assert-DefenderTargetNotExcluded {
+    param([Parameter(Mandatory = $true)][string]$TargetPath)
+
+    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender exclusion-check target is missing: $TargetPath"
+    $mpCmdRunPath = Get-MpCmdRunPath
+    $safeLabel = [System.IO.Path]::GetFileName($TargetPath)
+    if ([string]::IsNullOrWhiteSpace($safeLabel)) {
+        $safeLabel = "target"
+    }
+    $result = Invoke-NativeChecked `
+        -FilePath $mpCmdRunPath `
+        -Arguments @("-CheckExclusion", "-Path", $TargetPath) `
+        -LogPath (Join-Path $EvidenceDirectory "defender-exclusion-$safeLabel.log") `
+        -AllowedExitCodes @(1)
+    Assert-Condition ($result.Output -match "(?i)\bis not excluded\b") "MpCmdRun returned indeterminate exclusion output for: $TargetPath"
+    Write-Evidence "Defender confirmed the target is not excluded from scanning: $TargetPath"
+}
+
+function Enable-DefenderForTarget {
+    param([Parameter(Mandatory = $true)][string]$TargetPath)
+
+    foreach ($requiredCommand in @("Get-MpComputerStatus", "Get-MpPreference", "Set-MpPreference", "Remove-MpPreference", "Update-MpSignature", "Start-MpScan", "Get-MpThreatDetection")) {
+        Assert-Condition ($null -ne (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) "Required Defender command is unavailable: $requiredCommand"
+    }
+
+    $coveringExclusions = Get-CoveringDefenderExclusions -TargetPath $TargetPath
+    foreach ($exclusion in $coveringExclusions) {
+        Write-Evidence "Removing Defender exclusion that covers the scan target: $exclusion"
+        Remove-MpPreference -ExclusionPath $exclusion
+    }
+
+    Set-MpPreference `
+        -DisableRealtimeMonitoring $false `
+        -DisableBehaviorMonitoring $false `
+        -DisableScriptScanning $false `
+        -DisableIOAVProtection $false `
+        -DisableArchiveScanning $false `
+        -PUAProtection Enabled
+    Update-MpSignature | Out-Null
+
+    $remainingExclusions = Get-CoveringDefenderExclusions -TargetPath $TargetPath
+    Assert-Condition ($remainingExclusions.Count -eq 0) "A Defender exclusion still covers the scan target: $($remainingExclusions -join ', ')"
+
+    $preference = Get-MpPreference
+    Assert-Condition (-not [bool]$preference.DisableRealtimeMonitoring) "Defender real-time monitoring remained disabled."
+    Assert-Condition (-not [bool]$preference.DisableBehaviorMonitoring) "Defender behavior monitoring remained disabled."
+    Assert-Condition (-not [bool]$preference.DisableScriptScanning) "Defender script scanning remained disabled."
+    Assert-Condition (-not [bool]$preference.DisableIOAVProtection) "Defender IOAV protection remained disabled."
+    Assert-Condition (-not [bool]$preference.DisableArchiveScanning) "Defender archive scanning remained disabled."
+    Assert-Condition ([int]$preference.PUAProtection -eq 1) "Defender PUA protection is not enabled."
+
+    $status = Get-MpComputerStatus
+    Assert-Condition ([bool]$status.AMServiceEnabled) "Defender antimalware service is not enabled."
+    Assert-Condition ([bool]$status.AntivirusEnabled) "Defender antivirus is not enabled."
+    Assert-Condition ([bool]$status.RealTimeProtectionEnabled) "Defender real-time protection is not enabled."
+    Assert-Condition ($status.AMRunningMode -eq "Normal") "Defender is not running in Normal mode: $($status.AMRunningMode)"
+    Assert-Condition ($null -ne $status.AntivirusSignatureLastUpdated) "Defender signature timestamp is unavailable."
+    Assert-Condition ([int]$status.AntivirusSignatureAge -le 1) "Defender signatures are stale: age $($status.AntivirusSignatureAge) day(s)."
+    Assert-DefenderTargetNotExcluded -TargetPath $TargetPath
+    Write-Evidence "Defender enabled; signature version $($status.AntivirusSignatureVersion), updated $($status.AntivirusSignatureLastUpdated.ToUniversalTime().ToString('o'))."
+}
+
+function Invoke-DefenderScan {
+    param(
+        [Parameter(Mandatory = $true)][string]$TargetPath,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan target is missing: $TargetPath"
+    $before = @{}
+    foreach ($item in @(Get-MpThreatDetection -ErrorAction Stop)) {
+        $before["$($item.ThreatID)|$($item.InitialDetectionTime)|$($item.Resources -join ';')"] = $true
+    }
+
+    $scanStartedAt = [DateTime]::UtcNow
+    Write-Evidence "Starting Defender custom scan: $Label"
+    Start-MpScan -ScanType CustomScan -ScanPath $TargetPath
+    $newDetections = @(Get-MpThreatDetection -ErrorAction Stop | Where-Object {
+        $key = "$($_.ThreatID)|$($_.InitialDetectionTime)|$($_.Resources -join ';')"
+        -not $before.ContainsKey($key)
+    })
+    Assert-Condition ($newDetections.Count -eq 0) "Defender reported a new detection while scanning $Label."
+    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan removed or quarantined $Label."
+    Write-Evidence "Defender custom scan completed with no new detection: $Label (started $($scanStartedAt.ToString('o')))."
+}
+
+function Write-FailureLogTails {
+    foreach ($log in @(Get-ChildItem -LiteralPath $EvidenceDirectory -Filter "*.log" -File -ErrorAction SilentlyContinue)) {
+        Write-Host "--- bounded tail: $($log.Name) ---"
+        Get-Content -LiteralPath $log.FullName -Tail 80 -ErrorAction SilentlyContinue | Write-Host
+    }
+}
+
+$manifestNames = @(
+    "$PackageIdentifier.yaml",
+    "$PackageIdentifier.locale.en-US.yaml",
+    "$PackageIdentifier.installer.yaml"
+)
+$actualManifestNames = @(Get-ChildItem -LiteralPath $ManifestDirectory -Filter "*.yaml" -File | Select-Object -ExpandProperty Name | Sort-Object)
+Assert-Condition (($actualManifestNames -join "|") -eq (($manifestNames | Sort-Object) -join "|")) "The manifest directory must contain exactly the three expected YAML files."
+
+$versionManifestPath = Join-Path $ManifestDirectory "$PackageIdentifier.yaml"
+$localeManifestPath = Join-Path $ManifestDirectory "$PackageIdentifier.locale.en-US.yaml"
+$installerManifestPath = Join-Path $ManifestDirectory "$PackageIdentifier.installer.yaml"
+$versionManifest = Get-Content -Raw -LiteralPath $versionManifestPath
+$localeManifest = Get-Content -Raw -LiteralPath $localeManifestPath
+$installerManifest = Get-Content -Raw -LiteralPath $installerManifestPath
+
+foreach ($source in @($versionManifest, $localeManifest, $installerManifest)) {
+    Assert-Condition ((Get-UniqueYamlScalar -Source $source -Key "PackageIdentifier") -eq $PackageIdentifier) "Manifest PackageIdentifier drifted."
+    Assert-Condition ((Get-UniqueYamlScalar -Source $source -Key "PackageVersion") -eq $ExpectedVersion) "Manifest PackageVersion drifted."
+    Assert-Condition ((Get-UniqueYamlScalar -Source $source -Key "ManifestVersion") -eq "1.12.0") "Manifest schema version drifted."
+}
+Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "InstallerType") -eq "wix") "InstallerType must remain wix."
+Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "Scope") -eq "machine") "Installer scope must remain machine."
+Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "ProductCode") -eq $ExpectedProductCode) "Manifest ProductCode drifted."
+Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "Architecture") -eq "x64") "Manifest architecture must remain x64."
+Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "InstallerUrl") -eq $ExpectedMsiUrl) "Manifest installer URL drifted."
+Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "InstallerSha256").ToUpperInvariant() -eq $ExpectedMsiSha256) "Manifest installer SHA-256 drifted."
+Assert-Condition ((Get-UniqueYamlScalar -Source $localeManifest -Key "Publisher") -eq $ExpectedPublisher) "Manifest publisher drifted."
+Assert-Condition ((Get-UniqueYamlScalar -Source $localeManifest -Key "PackageName") -eq $ExpectedProductName) "Manifest package name drifted."
+Assert-Condition ((Get-UniqueYamlScalar -Source $localeManifest -Key "License") -eq "MIT") "Manifest license drifted."
+
+$wingetCommand = Get-Command "winget" -ErrorAction SilentlyContinue
+Assert-Condition ($null -ne $wingetCommand) "winget is unavailable."
+$wingetPath = $wingetCommand.Source
+$wingetVersion = @(& $wingetPath --version 2>&1) -join " "
+Assert-Condition ($LASTEXITCODE -eq 0) "winget --version failed."
+Write-Evidence "Runner image: $($env:ImageOS) $($env:ImageVersion); OS: $([Environment]::OSVersion.VersionString); WinGet: $wingetVersion."
+
+$validateLog = Join-Path $EvidenceDirectory "winget-validate.log"
+Invoke-NativeChecked -FilePath $wingetPath -Arguments @("validate", "--manifest", $ManifestDirectory) -LogPath $validateLog | Out-Null
+Write-Evidence "Tracked WinGet manifest passed static validation."
+
+if ($Mode -eq "ValidateManifest") {
+    Write-Evidence "PASS: static manifest validation only; no installer was downloaded or executed."
+    exit 0
+}
+
+Assert-Condition ($env:GITHUB_REF -eq "refs/heads/main") "Lifecycle mode is restricted to refs/heads/main."
+Assert-Condition ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") "Lifecycle mode is restricted to workflow_dispatch."
+
+$smokeRoot = "C:\FlowtakeSmoke-$([guid]::NewGuid().ToString('N'))"
+$msiPath = Join-Path $smokeRoot $ExpectedMsiName
+$checksumsPath = Join-Path $smokeRoot "SHA256SUMS.txt"
+$wingetInstallLog = Join-Path $EvidenceDirectory "winget-install.log"
+$wingetUninstallLog = Join-Path $EvidenceDirectory "winget-uninstall.log"
+$fallbackUninstallLog = Join-Path $EvidenceDirectory "msi-fallback-uninstall.log"
+$trackedProcess = $null
+$primaryFailure = $null
+$cleanupFailure = $null
+$installObserved = $false
+
+try {
+    Assert-CleanInstallState
+    New-Item -ItemType Directory -Path $smokeRoot | Out-Null
+
+    $releaseHeaders = @{
+        Accept = "application/vnd.github+json"
+        "User-Agent" = "Flowtake-WinGet-Lifecycle-Proof"
+        "X-GitHub-Api-Version" = "2022-11-28"
+    }
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/JNX03/Flowtake/releases/tags/$ExpectedTag" -Headers $releaseHeaders
+    Assert-Condition ($release.tag_name -eq $ExpectedTag) "GitHub release tag drifted."
+    Assert-Condition (-not [bool]$release.draft) "GitHub release is a draft."
+    Assert-Condition (-not [bool]$release.prerelease) "GitHub release is a prerelease."
+
+    $msiAssets = @($release.assets | Where-Object { $_.name -eq $ExpectedMsiName })
+    $checksumAssets = @($release.assets | Where-Object { $_.name -eq "SHA256SUMS.txt" })
+    Assert-Condition ($msiAssets.Count -eq 1) "Expected exactly one MSI release asset."
+    Assert-Condition ($checksumAssets.Count -eq 1) "Expected exactly one checksum release asset."
+    $msiAsset = $msiAssets[0]
+    $checksumAsset = $checksumAssets[0]
+    Assert-Condition ($msiAsset.browser_download_url -eq $ExpectedMsiUrl) "GitHub MSI asset URL drifted."
+    Assert-Condition ([int64]$msiAsset.size -eq $ExpectedMsiSize) "GitHub MSI asset size drifted."
+    Assert-Condition ($msiAsset.digest -eq "sha256:$($ExpectedMsiSha256.ToLowerInvariant())") "GitHub MSI asset digest drifted."
+    Assert-Condition ($checksumAsset.digest -eq "sha256:$($ExpectedChecksumsSha256.ToLowerInvariant())") "GitHub checksum asset digest drifted."
+
+    Invoke-WebRequest -UseBasicParsing -MaximumRetryCount 3 -RetryIntervalSec 2 -Uri $checksumAsset.browser_download_url -OutFile $checksumsPath
+    Invoke-WebRequest -UseBasicParsing -MaximumRetryCount 3 -RetryIntervalSec 2 -Uri $msiAsset.browser_download_url -OutFile $msiPath
+
+    Assert-Condition ((Get-Item -LiteralPath $msiPath).Length -eq $ExpectedMsiSize) "Downloaded MSI size mismatch."
+    $actualMsiSha256 = (Get-FileHash -LiteralPath $msiPath -Algorithm SHA256).Hash.ToUpperInvariant()
+    Assert-Condition ($actualMsiSha256 -eq $ExpectedMsiSha256) "Downloaded MSI SHA-256 mismatch."
+    $actualChecksumsSha256 = (Get-FileHash -LiteralPath $checksumsPath -Algorithm SHA256).Hash.ToUpperInvariant()
+    Assert-Condition ($actualChecksumsSha256 -eq $ExpectedChecksumsSha256) "Downloaded checksum manifest SHA-256 mismatch."
+    $checksumSource = Get-Content -Raw -LiteralPath $checksumsPath
+    $escapedMsiName = [regex]::Escape($ExpectedMsiName)
+    $checksumMatches = [regex]::Matches($checksumSource, "(?im)^(?<hash>[a-f0-9]{64})\s+\*?$escapedMsiName\s*$")
+    Assert-Condition ($checksumMatches.Count -eq 1) "SHA256SUMS.txt must contain exactly one row for the MSI."
+    Assert-Condition ($checksumMatches[0].Groups["hash"].Value.ToUpperInvariant() -eq $ExpectedMsiSha256) "SHA256SUMS.txt MSI digest mismatch."
+    Write-Evidence "Exact published MSI verified before execution: $ExpectedMsiSha256, $ExpectedMsiSize bytes."
+
+    $windowsInstaller = $null
+    $database = $null
+    try {
+        $windowsInstaller = New-Object -ComObject WindowsInstaller.Installer
+        $database = $windowsInstaller.OpenDatabase($msiPath, 0)
+        $expectedProperties = @{
+            ProductName = $ExpectedProductName
+            ProductVersion = $ExpectedVersion
+            Manufacturer = $ExpectedPublisher
+            ProductCode = $ExpectedProductCode
+            UpgradeCode = $ExpectedUpgradeCode
+            ALLUSERS = "1"
+        }
+        foreach ($property in $expectedProperties.GetEnumerator()) {
+            $actual = Get-MsiProperty -Database $database -Name $property.Key
+            Assert-Condition ($actual -eq $property.Value) "MSI property $($property.Key) mismatch: $actual"
+        }
+    }
+    finally {
+        try {
+            Release-ComObject -ComObject $database
+        }
+        finally {
+            Release-ComObject -ComObject $windowsInstaller
+        }
+    }
+    $signatureStatus = (Get-AuthenticodeSignature -LiteralPath $msiPath).Status.ToString()
+    Assert-Condition ($signatureStatus -eq "NotSigned") "v1.6.0 MSI signing status drifted: $signatureStatus"
+    Write-Evidence "MSI metadata matches product, version, publisher, product/upgrade codes, machine scope, and disclosed unsigned status."
+
+    Enable-DefenderForTarget -TargetPath $msiPath
+    Invoke-DefenderScan -TargetPath $msiPath -Label "published Flowtake MSI"
+    Assert-Condition ((Get-FileHash -LiteralPath $msiPath -Algorithm SHA256).Hash.ToUpperInvariant() -eq $ExpectedMsiSha256) "MSI changed after Defender scan."
+
+    $localManifestSetting = Get-WinGetAdminSetting `
+        -WinGetPath $wingetPath `
+        -Name "LocalManifestFiles" `
+        -LogPath (Join-Path $EvidenceDirectory "winget-settings-before-enable.log")
+    Assert-Condition (-not $localManifestSetting) "LocalManifestFiles was already enabled before the lifecycle proof."
+    Invoke-NativeChecked -FilePath $wingetPath -Arguments @("settings", "--enable", "LocalManifestFiles") -LogPath (Join-Path $EvidenceDirectory "winget-enable-local-manifests.log") | Out-Null
+    $localManifestSetting = Get-WinGetAdminSetting `
+        -WinGetPath $wingetPath `
+        -Name "LocalManifestFiles" `
+        -LogPath (Join-Path $EvidenceDirectory "winget-settings-after-enable.log")
+    Assert-Condition $localManifestSetting "LocalManifestFiles did not become enabled."
+    Invoke-NativeChecked -FilePath $wingetPath -Arguments @(
+        "install", "--manifest", $ManifestDirectory,
+        "--silent", "--scope", "machine", "--disable-interactivity",
+        "--accept-package-agreements", "--accept-source-agreements",
+        "--verbose-logs", "--log", $wingetInstallLog
+    ) -LogPath (Join-Path $EvidenceDirectory "winget-install-command.log") | Out-Null
+    $installObserved = $true
+
+    Assert-Condition (Test-Path -LiteralPath $ExpectedUninstallKey) "Expected 64-bit ARP product key is missing after install."
+    Assert-Condition (-not (Test-Path -LiteralPath $UnexpectedWowUninstallKey)) "Product was registered unexpectedly under WOW6432Node."
+    $arp = Get-ItemProperty -LiteralPath $ExpectedUninstallKey
+    Assert-Condition ($arp.DisplayName -eq $ExpectedProductName) "ARP DisplayName mismatch."
+    Assert-Condition ($arp.DisplayVersion -eq $ExpectedVersion) "ARP DisplayVersion mismatch."
+    Assert-Condition ($arp.Publisher -eq $ExpectedPublisher) "ARP Publisher mismatch."
+    Assert-Condition ([int]$arp.WindowsInstaller -eq 1) "ARP WindowsInstaller marker mismatch."
+    Assert-Condition ($arp.UninstallString -match [regex]::Escape($ExpectedProductCode)) "ARP uninstall command does not contain the expected product code."
+
+    Assert-Condition (Test-Path -LiteralPath $ExpectedVendorKey) "Installer-owned HKCU vendor key is missing."
+    $recordedInstallDir = (Get-ItemProperty -LiteralPath $ExpectedVendorKey -Name "InstallDir").InstallDir
+    Assert-Condition ([System.IO.Path]::GetFullPath($recordedInstallDir).TrimEnd('\') -ieq $ExpectedInstallDirectory) "Installer HKCU InstallDir mismatch."
+    Assert-Condition (Test-Path -LiteralPath $ExpectedExecutable -PathType Leaf) "Installed Flowtake executable is missing."
+    $fileVersion = (Get-Item -LiteralPath $ExpectedExecutable).VersionInfo.FileVersion
+    Assert-Condition ($fileVersion -eq $ExpectedFileVersion) "Installed executable version mismatch: $fileVersion"
+
+    $requiredShortcuts = @(
+        (Join-Path $env:USERPROFILE "Desktop\Flowtake.lnk"),
+        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Flowtake\Flowtake.lnk"),
+        (Join-Path $ExpectedInstallDirectory "Uninstall Flowtake.lnk")
+    )
+    foreach ($shortcut in $requiredShortcuts) {
+        Assert-Condition (Test-Path -LiteralPath $shortcut -PathType Leaf) "Expected installer shortcut is missing: $shortcut"
+    }
+
+    $listResult = Invoke-NativeChecked -FilePath $wingetPath -Arguments @(
+        "list", "--name", $ExpectedProductName, "--exact", "--scope", "machine",
+        "--accept-source-agreements", "--disable-interactivity"
+    ) -LogPath (Join-Path $EvidenceDirectory "winget-list-installed.log")
+    Assert-Condition ($listResult.Output -match "Flowtake") "WinGet list did not correlate the installed package name."
+    Assert-Condition ($listResult.Output -match [regex]::Escape($ExpectedVersion)) "WinGet list did not correlate the installed version."
+    Write-Evidence "Installation correlated across WinGet inventory, 64-bit ARP, MSI ProductCode, HKCU installer key, shortcuts, and executable metadata."
+
+    Enable-DefenderForTarget -TargetPath $ExpectedInstallDirectory
+    Assert-DefenderTargetNotExcluded -TargetPath $ExpectedExecutable
+    Invoke-DefenderScan -TargetPath $ExpectedInstallDirectory -Label "installed Flowtake directory"
+    Assert-Condition (Test-Path -LiteralPath $ExpectedExecutable -PathType Leaf) "Installed executable disappeared after Defender scan."
+
+    $trackedProcess = Start-Process -FilePath $ExpectedExecutable -PassThru
+    Start-Sleep -Seconds 2
+    $trackedProcess.Refresh()
+    Assert-Condition (-not $trackedProcess.HasExited) "Flowtake exited during bounded startup."
+    Assert-Condition ([System.IO.Path]::GetFullPath($trackedProcess.Path) -ieq $ExpectedExecutable) "Started process path mismatch."
+    Start-Sleep -Seconds 10
+    $trackedProcess.Refresh()
+    Assert-Condition (-not $trackedProcess.HasExited) "Flowtake did not remain alive for the bounded startup interval."
+    $launchedPid = $trackedProcess.Id
+    Invoke-NativeChecked -FilePath "taskkill.exe" -Arguments @("/PID", "$launchedPid", "/T", "/F") -LogPath (Join-Path $EvidenceDirectory "taskkill.log") | Out-Null
+    Start-Sleep -Seconds 2
+    Assert-Condition (@(Get-FlowtakeProcesses).Count -eq 0) "Flowtake process remained after bounded startup cleanup."
+    $trackedProcess = $null
+    Write-Evidence "Exact installed executable remained alive for 10 seconds and its tracked PID tree was terminated."
+
+    Invoke-NativeChecked -FilePath $wingetPath -Arguments @(
+        "uninstall", "--manifest", $ManifestDirectory,
+        "--silent", "--disable-interactivity", "--accept-source-agreements",
+        "--verbose-logs", "--log", $wingetUninstallLog
+    ) -LogPath (Join-Path $EvidenceDirectory "winget-uninstall-command.log") | Out-Null
+    $installObserved = $false
+    Start-Sleep -Seconds 3
+    Assert-CleanInstallState -AfterUninstall
+    Write-Evidence "WinGet manifest uninstall removed the MSI product, installer-owned registry state, shortcuts, files, and process."
+}
+catch {
+    $primaryFailure = $_
+}
+finally {
+    $cleanupErrors = [System.Collections.Generic.List[string]]::new()
+
+    try {
+        if ($null -ne $trackedProcess) {
+            $trackedProcess.Refresh()
+            if (-not $trackedProcess.HasExited) {
+                Invoke-NativeChecked `
+                    -FilePath "taskkill.exe" `
+                    -Arguments @("/PID", "$($trackedProcess.Id)", "/T", "/F") `
+                    -LogPath (Join-Path $EvidenceDirectory "taskkill-finally.log") | Out-Null
+            }
+        }
+    }
+    catch {
+        $cleanupErrors.Add("tracked process termination: $($_.Exception.Message)")
+    }
+
+    try {
+        if (
+            $installObserved -or
+            (Test-Path -LiteralPath $ExpectedUninstallKey) -or
+            (Test-Path -LiteralPath $UnexpectedWowUninstallKey) -or
+            (Test-Path -LiteralPath $ExpectedExecutable) -or
+            (Test-Path -LiteralPath $ExpectedInstallDirectory) -or
+            (Test-Path -LiteralPath $ExpectedVendorKey)
+        ) {
+            Invoke-NativeChecked -FilePath "msiexec.exe" -Arguments @(
+                "/x", $ExpectedProductCode, "/qn", "/norestart", "/L*V", $fallbackUninstallLog
+            ) -LogPath (Join-Path $EvidenceDirectory "msi-fallback-uninstall-command.log") -AllowedExitCodes @(0, 1605, 3010) | Out-Null
+        }
+    }
+    catch {
+        $cleanupErrors.Add("fallback MSI uninstall: $($_.Exception.Message)")
+    }
+
+    foreach ($runtimePath in @(
+        (Join-Path $env:APPDATA "com.flowtake.desktop"),
+        (Join-Path $env:LOCALAPPDATA "com.flowtake.desktop")
+    )) {
+        try {
+            if (Test-Path -LiteralPath $runtimePath) {
+                Remove-Item -LiteralPath $runtimePath -Recurse -Force
+            }
+        }
+        catch {
+            $cleanupErrors.Add("runtime path removal ($runtimePath): $($_.Exception.Message)")
+        }
+    }
+
+    try {
+        if (Test-Path -LiteralPath $smokeRoot) {
+            Remove-Item -LiteralPath $smokeRoot -Recurse -Force
+        }
+    }
+    catch {
+        $cleanupErrors.Add("smoke directory removal: $($_.Exception.Message)")
+    }
+
+    try {
+        Invoke-NativeChecked `
+            -FilePath $wingetPath `
+            -Arguments @("settings", "--disable", "LocalManifestFiles") `
+            -LogPath (Join-Path $EvidenceDirectory "winget-disable-local-manifests.log") | Out-Null
+        $localManifestSetting = Get-WinGetAdminSetting `
+            -WinGetPath $wingetPath `
+            -Name "LocalManifestFiles" `
+            -LogPath (Join-Path $EvidenceDirectory "winget-settings-after-disable.log")
+        Assert-Condition (-not $localManifestSetting) "LocalManifestFiles remained enabled after cleanup."
+    }
+    catch {
+        $cleanupErrors.Add("LocalManifestFiles restoration: $($_.Exception.Message)")
+    }
+
+    try {
+        Assert-CleanInstallState -AfterUninstall
+    }
+    catch {
+        $cleanupErrors.Add("final install-state assertion: $($_.Exception.Message)")
+    }
+
+    if ($cleanupErrors.Count -gt 0) {
+        try {
+            throw "Cleanup failed: $($cleanupErrors -join ' | ')"
+        }
+        catch {
+            $cleanupFailure = $_
+        }
+    }
+}
+
+if ($null -ne $primaryFailure) {
+    Write-Error "Lifecycle proof failed: $($primaryFailure.Exception.Message)" -ErrorAction Continue
+    if ($null -ne $cleanupFailure) {
+        Write-Error "Cleanup also failed: $($cleanupFailure.Exception.Message)" -ErrorAction Continue
+    }
+    Write-FailureLogTails
+    throw $primaryFailure
+}
+
+if ($null -ne $cleanupFailure) {
+    Write-FailureLogTails
+    throw $cleanupFailure
+}
+
+Write-Evidence "PASS: exact-manifest validation, published-asset integrity, active Defender custom scans, silent install, correlation, bounded startup, WinGet uninstall, and cleanup all passed."
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    @(
+        "## Flowtake Windows MSI lifecycle proof",
+        "",
+        "- Result: PASS",
+        "- Package: ``$PackageIdentifier $ExpectedVersion``",
+        "- MSI SHA-256: ``$ExpectedMsiSha256``",
+        "- ProductCode: ``$ExpectedProductCode``",
+        "- Runner: ``$($env:ImageOS) $($env:ImageVersion)``",
+        "- WinGet: ``$wingetVersion``",
+        "- Evidence: manifest validation, release digest/checksum, MSI metadata, active Defender custom scans, install/registry correlation, 10-second startup, uninstall, and cleanup"
+    ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+}

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+import yaml from "js-yaml"
+
+const workflowSource = await readFile(
+    new URL("../.github/workflows/windows-msi-lifecycle.yml", import.meta.url),
+    "utf8"
+)
+const lifecycleScript = await readFile(
+    new URL("../scripts/test-windows-msi-lifecycle.ps1", import.meta.url),
+    "utf8"
+)
+const manifestRoot = new URL("../packaging/winget/JNX03.Flowtake/1.6.0/", import.meta.url)
+const versionManifestSource = await readFile(new URL("JNX03.Flowtake.yaml", manifestRoot), "utf8")
+const localeManifestSource = await readFile(new URL("JNX03.Flowtake.locale.en-US.yaml", manifestRoot), "utf8")
+const installerManifestSource = await readFile(new URL("JNX03.Flowtake.installer.yaml", manifestRoot), "utf8")
+const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
+
+const workflow = yaml.load(workflowSource)
+const versionManifest = yaml.load(versionManifestSource)
+const localeManifest = yaml.load(localeManifestSource)
+const installerManifest = yaml.load(installerManifestSource)
+
+const expected = {
+    identifier: "JNX03.Flowtake",
+    version: "1.6.0",
+    productCode: "{CEB7F435-02D2-41EF-8B21-28D9E7D3E5CB}",
+    upgradeCode: "{CE51BD38-DC3B-53D2-881E-5413CF117167}",
+    msiName: "Flowtake_1.6.0_x64_en-US.msi",
+    msiUrl: "https://github.com/JNX03/Flowtake/releases/download/v1.6.0/Flowtake_1.6.0_x64_en-US.msi",
+    msiSha256: "497FE1454687EE1224FC839C2290A44471041DB7490E72F55EE14464ADD61B8D",
+}
+
+test("tracked WinGet manifests describe the exact reviewed release", () => {
+    assert.equal(packageJson.version, expected.version)
+
+    for (const manifest of [versionManifest, localeManifest, installerManifest]) {
+        assert.equal(manifest.PackageIdentifier, expected.identifier)
+        assert.equal(manifest.PackageVersion, expected.version)
+        assert.equal(manifest.ManifestVersion, "1.12.0")
+    }
+
+    assert.equal(versionManifest.DefaultLocale, "en-US")
+    assert.equal(versionManifest.ManifestType, "version")
+    assert.equal(localeManifest.Publisher, "Jnx03")
+    assert.equal(localeManifest.PackageName, "Flowtake")
+    assert.equal(localeManifest.License, "MIT")
+    assert.equal(
+        localeManifest.PrivacyUrl,
+        "https://github.com/JNX03/Flowtake/blob/v1.6.0/README.md#privacy-and-open-source-boundary"
+    )
+    assert.equal(localeManifest.ManifestType, "defaultLocale")
+
+    assert.equal(installerManifest.InstallerType, "wix")
+    assert.equal(installerManifest.Scope, "machine")
+    assert.equal(installerManifest.ProductCode, expected.productCode)
+    assert.equal(installerManifest.ManifestType, "installer")
+    assert.equal(installerManifest.Installers.length, 1)
+    assert.deepEqual(installerManifest.Installers[0], {
+        Architecture: "x64",
+        InstallerUrl: expected.msiUrl,
+        InstallerSha256: expected.msiSha256,
+    })
+})
+
+test("MSI execution is restricted to a manual main-branch dispatch", () => {
+    assert.deepEqual(Object.keys(workflow.on).sort(), ["pull_request", "workflow_dispatch"])
+    assert.equal(workflow.on.pull_request.branches[0], "main")
+    assert.equal(workflow.on.pull_request.paths.includes("packaging/winget/**"), true)
+    assert.equal(workflow.push, undefined)
+    assert.equal(workflow.schedule, undefined)
+    assert.doesNotMatch(workflowSource, /pull_request_target|\bschedule\s*:|\bpush\s*:/)
+    assert.deepEqual(workflow.permissions, { contents: "read" })
+
+    const validationJob = workflow.jobs["validate-manifest"]
+    const lifecycleJob = workflow.jobs["installer-lifecycle"]
+    assert.equal(validationJob["runs-on"], "windows-2025")
+    assert.equal(lifecycleJob["runs-on"], "windows-2025")
+    assert.equal(
+        lifecycleJob.if,
+        "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'"
+    )
+    assert.match(
+        validationJob.steps.find(step => step.name === "Require main for a lifecycle dispatch").run,
+        /GITHUB_REF -ne "refs\/heads\/main"/
+    )
+    assert.match(
+        validationJob.steps.find(step => step.name === "Validate immutable package metadata").run,
+        /-Mode ValidateManifest/
+    )
+    assert.match(
+        lifecycleJob.steps.find(step => step.name === "Prove the exact published MSI lifecycle").run,
+        /-Mode Lifecycle/
+    )
+})
+
+test("installer proof uses immutable actions and a pinned official WinGet bootstrap", () => {
+    const actionRefs = [...workflowSource.matchAll(/uses:\s+([^@\s]+)@([^\s#]+)/g)]
+    assert.deepEqual(
+        actionRefs.map(([, action, ref]) => ({ action, ref })),
+        [
+            { action: "actions/checkout", ref: "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" },
+            { action: "actions/checkout", ref: "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" },
+        ]
+    )
+    assert.equal(workflowSource.match(/persist-credentials: false/g)?.length, 2)
+    assert.equal(workflow.env.WINGET_BOOTSTRAP_VERSION, "1.29.280")
+    assert.equal(
+        workflow.env.WINGET_MODULE_URL,
+        "https://www.powershellgallery.com/api/v2/package/Microsoft.WinGet.Client/1.29.280"
+    )
+    assert.equal(workflow.env.WINGET_MODULE_SIZE, "20883488")
+    assert.equal(
+        workflow.env.WINGET_MODULE_SHA512,
+        "DE5818DA64D4362904FFE35737A2D7DFC7179CB4D248E5816CE89AFE7E08C0A8AC63012F5489095F49724E1BEC0EAA2E53A90593AEF204979DE6CB27534A91A6"
+    )
+    assert.equal(workflowSource.match(/Microsoft\.WinGet\.Client/g)?.length >= 6, true)
+    assert.equal(workflowSource.match(/Get-FileHash[^\n]+-Algorithm SHA512/g)?.length, 2)
+    assert.equal(workflowSource.match(/Test-ModuleManifest -Path \$moduleManifest/g)?.length, 2)
+    assert.match(workflowSource, /Repair-WinGetPackageManager/g)
+    assert.match(workflowSource, /\$module\.Author -ne "Microsoft Corporation"/m)
+    assert.doesNotMatch(
+        workflowSource,
+        /continue-on-error|contents:\s*write|secrets\.|pull_request_target|Install-Module|Install-PackageProvider|Set-PSRepository/
+    )
+})
+
+test("lifecycle script fails closed around integrity, Defender, install, and cleanup", () => {
+    for (const immutableValue of [
+        expected.identifier,
+        expected.version,
+        expected.productCode,
+        expected.upgradeCode,
+        expected.msiUrl,
+        expected.msiSha256,
+        "92131328",
+        "34DFA1267068590F277E5A172E5538159FF809A94D364812CAF3DA6CFBCB3B16",
+    ]) {
+        assert.ok(lifecycleScript.includes(immutableValue), `missing immutable lifecycle value: ${immutableValue}`)
+    }
+
+    const checksumIndex = lifecycleScript.indexOf("Downloaded MSI SHA-256 mismatch")
+    const firstInstallerExecution = lifecycleScript.indexOf('"install", "--manifest"')
+    const msiDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $msiPath')
+    const installedDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $ExpectedInstallDirectory')
+    const launchIndex = lifecycleScript.indexOf("Start-Process -FilePath $ExpectedExecutable")
+    const uninstallIndex = lifecycleScript.indexOf('"uninstall", "--manifest"')
+    const finallyIndex = lifecycleScript.indexOf("finally {")
+    const fallbackUninstallIndex = lifecycleScript.indexOf('"msiexec.exe"', finallyIndex)
+
+    assert.ok(checksumIndex >= 0 && checksumIndex < msiDefenderIndex)
+    assert.ok(msiDefenderIndex < firstInstallerExecution)
+    assert.ok(firstInstallerExecution < installedDefenderIndex)
+    assert.ok(installedDefenderIndex < launchIndex)
+    assert.ok(launchIndex < uninstallIndex)
+    assert.ok(finallyIndex >= 0 && fallbackUninstallIndex > finallyIndex)
+
+    for (const requiredBoundary of [
+        'GITHUB_REF -eq "refs/heads/main"',
+        'GITHUB_EVENT_NAME -eq "workflow_dispatch"',
+        "Get-MpComputerStatus",
+        "Remove-MpPreference -ExclusionPath",
+        "-DisableRealtimeMonitoring $false",
+        "Update-MpSignature",
+        "AntivirusEnabled",
+        "RealTimeProtectionEnabled",
+        "AMRunningMode",
+        "Start-MpScan -ScanType CustomScan",
+        "Get-MpThreatDetection",
+        "Get-MpThreatDetection -ErrorAction Stop",
+        '"-CheckExclusion", "-Path", $TargetPath',
+        "-AllowedExitCodes @(1)",
+        "is not excluded",
+        "Enable-DefenderForTarget -TargetPath $msiPath",
+        "Enable-DefenderForTarget -TargetPath $ExpectedInstallDirectory",
+        "Assert-DefenderTargetNotExcluded -TargetPath $ExpectedExecutable",
+        "WindowsInstaller",
+        "$windowsInstaller.OpenDatabase($msiPath, 0)",
+        "FinalReleaseComObject",
+        'InvokeMember("Close", "InvokeMethod"',
+        "DisplayVersion",
+        "UninstallString",
+        "WinGet list did not correlate",
+        "Start-Sleep -Seconds 10",
+        "Assert-CleanInstallState -AfterUninstall",
+        '-Arguments @("settings", "--disable", "LocalManifestFiles")',
+        'winget-settings-after-disable.log',
+        "Could not inspect flowtake process",
+        'Write-Error "Lifecycle proof failed: $($primaryFailure.Exception.Message)" -ErrorAction Continue',
+        'Write-Error "Cleanup also failed: $($cleanupFailure.Exception.Message)" -ErrorAction Continue',
+    ]) {
+        assert.ok(lifecycleScript.includes(requiredBoundary), `missing fail-closed boundary: ${requiredBoundary}`)
+    }
+
+    assert.doesNotMatch(
+        lifecycleScript,
+        /continue-on-error|ignore-security-hash|LocalArchiveMalwareScanOverride|InstallerHashOverride|Win32_Product|\|\|\s*true|"--product-code"/
+    )
+    assert.doesNotMatch(lifecycleScript, /Get-MpThreatDetection[^\r\n]*SilentlyContinue/)
+    assert.doesNotMatch(lifecycleScript, /&\s+\$wingetPath\s+settings\s+--disable/)
+    assert.doesNotMatch(lifecycleScript, /InvokeMember\("OpenDatabase"/)
+
+    const exclusionCheck = lifecycleScript.slice(
+        lifecycleScript.indexOf("function Assert-DefenderTargetNotExcluded"),
+        lifecycleScript.indexOf("function Enable-DefenderForTarget")
+    )
+    assert.match(exclusionCheck, /-AllowedExitCodes @\(1\)/)
+    assert.doesNotMatch(exclusionCheck, /-AllowedExitCodes @\([^)]*0/)
+})

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -122,7 +122,7 @@ test("installer proof uses immutable actions and a pinned official WinGet bootst
     assert.match(workflowSource, /\$module\.Author -ne "Microsoft Corporation"/m)
     assert.doesNotMatch(
         workflowSource,
-        /continue-on-error|contents:\s*write|secrets\.|pull_request_target|Install-Module|Install-PackageProvider|Set-PSRepository/
+        /continue-on-error|contents:\s*write|secrets\.|pull_request_target|Add-AppxPackage|Install-Module|Install-PackageProvider|Set-PSRepository/
     )
 })
 

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -106,23 +106,41 @@ test("installer proof uses immutable actions and a pinned official WinGet bootst
     )
     assert.equal(workflowSource.match(/persist-credentials: false/g)?.length, 2)
     assert.equal(workflow.env.WINGET_BOOTSTRAP_VERSION, "1.29.280")
+    assert.equal(workflow.env.WINGET_PACKAGE_VERSION, "1.29.280.0")
     assert.equal(
-        workflow.env.WINGET_MODULE_URL,
-        "https://www.powershellgallery.com/api/v2/package/Microsoft.WinGet.Client/1.29.280"
+        workflow.env.WINGET_BUNDLE_URL,
+        "https://github.com/microsoft/winget-cli/releases/download/v1.29.280/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
     )
-    assert.equal(workflow.env.WINGET_MODULE_SIZE, "20883488")
+    assert.equal(workflow.env.WINGET_BUNDLE_SIZE, "216775738")
     assert.equal(
-        workflow.env.WINGET_MODULE_SHA512,
-        "DE5818DA64D4362904FFE35737A2D7DFC7179CB4D248E5816CE89AFE7E08C0A8AC63012F5489095F49724E1BEC0EAA2E53A90593AEF204979DE6CB27534A91A6"
+        workflow.env.WINGET_BUNDLE_SHA256,
+        "0809FA9F52E395D6E7DE692331DCE847AC991952675116BB4D8AAE2DDCC20946"
     )
-    assert.equal(workflowSource.match(/Microsoft\.WinGet\.Client/g)?.length >= 6, true)
-    assert.equal(workflowSource.match(/Get-FileHash[^\n]+-Algorithm SHA512/g)?.length, 2)
-    assert.equal(workflowSource.match(/Test-ModuleManifest -Path \$moduleManifest/g)?.length, 2)
-    assert.match(workflowSource, /Repair-WinGetPackageManager/g)
-    assert.match(workflowSource, /\$module\.Author -ne "Microsoft Corporation"/m)
+    assert.equal(
+        workflow.env.WINGET_DEPENDENCIES_URL,
+        "https://github.com/microsoft/winget-cli/releases/download/v1.29.280/DesktopAppInstaller_Dependencies.zip"
+    )
+    assert.equal(workflow.env.WINGET_DEPENDENCIES_SIZE, "97760717")
+    assert.equal(
+        workflow.env.WINGET_DEPENDENCIES_SHA256,
+        "3BBFCAA5CB011C48FAC48D896D64A5C7C6898859A9F3D01555C8CD000F4E2962"
+    )
+    assert.equal(workflowSource.match(/Get-FileHash[^\n]+-Algorithm SHA256/g)?.length, 4)
+    assert.equal(workflowSource.match(/Add-AppxPackage/g)?.length, 2)
+    assert.equal(workflowSource.match(/-DependencyPath \$dependencyPaths/g)?.length, 2)
+    assert.equal(workflowSource.match(/Get-AppxPackage -Name Microsoft\.DesktopAppInstaller/g)?.length, 2)
+    assert.equal(workflowSource.match(/PackageFamilyName -eq "Microsoft\.DesktopAppInstaller_8wekyb3d8bbwe"/g)?.length, 2)
+    assert.equal(workflowSource.match(/PublisherId -eq "8wekyb3d8bbwe"/g)?.length, 2)
+    for (const dependencyName of [
+        "Microsoft.VCLibs.140.00_14.0.33519.0_x64.appx",
+        "Microsoft.VCLibs.140.00.UWPDesktop_14.0.33728.0_x64.appx",
+        "Microsoft.WindowsAppRuntime.1.8_8000.616.304.0_x64.appx",
+    ]) {
+        assert.equal(workflowSource.match(new RegExp(dependencyName.replaceAll(".", "\\."), "g"))?.length, 2)
+    }
     assert.doesNotMatch(
         workflowSource,
-        /continue-on-error|contents:\s*write|secrets\.|pull_request_target|Add-AppxPackage|Install-Module|Install-PackageProvider|Set-PSRepository/
+        /continue-on-error|contents:\s*write|secrets\.|pull_request_target|RegisterByFamilyName|Repair-WinGetPackageManager|WINGET_MODULE|Install-Module|Install-PackageProvider|Set-PSRepository/
     )
 })
 

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -105,6 +105,13 @@ test("installer proof uses immutable actions and a pinned official WinGet bootst
         ]
     )
     assert.equal(workflowSource.match(/persist-credentials: false/g)?.length, 2)
+    const bootstrapSteps = Object.values(workflow.jobs).map(job =>
+        job.steps.find(step => step.name === "Provision the pinned Microsoft WinGet client")
+    )
+    assert.equal(bootstrapSteps.length, 2)
+    assert.equal(bootstrapSteps.every(step => step?.shell === "powershell"), true)
+    assert.equal(bootstrapSteps.every(step => step?.run.includes('$ProgressPreference = "SilentlyContinue"')), true)
+    assert.doesNotMatch(bootstrapSteps.map(step => step.run).join("\n"), /MaximumRetryCount|RetryIntervalSec/)
     assert.equal(workflow.env.WINGET_BOOTSTRAP_VERSION, "1.29.280")
     assert.equal(workflow.env.WINGET_PACKAGE_VERSION, "1.29.280.0")
     assert.equal(


### PR DESCRIPTION
## What changed

- add the reviewed three-file WinGet manifest set for `JNX03.Flowtake 1.6.0`
- add a path-scoped Windows workflow that performs static manifest validation on pull requests
- restrict real Flowtake MSI execution to a manual `workflow_dispatch` from `refs/heads/main`
- bootstrap WinGet from Microsoft’s official `v1.29.280` full x64 MSIX bundle and dependency archive, pinned by exact release URLs, byte sizes, SHA-256 hashes, package family, publisher, architecture, package version, CLI version, and CLI operability
- verify the immutable Flowtake release asset, checksum file, MSI metadata, ARP identity, installed executable, shortcuts, bounded startup, WinGet inventory, uninstall, and final cleanup
- re-enable Microsoft Defender, remove covering path exclusions, verify `Normal` active mode, use `MpCmdRun -CheckExclusion` for the MSI/directory/executable, and fail on telemetry or scan detections

## Why

The upstream WinGet contribution checklist requires a package that has actually been validated and installed. Pull-request code must not be allowed to execute the published Flowtake MSI, so this change separates safe static review from a deliberate post-merge lifecycle proof.

The hosted `windows-2025` image currently contains an incomplete provisioned Desktop App Installer bundle: family registration and the Microsoft repair module both reach the same missing-x64-payload failure. The pinned official release bundle contains the full x64 package and exact dependencies, so the bootstrap installs that reviewed Microsoft package directly.

## Impact and boundaries

- pull requests receive only `contents: read`, no secrets, and no persistent checkout credentials
- pull requests bootstrap Microsoft WinGet and perform static manifest validation only; they cannot execute the Flowtake installer
- Flowtake lifecycle execution remains blocked until this PR is reviewed, checked, and normally merged
- a green lifecycle run proves unattended install/startup/uninstall on the GitHub-hosted Windows Server 2025 runner; it does not claim broad Windows compatibility
- the upstream `microsoft/winget-pkgs` submission remains blocked until that main-only run passes

## Validation

- `npm test`: 147/147 passed
- targeted lifecycle tests: 4/4 passed
- targeted ESLint: passed
- repository lint: 0 errors, 41 pre-existing warnings
- PowerShell AST parse: passed
- `test-windows-msi-lifecycle.ps1 -Mode ValidateManifest`: passed without downloading or executing the Flowtake installer
- `winget validate --manifest packaging/winget/JNX03.Flowtake/1.6.0`: passed on WinGet 1.29.280
- exact Microsoft bundle/dependency assets, inner manifests, package identity, and PowerShell parameter binding reproduced independently
- exact Flowtake MSI metadata and COM lock-release behavior reproduced independently
- independent runtime correctness review: GO
- independent fail-closed security rereview: GO
- independent hosted-runner feasibility review: GO

## Post-merge gate

After a normal merge, manually dispatch **Windows MSI Lifecycle Proof** on `main`. Submit to WinGet upstream only if the complete lifecycle job is green.