### PR TITLE
ci: preserve Defender exclusion collections

### DIFF
--- a/scripts/test-windows-msi-lifecycle.ps1
+++ b/scripts/test-windows-msi-lifecycle.ps1
@@ -265,7 +265,7 @@ function Enable-DefenderForTarget {
         Assert-Condition ($null -ne (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) "Required Defender command is unavailable: $requiredCommand"
     }
 
-    $coveringExclusions = Get-CoveringDefenderExclusions -TargetPath $TargetPath
+    $coveringExclusions = @(Get-CoveringDefenderExclusions -TargetPath $TargetPath)
     foreach ($exclusion in $coveringExclusions) {
         Write-Evidence "Removing Defender exclusion that covers the scan target: $exclusion"
         Remove-MpPreference -ExclusionPath $exclusion
@@ -280,7 +280,7 @@ function Enable-DefenderForTarget {
         -PUAProtection Enabled
     Update-MpSignature | Out-Null
 
-    $remainingExclusions = Get-CoveringDefenderExclusions -TargetPath $TargetPath
+    $remainingExclusions = @(Get-CoveringDefenderExclusions -TargetPath $TargetPath)
     Assert-Condition ($remainingExclusions.Count -eq 0) "A Defender exclusion still covers the scan target: $($remainingExclusions -join ', ')"
 
     $preference = Get-MpPreference

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -225,6 +225,10 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     assert.doesNotMatch(lifecycleScript, /Get-MpThreatDetection[^\r\n]*SilentlyContinue/)
     assert.doesNotMatch(lifecycleScript, /&\s+\$wingetPath\s+settings\s+--disable/)
     assert.doesNotMatch(lifecycleScript, /InvokeMember\("OpenDatabase"/)
+    assert.equal(
+        lifecycleScript.match(/= @\(Get-CoveringDefenderExclusions -TargetPath \$TargetPath\)/g)?.length,
+        2
+    )
 
     const exclusionCheck = lifecycleScript.slice(
         lifecycleScript.indexOf("function Assert-DefenderTargetNotExcluded"),


### PR DESCRIPTION
## What changed

- normalize both Defender exclusion query results to arrays before iteration and Count checks
- preserve the existing fail-closed assertion when any exclusion still covers the scan target
- add a regression guard requiring both collection-normalization call sites

## Why

Main-only lifecycle run https://github.com/JNX03/Flowtake/actions/runs/29498171553 removed the hosted runner's broad C:\ exclusion, then PowerShell emitted the empty result as null. Under strict mode, the subsequent Count access failed before Flowtake was installed.

## Safety

- the failed run did not install or execute Flowtake
- Defender normalization and command errors still propagate
- the authoritative MpCmdRun exclusion check remains unchanged
- no installer can execute on this pull request

## Validation

- npm test: 147/147 passed
- targeted lifecycle tests: 4/4 passed
- targeted ESLint: passed
- static WinGet manifest validation: passed
- Windows PowerShell parser: passed
- strict-mode empty-collection reproduction: passed
- three independent reviews reproduced the failure and approved this exact fix

## Post-merge gate

After normal merge, dispatch Windows MSI Lifecycle Proof on main again. WinGet upstream remains blocked until the full lifecycle job is green.