### PR TITLE
ci: scan MSI despite runner exclusions

### DIFF
--- a/.github/workflows/windows-msi-lifecycle.yml
+++ b/.github/workflows/windows-msi-lifecycle.yml
@@ -140,6 +140,14 @@ jobs:
             -Mode ValidateManifest `
             -ManifestDirectory $env:FLOWTAKE_MANIFEST_DIR
 
+      - name: Verify exclusion-independent Defender custom scan
+        if: github.event_name == 'pull_request'
+        shell: pwsh
+        run: |
+          ./scripts/test-windows-msi-lifecycle.ps1 `
+            -Mode ValidateDefender `
+            -ManifestDirectory $env:FLOWTAKE_MANIFEST_DIR
+
   installer-lifecycle:
     name: Install, scan, launch, and uninstall exact MSI
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'

--- a/scripts/test-windows-msi-lifecycle.ps1
+++ b/scripts/test-windows-msi-lifecycle.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("ValidateManifest", "Lifecycle")]
+    [ValidateSet("ValidateManifest", "ValidateDefender", "Lifecycle")]
     [string]$Mode,
 
     [Parameter(Mandatory = $true)]
@@ -207,25 +207,6 @@ function Assert-CleanInstallState {
     }
 }
 
-function Get-CoveringDefenderExclusions {
-    param([Parameter(Mandatory = $true)][string]$TargetPath)
-
-    $target = [System.IO.Path]::GetFullPath($TargetPath).TrimEnd('\')
-    $preference = Get-MpPreference
-    $exclusions = @($preference.ExclusionPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-    return @($exclusions | Where-Object {
-        $exclusion = $_
-        $expanded = [Environment]::ExpandEnvironmentVariables($exclusion)
-        try {
-            $normalized = [System.IO.Path]::GetFullPath($expanded).TrimEnd('\')
-            $target -ieq $normalized -or $target.StartsWith("$normalized\", [StringComparison]::OrdinalIgnoreCase)
-        }
-        catch {
-            throw "Could not normalize Defender exclusion '$exclusion': $($_.Exception.Message)"
-        }
-    })
-}
-
 function Get-MpCmdRunPath {
     $candidates = [System.Collections.Generic.List[string]]::new()
     $platformRoot = Join-Path $env:ProgramData "Microsoft\Windows Defender\Platform"
@@ -240,35 +221,12 @@ function Get-MpCmdRunPath {
     return $mpCmdRunPath[0]
 }
 
-function Assert-DefenderTargetNotExcluded {
-    param([Parameter(Mandatory = $true)][string]$TargetPath)
-
-    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender exclusion-check target is missing: $TargetPath"
-    $mpCmdRunPath = Get-MpCmdRunPath
-    $safeLabel = [System.IO.Path]::GetFileName($TargetPath)
-    if ([string]::IsNullOrWhiteSpace($safeLabel)) {
-        $safeLabel = "target"
-    }
-    $result = Invoke-NativeChecked `
-        -FilePath $mpCmdRunPath `
-        -Arguments @("-CheckExclusion", "-Path", $TargetPath) `
-        -LogPath (Join-Path $EvidenceDirectory "defender-exclusion-$safeLabel.log") `
-        -AllowedExitCodes @(1)
-    Assert-Condition ($result.Output -match "(?i)\bis not excluded\b") "MpCmdRun returned indeterminate exclusion output for: $TargetPath"
-    Write-Evidence "Defender confirmed the target is not excluded from scanning: $TargetPath"
-}
-
 function Enable-DefenderForTarget {
     param([Parameter(Mandatory = $true)][string]$TargetPath)
 
-    foreach ($requiredCommand in @("Get-MpComputerStatus", "Get-MpPreference", "Set-MpPreference", "Remove-MpPreference", "Update-MpSignature", "Start-MpScan", "Get-MpThreatDetection")) {
+    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender target is missing: $TargetPath"
+    foreach ($requiredCommand in @("Get-MpComputerStatus", "Get-MpPreference", "Set-MpPreference", "Update-MpSignature")) {
         Assert-Condition ($null -ne (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) "Required Defender command is unavailable: $requiredCommand"
-    }
-
-    $coveringExclusions = @(Get-CoveringDefenderExclusions -TargetPath $TargetPath)
-    foreach ($exclusion in $coveringExclusions) {
-        Write-Evidence "Removing Defender exclusion that covers the scan target: $exclusion"
-        Remove-MpPreference -ExclusionPath $exclusion
     }
 
     Set-MpPreference `
@@ -279,9 +237,6 @@ function Enable-DefenderForTarget {
         -DisableArchiveScanning $false `
         -PUAProtection Enabled
     Update-MpSignature | Out-Null
-
-    $remainingExclusions = @(Get-CoveringDefenderExclusions -TargetPath $TargetPath)
-    Assert-Condition ($remainingExclusions.Count -eq 0) "A Defender exclusion still covers the scan target: $($remainingExclusions -join ', ')"
 
     $preference = Get-MpPreference
     Assert-Condition (-not [bool]$preference.DisableRealtimeMonitoring) "Defender real-time monitoring remained disabled."
@@ -296,10 +251,11 @@ function Enable-DefenderForTarget {
     Assert-Condition ([bool]$status.AntivirusEnabled) "Defender antivirus is not enabled."
     Assert-Condition ([bool]$status.RealTimeProtectionEnabled) "Defender real-time protection is not enabled."
     Assert-Condition ($status.AMRunningMode -eq "Normal") "Defender is not running in Normal mode: $($status.AMRunningMode)"
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$status.AMEngineVersion)) "Defender engine version is unavailable."
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$status.AntivirusSignatureVersion)) "Defender signature version is unavailable."
     Assert-Condition ($null -ne $status.AntivirusSignatureLastUpdated) "Defender signature timestamp is unavailable."
     Assert-Condition ([int]$status.AntivirusSignatureAge -le 1) "Defender signatures are stale: age $($status.AntivirusSignatureAge) day(s)."
-    Assert-DefenderTargetNotExcluded -TargetPath $TargetPath
-    Write-Evidence "Defender enabled; signature version $($status.AntivirusSignatureVersion), updated $($status.AntivirusSignatureLastUpdated.ToUniversalTime().ToString('o'))."
+    Write-Evidence "Defender enabled in Normal mode for an exclusion-independent custom scan of $TargetPath; engine $($status.AMEngineVersion), signature $($status.AntivirusSignatureVersion), updated $($status.AntivirusSignatureLastUpdated.ToUniversalTime().ToString('o'))."
 }
 
 function Invoke-DefenderScan {
@@ -309,21 +265,17 @@ function Invoke-DefenderScan {
     )
 
     Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan target is missing: $TargetPath"
-    $before = @{}
-    foreach ($item in @(Get-MpThreatDetection -ErrorAction Stop)) {
-        $before["$($item.ThreatID)|$($item.InitialDetectionTime)|$($item.Resources -join ';')"] = $true
-    }
-
-    $scanStartedAt = [DateTime]::UtcNow
-    Write-Evidence "Starting Defender custom scan: $Label"
-    Start-MpScan -ScanType CustomScan -ScanPath $TargetPath
-    $newDetections = @(Get-MpThreatDetection -ErrorAction Stop | Where-Object {
-        $key = "$($_.ThreatID)|$($_.InitialDetectionTime)|$($_.Resources -join ';')"
-        -not $before.ContainsKey($key)
-    })
-    Assert-Condition ($newDetections.Count -eq 0) "Defender reported a new detection while scanning $Label."
-    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan removed or quarantined $Label."
-    Write-Evidence "Defender custom scan completed with no new detection: $Label (started $($scanStartedAt.ToString('o')))."
+    $safeLabel = ($Label -replace "[^A-Za-z0-9.-]", "-").Trim("-")
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($safeLabel)) "Defender scan label is invalid."
+    $result = Invoke-NativeChecked `
+        -FilePath (Get-MpCmdRunPath) `
+        -Arguments @("-Scan", "-ScanType", "3", "-File", $TargetPath, "-DisableRemediation") `
+        -LogPath (Join-Path $EvidenceDirectory "defender-scan-$safeLabel.log") `
+        -AllowedExitCodes @(0)
+    Assert-Condition ($result.Output -match "(?im)^\s*Scan finished\.\s*$") "Defender did not report a completed scan for $Label."
+    Assert-Condition ($result.Output -match "(?im)\bfound no threats\.\s*$") "Defender did not report a clean scan for $Label."
+    Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan target disappeared: $Label."
+    Write-Evidence "Defender exclusion-independent custom scan completed with no threats: $Label."
 }
 
 function Write-FailureLogTails {
@@ -358,7 +310,8 @@ Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "Scope")
 Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "ProductCode") -eq $ExpectedProductCode) "Manifest ProductCode drifted."
 Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "Architecture") -eq "x64") "Manifest architecture must remain x64."
 Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "InstallerUrl") -eq $ExpectedMsiUrl) "Manifest installer URL drifted."
-Assert-Condition ((Get-UniqueYamlScalar -Source $installerManifest -Key "InstallerSha256").ToUpperInvariant() -eq $ExpectedMsiSha256) "Manifest installer SHA-256 drifted."
+$manifestInstallerSha256 = (Get-UniqueYamlScalar -Source $installerManifest -Key "InstallerSha256").ToUpperInvariant()
+Assert-Condition ($manifestInstallerSha256 -eq $ExpectedMsiSha256) "Manifest installer SHA-256 drifted."
 Assert-Condition ((Get-UniqueYamlScalar -Source $localeManifest -Key "Publisher") -eq $ExpectedPublisher) "Manifest publisher drifted."
 Assert-Condition ((Get-UniqueYamlScalar -Source $localeManifest -Key "PackageName") -eq $ExpectedProductName) "Manifest package name drifted."
 Assert-Condition ((Get-UniqueYamlScalar -Source $localeManifest -Key "License") -eq "MIT") "Manifest license drifted."
@@ -375,7 +328,25 @@ Invoke-NativeChecked -FilePath $wingetPath -Arguments @("validate", "--manifest"
 Write-Evidence "Tracked WinGet manifest passed static validation."
 
 if ($Mode -eq "ValidateManifest") {
-    Write-Evidence "PASS: static manifest validation only; no installer was downloaded or executed."
+    Write-Evidence "PASS: static manifest validation only; no Flowtake installer was downloaded or executed."
+    exit 0
+}
+
+if ($Mode -eq "ValidateDefender") {
+    Assert-Condition ($env:GITHUB_EVENT_NAME -eq "pull_request") "ValidateDefender mode is restricted to pull_request."
+    $probePath = "C:\FlowtakeDefenderProbe-$([guid]::NewGuid().ToString('N')).txt"
+    try {
+        [System.IO.File]::WriteAllText($probePath, "Harmless Flowtake Defender scan-path probe.")
+        Enable-DefenderForTarget -TargetPath $probePath
+        Invoke-DefenderScan -TargetPath $probePath -Label "harmless PR probe"
+        Assert-Condition (Test-Path -LiteralPath $probePath -PathType Leaf) "Defender probe file disappeared after scanning."
+        Write-Evidence "PASS: exclusion-independent Defender custom scan validated on a harmless file; no Flowtake installer was downloaded or executed."
+    }
+    finally {
+        if (Test-Path -LiteralPath $probePath) {
+            Remove-Item -LiteralPath $probePath -Force
+        }
+    }
     exit 0
 }
 
@@ -465,7 +436,11 @@ try {
 
     Enable-DefenderForTarget -TargetPath $msiPath
     Invoke-DefenderScan -TargetPath $msiPath -Label "published Flowtake MSI"
-    Assert-Condition ((Get-FileHash -LiteralPath $msiPath -Algorithm SHA256).Hash.ToUpperInvariant() -eq $ExpectedMsiSha256) "MSI changed after Defender scan."
+    Assert-Condition (Test-Path -LiteralPath $msiPath -PathType Leaf) "MSI disappeared after Defender scan."
+    Assert-Condition ((Get-Item -LiteralPath $msiPath).Length -eq $ExpectedMsiSize) "MSI size changed after Defender scan."
+    $scannedMsiSha256 = (Get-FileHash -LiteralPath $msiPath -Algorithm SHA256).Hash.ToUpperInvariant()
+    Assert-Condition ($scannedMsiSha256 -eq $ExpectedMsiSha256) "MSI changed after Defender scan."
+    Assert-Condition ($scannedMsiSha256 -eq $manifestInstallerSha256) "Defender-scanned MSI SHA-256 does not match the tracked manifest."
 
     $localManifestSetting = Get-WinGetAdminSetting `
         -WinGetPath $wingetPath `
@@ -478,12 +453,25 @@ try {
         -Name "LocalManifestFiles" `
         -LogPath (Join-Path $EvidenceDirectory "winget-settings-after-enable.log")
     Assert-Condition $localManifestSetting "LocalManifestFiles did not become enabled."
-    Invoke-NativeChecked -FilePath $wingetPath -Arguments @(
+    $installerHashOverride = Get-WinGetAdminSetting `
+        -WinGetPath $wingetPath `
+        -Name "InstallerHashOverride" `
+        -LogPath (Join-Path $EvidenceDirectory "winget-settings-hash-override.log")
+    Assert-Condition (-not $installerHashOverride) "WinGet InstallerHashOverride is enabled."
+    Assert-Condition (Test-Path -LiteralPath $msiPath -PathType Leaf) "Scanned MSI is missing immediately before WinGet install."
+    Assert-Condition ((Get-Item -LiteralPath $msiPath).Length -eq $ExpectedMsiSize) "Scanned MSI size changed immediately before WinGet install."
+    $preInstallMsiSha256 = (Get-FileHash -LiteralPath $msiPath -Algorithm SHA256).Hash.ToUpperInvariant()
+    Assert-Condition ($preInstallMsiSha256 -eq $scannedMsiSha256) "Scanned MSI changed immediately before WinGet install."
+    Write-Evidence "Defender scanned published MSI content SHA-256 $scannedMsiSha256; the tracked manifest pins WinGet's installer download to that digest."
+    $installResult = Invoke-NativeChecked -FilePath $wingetPath -Arguments @(
         "install", "--manifest", $ManifestDirectory,
         "--silent", "--scope", "machine", "--disable-interactivity",
         "--accept-package-agreements", "--accept-source-agreements",
         "--verbose-logs", "--log", $wingetInstallLog
-    ) -LogPath (Join-Path $EvidenceDirectory "winget-install-command.log") | Out-Null
+    ) -LogPath (Join-Path $EvidenceDirectory "winget-install-command.log")
+    Assert-Condition ($installResult.Output -match "(?i)\bSuccessfully verified installer hash\b") "WinGet did not report successful installer hash verification."
+    Assert-Condition ($installResult.Output -notmatch "(?i)hash\s+(?:mismatch|override)|ignore-security-hash") "WinGet reported an installer hash mismatch or override."
+    Write-Evidence "WinGet verified downloaded installer content SHA-256 $manifestInstallerSha256 before execution."
     $installObserved = $true
 
     Assert-Condition (Test-Path -LiteralPath $ExpectedUninstallKey) "Expected 64-bit ARP product key is missing after install."
@@ -520,8 +508,8 @@ try {
     Write-Evidence "Installation correlated across WinGet inventory, 64-bit ARP, MSI ProductCode, HKCU installer key, shortcuts, and executable metadata."
 
     Enable-DefenderForTarget -TargetPath $ExpectedInstallDirectory
-    Assert-DefenderTargetNotExcluded -TargetPath $ExpectedExecutable
     Invoke-DefenderScan -TargetPath $ExpectedInstallDirectory -Label "installed Flowtake directory"
+    Invoke-DefenderScan -TargetPath $ExpectedExecutable -Label "installed Flowtake executable"
     Assert-Condition (Test-Path -LiteralPath $ExpectedExecutable -PathType Leaf) "Installed executable disappeared after Defender scan."
 
     $trackedProcess = Start-Process -FilePath $ExpectedExecutable -PassThru

--- a/scripts/test-windows-msi-lifecycle.ps1
+++ b/scripts/test-windows-msi-lifecycle.ps1
@@ -221,6 +221,60 @@ function Get-MpCmdRunPath {
     return $mpCmdRunPath[0]
 }
 
+function Test-DefenderSignatureFresh {
+    param([Parameter(Mandatory = $true)]$Status)
+
+    if ([string]::IsNullOrWhiteSpace([string]$Status.AntivirusSignatureVersion)) {
+        return $false
+    }
+    if ($null -eq $Status.AntivirusSignatureLastUpdated) {
+        return $false
+    }
+    $ageProperty = $Status.PSObject.Properties["AntivirusSignatureAge"]
+    if ($null -eq $ageProperty -or $null -eq $ageProperty.Value) {
+        return $false
+    }
+    try {
+        $age = [uint64]$ageProperty.Value
+        $updatedUtc = ([datetime]$Status.AntivirusSignatureLastUpdated).ToUniversalTime()
+    }
+    catch {
+        return $false
+    }
+    $nowUtc = [DateTime]::UtcNow
+    return (
+        $age -le [uint64]1 -and
+        $updatedUtc -ge $nowUtc.AddHours(-48) -and
+        $updatedUtc -le $nowUtc.AddMinutes(5)
+    )
+}
+
+function Get-DefenderStatusWithRetry {
+    $lastFailure = "no error was reported"
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+        try {
+            return Get-MpComputerStatus -ErrorAction Stop
+        }
+        catch {
+            $lastFailure = $_.Exception.Message
+            Write-Evidence "Get-MpComputerStatus attempt $attempt of 3 failed: $lastFailure"
+            if ($attempt -lt 3) {
+                Start-Sleep -Seconds 2
+            }
+        }
+    }
+    throw "Could not read Defender status after 3 attempts: $lastFailure"
+}
+
+function Assert-DefenderCoreReady {
+    param([Parameter(Mandatory = $true)]$Status)
+
+    Assert-Condition ([bool]$Status.AMServiceEnabled) "Defender antimalware service is not enabled."
+    Assert-Condition ([bool]$Status.AntivirusEnabled) "Defender antivirus is not enabled."
+    Assert-Condition ($Status.AMRunningMode -eq "Normal") "Defender is not running in Normal mode: $($Status.AMRunningMode)"
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$Status.AMEngineVersion)) "Defender engine version is unavailable."
+}
+
 function Prepare-DefenderScan {
     param([Parameter(Mandatory = $true)][string]$TargetPath)
 
@@ -229,16 +283,58 @@ function Prepare-DefenderScan {
         Assert-Condition ($null -ne (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) "Required Defender command is unavailable: $requiredCommand"
     }
 
-    Update-MpSignature | Out-Null
+    $status = Get-DefenderStatusWithRetry
+    Assert-DefenderCoreReady -Status $status
+    $updateFailures = [System.Collections.Generic.List[string]]::new()
 
-    $status = Get-MpComputerStatus
-    Assert-Condition ([bool]$status.AMServiceEnabled) "Defender antimalware service is not enabled."
-    Assert-Condition ([bool]$status.AntivirusEnabled) "Defender antivirus is not enabled."
-    Assert-Condition ($status.AMRunningMode -eq "Normal") "Defender is not running in Normal mode: $($status.AMRunningMode)"
-    Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$status.AMEngineVersion)) "Defender engine version is unavailable."
+    if (Test-DefenderSignatureFresh -Status $status) {
+        Write-Evidence "Defender signatures are already fresh; no network signature update is required."
+    }
+    else {
+        Write-Evidence "Attempting Defender signature update with the explicit MMPC source."
+        try {
+            Update-MpSignature -UpdateSource MMPC -ErrorAction Stop | Out-Null
+        }
+        catch {
+            $message = "Update-MpSignature MMPC attempt failed: $($_.Exception.Message)"
+            $updateFailures.Add($message)
+            Write-Evidence $message
+        }
+        $status = Get-DefenderStatusWithRetry
+
+        if (-not (Test-DefenderSignatureFresh -Status $status)) {
+            Write-Evidence "PowerShell signature updates did not establish freshness; trying the official MpCmdRun MMPC fallback."
+            try {
+                Invoke-NativeChecked `
+                    -FilePath (Get-MpCmdRunPath) `
+                    -Arguments @("-SignatureUpdate", "-MMPC") `
+                    -LogPath (Join-Path $EvidenceDirectory "defender-signature-update-mmpc.log") `
+                    -AllowedExitCodes @(0) | Out-Null
+            }
+            catch {
+                $message = "MpCmdRun MMPC signature update failed: $($_.Exception.Message)"
+                $updateFailures.Add($message)
+                Write-Evidence $message
+            }
+
+            for ($poll = 1; $poll -le 6; $poll++) {
+                $status = Get-DefenderStatusWithRetry
+                if (Test-DefenderSignatureFresh -Status $status) {
+                    break
+                }
+                if ($poll -lt 6) {
+                    Start-Sleep -Seconds 2
+                }
+            }
+        }
+    }
+
+    $status = Get-DefenderStatusWithRetry
+    Assert-DefenderCoreReady -Status $status
     Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$status.AntivirusSignatureVersion)) "Defender signature version is unavailable."
     Assert-Condition ($null -ne $status.AntivirusSignatureLastUpdated) "Defender signature timestamp is unavailable."
-    Assert-Condition ([int]$status.AntivirusSignatureAge -le 1) "Defender signatures are stale: age $($status.AntivirusSignatureAge) day(s)."
+    $failureSummary = if ($updateFailures.Count -gt 0) { $updateFailures -join " | " } else { "no updater error was reported" }
+    Assert-Condition (Test-DefenderSignatureFresh -Status $status) "Defender signatures are stale or missing after bounded update attempts; age $($status.AntivirusSignatureAge) day(s); $failureSummary."
     Write-Evidence "Defender on-demand scan prerequisites are ready for $TargetPath; mode Normal, engine $($status.AMEngineVersion), signature $($status.AntivirusSignatureVersion), updated $($status.AntivirusSignatureLastUpdated.ToUniversalTime().ToString('o')). Real-time status is $([bool]$status.RealTimeProtectionEnabled) and is observed only, not used as a custom-scan prerequisite or claimed as installer-write coverage."
 }
 
@@ -353,6 +449,7 @@ $installObserved = $false
 try {
     Assert-CleanInstallState
     New-Item -ItemType Directory -Path $smokeRoot | Out-Null
+    Prepare-DefenderScan -TargetPath $smokeRoot
 
     $releaseHeaders = @{
         Accept = "application/vnd.github+json"

--- a/scripts/test-windows-msi-lifecycle.ps1
+++ b/scripts/test-windows-msi-lifecycle.ps1
@@ -221,41 +221,25 @@ function Get-MpCmdRunPath {
     return $mpCmdRunPath[0]
 }
 
-function Enable-DefenderForTarget {
+function Prepare-DefenderScan {
     param([Parameter(Mandatory = $true)][string]$TargetPath)
 
     Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender target is missing: $TargetPath"
-    foreach ($requiredCommand in @("Get-MpComputerStatus", "Get-MpPreference", "Set-MpPreference", "Update-MpSignature")) {
+    foreach ($requiredCommand in @("Get-MpComputerStatus", "Update-MpSignature")) {
         Assert-Condition ($null -ne (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) "Required Defender command is unavailable: $requiredCommand"
     }
 
-    Set-MpPreference `
-        -DisableRealtimeMonitoring $false `
-        -DisableBehaviorMonitoring $false `
-        -DisableScriptScanning $false `
-        -DisableIOAVProtection $false `
-        -DisableArchiveScanning $false `
-        -PUAProtection Enabled
     Update-MpSignature | Out-Null
-
-    $preference = Get-MpPreference
-    Assert-Condition (-not [bool]$preference.DisableRealtimeMonitoring) "Defender real-time monitoring remained disabled."
-    Assert-Condition (-not [bool]$preference.DisableBehaviorMonitoring) "Defender behavior monitoring remained disabled."
-    Assert-Condition (-not [bool]$preference.DisableScriptScanning) "Defender script scanning remained disabled."
-    Assert-Condition (-not [bool]$preference.DisableIOAVProtection) "Defender IOAV protection remained disabled."
-    Assert-Condition (-not [bool]$preference.DisableArchiveScanning) "Defender archive scanning remained disabled."
-    Assert-Condition ([int]$preference.PUAProtection -eq 1) "Defender PUA protection is not enabled."
 
     $status = Get-MpComputerStatus
     Assert-Condition ([bool]$status.AMServiceEnabled) "Defender antimalware service is not enabled."
     Assert-Condition ([bool]$status.AntivirusEnabled) "Defender antivirus is not enabled."
-    Assert-Condition ([bool]$status.RealTimeProtectionEnabled) "Defender real-time protection is not enabled."
     Assert-Condition ($status.AMRunningMode -eq "Normal") "Defender is not running in Normal mode: $($status.AMRunningMode)"
     Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$status.AMEngineVersion)) "Defender engine version is unavailable."
     Assert-Condition (-not [string]::IsNullOrWhiteSpace([string]$status.AntivirusSignatureVersion)) "Defender signature version is unavailable."
     Assert-Condition ($null -ne $status.AntivirusSignatureLastUpdated) "Defender signature timestamp is unavailable."
     Assert-Condition ([int]$status.AntivirusSignatureAge -le 1) "Defender signatures are stale: age $($status.AntivirusSignatureAge) day(s)."
-    Write-Evidence "Defender enabled in Normal mode for an exclusion-independent custom scan of $TargetPath; engine $($status.AMEngineVersion), signature $($status.AntivirusSignatureVersion), updated $($status.AntivirusSignatureLastUpdated.ToUniversalTime().ToString('o'))."
+    Write-Evidence "Defender on-demand scan prerequisites are ready for $TargetPath; mode Normal, engine $($status.AMEngineVersion), signature $($status.AntivirusSignatureVersion), updated $($status.AntivirusSignatureLastUpdated.ToUniversalTime().ToString('o')). Real-time status is $([bool]$status.RealTimeProtectionEnabled) and is observed only, not used as a custom-scan prerequisite or claimed as installer-write coverage."
 }
 
 function Invoke-DefenderScan {
@@ -265,15 +249,17 @@ function Invoke-DefenderScan {
     )
 
     Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan target is missing: $TargetPath"
+    $resolvedTarget = (Resolve-Path -LiteralPath $TargetPath).Path
     $safeLabel = ($Label -replace "[^A-Za-z0-9.-]", "-").Trim("-")
     Assert-Condition (-not [string]::IsNullOrWhiteSpace($safeLabel)) "Defender scan label is invalid."
     $result = Invoke-NativeChecked `
         -FilePath (Get-MpCmdRunPath) `
-        -Arguments @("-Scan", "-ScanType", "3", "-File", $TargetPath, "-DisableRemediation") `
+        -Arguments @("-Scan", "-ScanType", "3", "-File", $resolvedTarget, "-DisableRemediation") `
         -LogPath (Join-Path $EvidenceDirectory "defender-scan-$safeLabel.log") `
         -AllowedExitCodes @(0)
     Assert-Condition ($result.Output -match "(?im)^\s*Scan finished\.\s*$") "Defender did not report a completed scan for $Label."
-    Assert-Condition ($result.Output -match "(?im)\bfound no threats\.\s*$") "Defender did not report a clean scan for $Label."
+    $cleanTargetPattern = "(?im)^\s*Scanning\s+{0}\s+found no threats\.\s*$" -f [regex]::Escape($resolvedTarget)
+    Assert-Condition ($result.Output -match $cleanTargetPattern) "Defender did not report a clean scan for the exact target: $Label."
     Assert-Condition (Test-Path -LiteralPath $TargetPath) "Defender scan target disappeared: $Label."
     Write-Evidence "Defender exclusion-independent custom scan completed with no threats: $Label."
 }
@@ -337,7 +323,7 @@ if ($Mode -eq "ValidateDefender") {
     $probePath = "C:\FlowtakeDefenderProbe-$([guid]::NewGuid().ToString('N')).txt"
     try {
         [System.IO.File]::WriteAllText($probePath, "Harmless Flowtake Defender scan-path probe.")
-        Enable-DefenderForTarget -TargetPath $probePath
+        Prepare-DefenderScan -TargetPath $probePath
         Invoke-DefenderScan -TargetPath $probePath -Label "harmless PR probe"
         Assert-Condition (Test-Path -LiteralPath $probePath -PathType Leaf) "Defender probe file disappeared after scanning."
         Write-Evidence "PASS: exclusion-independent Defender custom scan validated on a harmless file; no Flowtake installer was downloaded or executed."
@@ -434,7 +420,7 @@ try {
     Assert-Condition ($signatureStatus -eq "NotSigned") "v1.6.0 MSI signing status drifted: $signatureStatus"
     Write-Evidence "MSI metadata matches product, version, publisher, product/upgrade codes, machine scope, and disclosed unsigned status."
 
-    Enable-DefenderForTarget -TargetPath $msiPath
+    Prepare-DefenderScan -TargetPath $msiPath
     Invoke-DefenderScan -TargetPath $msiPath -Label "published Flowtake MSI"
     Assert-Condition (Test-Path -LiteralPath $msiPath -PathType Leaf) "MSI disappeared after Defender scan."
     Assert-Condition ((Get-Item -LiteralPath $msiPath).Length -eq $ExpectedMsiSize) "MSI size changed after Defender scan."
@@ -507,7 +493,7 @@ try {
     Assert-Condition ($listResult.Output -match [regex]::Escape($ExpectedVersion)) "WinGet list did not correlate the installed version."
     Write-Evidence "Installation correlated across WinGet inventory, 64-bit ARP, MSI ProductCode, HKCU installer key, shortcuts, and executable metadata."
 
-    Enable-DefenderForTarget -TargetPath $ExpectedInstallDirectory
+    Prepare-DefenderScan -TargetPath $ExpectedInstallDirectory
     Invoke-DefenderScan -TargetPath $ExpectedInstallDirectory -Label "installed Flowtake directory"
     Invoke-DefenderScan -TargetPath $ExpectedExecutable -Label "installed Flowtake executable"
     Assert-Condition (Test-Path -LiteralPath $ExpectedExecutable -PathType Leaf) "Installed executable disappeared after Defender scan."
@@ -645,7 +631,7 @@ if ($null -ne $cleanupFailure) {
     throw $cleanupFailure
 }
 
-Write-Evidence "PASS: exact-manifest validation, published-asset integrity, active Defender custom scans, silent install, correlation, bounded startup, WinGet uninstall, and cleanup all passed."
+Write-Evidence "PASS: exact-manifest validation, published-asset integrity, exclusion-independent Defender on-demand scans, silent install, correlation, bounded startup, WinGet uninstall, and cleanup all passed."
 
 if ($env:GITHUB_STEP_SUMMARY) {
     @(
@@ -657,6 +643,6 @@ if ($env:GITHUB_STEP_SUMMARY) {
         "- ProductCode: ``$ExpectedProductCode``",
         "- Runner: ``$($env:ImageOS) $($env:ImageVersion)``",
         "- WinGet: ``$wingetVersion``",
-        "- Evidence: manifest validation, release digest/checksum, MSI metadata, active Defender custom scans, install/registry correlation, 10-second startup, uninstall, and cleanup"
+        "- Evidence: manifest validation, release digest/checksum, MSI metadata, exclusion-independent Defender on-demand scans, install/registry correlation, 10-second startup, uninstall, and cleanup"
     ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
 }

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -89,6 +89,12 @@ test("MSI execution is restricted to a manual main-branch dispatch", () => {
         validationJob.steps.find(step => step.name === "Validate immutable package metadata").run,
         /-Mode ValidateManifest/
     )
+    const defenderProbe = validationJob.steps.find(
+        step => step.name === "Verify exclusion-independent Defender custom scan"
+    )
+    assert.equal(defenderProbe.if, "github.event_name == 'pull_request'")
+    assert.equal(defenderProbe.shell, "pwsh")
+    assert.match(defenderProbe.run, /-Mode ValidateDefender/)
     assert.match(
         lifecycleJob.steps.find(step => step.name === "Prove the exact published MSI lifecycle").run,
         /-Mode Lifecycle/
@@ -168,38 +174,55 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     const checksumIndex = lifecycleScript.indexOf("Downloaded MSI SHA-256 mismatch")
     const firstInstallerExecution = lifecycleScript.indexOf('"install", "--manifest"')
     const msiDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $msiPath')
+    const scannedHashIndex = lifecycleScript.indexOf("$scannedMsiSha256 =")
+    const manifestHashCorrelationIndex = lifecycleScript.indexOf("$scannedMsiSha256 -eq $manifestInstallerSha256")
+    const installerHashOverrideIndex = lifecycleScript.indexOf('-Name "InstallerHashOverride"')
+    const preInstallHashIndex = lifecycleScript.indexOf("$preInstallMsiSha256 =")
     const installedDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $ExpectedInstallDirectory')
+    const executableDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $ExpectedExecutable')
     const launchIndex = lifecycleScript.indexOf("Start-Process -FilePath $ExpectedExecutable")
     const uninstallIndex = lifecycleScript.indexOf('"uninstall", "--manifest"')
     const finallyIndex = lifecycleScript.indexOf("finally {")
     const fallbackUninstallIndex = lifecycleScript.indexOf('"msiexec.exe"', finallyIndex)
 
     assert.ok(checksumIndex >= 0 && checksumIndex < msiDefenderIndex)
-    assert.ok(msiDefenderIndex < firstInstallerExecution)
+    assert.ok(msiDefenderIndex < scannedHashIndex)
+    assert.ok(scannedHashIndex < manifestHashCorrelationIndex)
+    assert.ok(manifestHashCorrelationIndex < installerHashOverrideIndex)
+    assert.ok(installerHashOverrideIndex < preInstallHashIndex)
+    assert.ok(preInstallHashIndex < firstInstallerExecution)
     assert.ok(firstInstallerExecution < installedDefenderIndex)
-    assert.ok(installedDefenderIndex < launchIndex)
+    assert.ok(installedDefenderIndex < executableDefenderIndex)
+    assert.ok(executableDefenderIndex < launchIndex)
     assert.ok(launchIndex < uninstallIndex)
     assert.ok(finallyIndex >= 0 && fallbackUninstallIndex > finallyIndex)
 
     for (const requiredBoundary of [
         'GITHUB_REF -eq "refs/heads/main"',
         'GITHUB_EVENT_NAME -eq "workflow_dispatch"',
+        'GITHUB_EVENT_NAME -eq "pull_request"',
         "Get-MpComputerStatus",
-        "Remove-MpPreference -ExclusionPath",
         "-DisableRealtimeMonitoring $false",
         "Update-MpSignature",
         "AntivirusEnabled",
         "RealTimeProtectionEnabled",
         "AMRunningMode",
-        "Start-MpScan -ScanType CustomScan",
-        "Get-MpThreatDetection",
-        "Get-MpThreatDetection -ErrorAction Stop",
-        '"-CheckExclusion", "-Path", $TargetPath',
-        "-AllowedExitCodes @(1)",
-        "is not excluded",
+        "AMEngineVersion",
+        '"-Scan", "-ScanType", "3", "-File", $TargetPath, "-DisableRemediation"',
+        "-AllowedExitCodes @(0)",
+        "Scan finished",
+        "found no threats",
+        "PASS: exclusion-independent Defender custom scan validated on a harmless file; no Flowtake installer was downloaded or executed",
         "Enable-DefenderForTarget -TargetPath $msiPath",
         "Enable-DefenderForTarget -TargetPath $ExpectedInstallDirectory",
-        "Assert-DefenderTargetNotExcluded -TargetPath $ExpectedExecutable",
+        "Invoke-DefenderScan -TargetPath $ExpectedExecutable",
+        "Defender-scanned MSI SHA-256 does not match the tracked manifest",
+        '-Name "InstallerHashOverride"',
+        "WinGet InstallerHashOverride is enabled",
+        "Scanned MSI size changed immediately before WinGet install",
+        "Scanned MSI changed immediately before WinGet install",
+        "Successfully verified installer hash",
+        "WinGet did not report successful installer hash verification",
         "WindowsInstaller",
         "$windowsInstaller.OpenDatabase($msiPath, 0)",
         "FinalReleaseComObject",
@@ -220,20 +243,16 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
 
     assert.doesNotMatch(
         lifecycleScript,
-        /continue-on-error|ignore-security-hash|LocalArchiveMalwareScanOverride|InstallerHashOverride|Win32_Product|\|\|\s*true|"--product-code"/
+        /continue-on-error|LocalArchiveMalwareScanOverride|Win32_Product|\|\|\s*true|"--product-code"|-ReturnHR|Start-MpScan|Get-MpThreatDetection|Remove-MpPreference|-CheckExclusion/
     )
-    assert.doesNotMatch(lifecycleScript, /Get-MpThreatDetection[^\r\n]*SilentlyContinue/)
+    assert.doesNotMatch(lifecycleScript, /["']--ignore-security-hash["']/)
     assert.doesNotMatch(lifecycleScript, /&\s+\$wingetPath\s+settings\s+--disable/)
     assert.doesNotMatch(lifecycleScript, /InvokeMember\("OpenDatabase"/)
-    assert.equal(
-        lifecycleScript.match(/= @\(Get-CoveringDefenderExclusions -TargetPath \$TargetPath\)/g)?.length,
-        2
-    )
 
-    const exclusionCheck = lifecycleScript.slice(
-        lifecycleScript.indexOf("function Assert-DefenderTargetNotExcluded"),
-        lifecycleScript.indexOf("function Enable-DefenderForTarget")
+    const defenderScan = lifecycleScript.slice(
+        lifecycleScript.indexOf("function Invoke-DefenderScan"),
+        lifecycleScript.indexOf("function Write-FailureLogTails")
     )
-    assert.match(exclusionCheck, /-AllowedExitCodes @\(1\)/)
-    assert.doesNotMatch(exclusionCheck, /-AllowedExitCodes @\([^)]*0/)
+    assert.match(defenderScan, /-AllowedExitCodes @\(0\)/)
+    assert.doesNotMatch(defenderScan, /-AllowedExitCodes @\([^)]*[1-9]/)
 })

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -202,19 +202,20 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
         'GITHUB_EVENT_NAME -eq "workflow_dispatch"',
         'GITHUB_EVENT_NAME -eq "pull_request"',
         "Get-MpComputerStatus",
-        "-DisableRealtimeMonitoring $false",
         "Update-MpSignature",
         "AntivirusEnabled",
-        "RealTimeProtectionEnabled",
         "AMRunningMode",
         "AMEngineVersion",
-        '"-Scan", "-ScanType", "3", "-File", $TargetPath, "-DisableRemediation"',
+        "RealTimeProtectionEnabled",
+        "observed only, not used as a custom-scan prerequisite or claimed as installer-write coverage",
+        '"-Scan", "-ScanType", "3", "-File", $resolvedTarget, "-DisableRemediation"',
         "-AllowedExitCodes @(0)",
         "Scan finished",
+        '[regex]::Escape($resolvedTarget)',
         "found no threats",
         "PASS: exclusion-independent Defender custom scan validated on a harmless file; no Flowtake installer was downloaded or executed",
-        "Enable-DefenderForTarget -TargetPath $msiPath",
-        "Enable-DefenderForTarget -TargetPath $ExpectedInstallDirectory",
+        "Prepare-DefenderScan -TargetPath $msiPath",
+        "Prepare-DefenderScan -TargetPath $ExpectedInstallDirectory",
         "Invoke-DefenderScan -TargetPath $ExpectedExecutable",
         "Defender-scanned MSI SHA-256 does not match the tracked manifest",
         '-Name "InstallerHashOverride"',
@@ -243,7 +244,7 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
 
     assert.doesNotMatch(
         lifecycleScript,
-        /continue-on-error|LocalArchiveMalwareScanOverride|Win32_Product|\|\|\s*true|"--product-code"|-ReturnHR|Start-MpScan|Get-MpThreatDetection|Remove-MpPreference|-CheckExclusion/
+        /continue-on-error|LocalArchiveMalwareScanOverride|Win32_Product|\|\|\s*true|"--product-code"|-ReturnHR|Start-MpScan|Get-MpThreatDetection|Remove-MpPreference|Set-MpPreference|Get-MpPreference|-CheckExclusion/
     )
     assert.doesNotMatch(lifecycleScript, /["']--ignore-security-hash["']/)
     assert.doesNotMatch(lifecycleScript, /&\s+\$wingetPath\s+settings\s+--disable/)

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -172,6 +172,8 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     }
 
     const checksumIndex = lifecycleScript.indexOf("Downloaded MSI SHA-256 mismatch")
+    const preDownloadDefenderIndex = lifecycleScript.indexOf('Prepare-DefenderScan -TargetPath $smokeRoot')
+    const firstFlowtakeDownloadIndex = lifecycleScript.indexOf("Invoke-WebRequest -UseBasicParsing -MaximumRetryCount")
     const firstInstallerExecution = lifecycleScript.indexOf('"install", "--manifest"')
     const msiDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $msiPath')
     const scannedHashIndex = lifecycleScript.indexOf("$scannedMsiSha256 =")
@@ -185,7 +187,9 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     const finallyIndex = lifecycleScript.indexOf("finally {")
     const fallbackUninstallIndex = lifecycleScript.indexOf('"msiexec.exe"', finallyIndex)
 
-    assert.ok(checksumIndex >= 0 && checksumIndex < msiDefenderIndex)
+    assert.ok(preDownloadDefenderIndex >= 0 && preDownloadDefenderIndex < firstFlowtakeDownloadIndex)
+    assert.ok(firstFlowtakeDownloadIndex < checksumIndex)
+    assert.ok(checksumIndex < msiDefenderIndex)
     assert.ok(msiDefenderIndex < scannedHashIndex)
     assert.ok(scannedHashIndex < manifestHashCorrelationIndex)
     assert.ok(manifestHashCorrelationIndex < installerHashOverrideIndex)
@@ -203,6 +207,16 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
         'GITHUB_EVENT_NAME -eq "pull_request"',
         "Get-MpComputerStatus",
         "Update-MpSignature",
+        "function Test-DefenderSignatureFresh",
+        "[uint64]$ageProperty.Value",
+        "AddHours(-48)",
+        "AddMinutes(5)",
+        "function Get-DefenderStatusWithRetry",
+        "for ($attempt = 1; $attempt -le 3; $attempt++)",
+        "Update-MpSignature -UpdateSource MMPC -ErrorAction Stop",
+        '"-SignatureUpdate", "-MMPC"',
+        "for ($poll = 1; $poll -le 6; $poll++)",
+        "Defender signatures are stale or missing after bounded update attempts",
         "AntivirusEnabled",
         "AMRunningMode",
         "AMEngineVersion",
@@ -247,6 +261,7 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
         /continue-on-error|LocalArchiveMalwareScanOverride|Win32_Product|\|\|\s*true|"--product-code"|-ReturnHR|Start-MpScan|Get-MpThreatDetection|Remove-MpPreference|Set-MpPreference|Get-MpPreference|-CheckExclusion/
     )
     assert.doesNotMatch(lifecycleScript, /["']--ignore-security-hash["']/)
+    assert.doesNotMatch(lifecycleScript, /while\s*\(/)
     assert.doesNotMatch(lifecycleScript, /&\s+\$wingetPath\s+settings\s+--disable/)
     assert.doesNotMatch(lifecycleScript, /InvokeMember\("OpenDatabase"/)
 


### PR DESCRIPTION
## Summary

- replace the hosted-runner exclusion-removal workaround with Microsoft's documented exclusion-independent Defender custom scan
- accept only Defender exit code 0 and require explicit completed/clean output while retaining the full scan log
- bind the Defender-scanned MSI digest to the tracked manifest, require WinGet hash overrides to be off, and require WinGet's own successful installer-hash evidence
- scan both the installed directory and exact executable before launch
- add a harmless pull-request-only Defender probe; the Flowtake MSI lifecycle remains manual and main-only

## Why

The first main run failed safely because PowerShell scalarized an empty exclusion collection. The second failed safely because Defender's engine-effective state still treated `C:\` as excluded after the visible preference entry was removed. Both stopped before any Flowtake MSI installation or execution:

- https://github.com/JNX03/Flowtake/actions/runs/29498171553
- https://github.com/JNX03/Flowtake/actions/runs/29499175463

GitHub's Windows image configures broad `C:\` and `D:\` exclusions. Microsoft documents that `MpCmdRun.exe -Scan -ScanType 3 -File <target> -DisableRemediation` ignores file exclusions, scans archives, applies no remediation, and returns detections in command output. This patch uses that supported path without mutating the runner's exclusion list.

## Security boundaries

- no Flowtake MSI is downloaded or executed on pull requests
- every Defender nonzero result, invocation failure, ambiguous output, or job timeout fails closed
- `-ReturnHR`, exclusion mutation, `--ignore-security-hash`, and security-hash overrides are not allowed
- the scanned release content is rehashed after scanning and immediately before WinGet; pinned WinGet must verify its independently downloaded copy against the same manifest SHA-256 before execution
- the proof claims cryptographic content identity, not physical cache-file identity or full real-time coverage of every installer write

## Validation

- `npm test` — 147/147 pass
- `npx eslint test/windowsMsiLifecycle.test.js` — pass
- focused lifecycle tests — 4/4 pass
- Windows PowerShell syntax parse — pass
- `winget validate` with pinned local v1.29.280 — pass
- direct exclusion-independent Defender scans of a local file and directory — exit 0 with completed/no-threat output
- independent correctness and security reviews — GO, no blocking findings

## Primary references

- https://learn.microsoft.com/en-us/defender-endpoint/command-line-arguments-microsoft-defender-antivirus
- https://github.com/actions/runner-images/blob/win25-vs2026/20260714.173/images/windows/scripts/build/Configure-WindowsDefender.ps1
- https://github.com/microsoft/winget-cli/blob/v1.29.280/src/AppInstallerCLICore/Workflows/DownloadFlow.cpp