### PR TITLE
ci: correct MSI lifecycle assertions

### DIFF
--- a/scripts/test-windows-msi-lifecycle.ps1
+++ b/scripts/test-windows-msi-lifecycle.ps1
@@ -31,7 +31,10 @@ $ExpectedMsiSize = 92131328L
 $ExpectedChecksumsSha256 = "34DFA1267068590F277E5A172E5538159FF809A94D364812CAF3DA6CFBCB3B16"
 $ExpectedExecutable = "C:\Program Files\Flowtake\flowtake.exe"
 $ExpectedInstallDirectory = "C:\Program Files\Flowtake"
-$ExpectedFileVersion = "1.6.0.0"
+$ExpectedFileVersion = $ExpectedVersion
+$ExpectedDesktopShortcut = Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::CommonDesktopDirectory)) "Flowtake.lnk"
+$ExpectedStartMenuShortcut = Join-Path ([Environment]::GetFolderPath([Environment+SpecialFolder]::CommonPrograms)) "Flowtake\Flowtake.lnk"
+$ExpectedUninstallShortcut = Join-Path $ExpectedInstallDirectory "Uninstall Flowtake.lnk"
 $ExpectedVendorKey = "HKCU:\Software\Jnx03\Flowtake"
 $ExpectedUninstallKey = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$ExpectedProductCode"
 $UnexpectedWowUninstallKey = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$ExpectedProductCode"
@@ -105,6 +108,46 @@ function Invoke-NativeChecked {
         ExitCode = $exitCode
         Output = ($output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
     }
+}
+
+function Invoke-MsiUninstallChecked {
+    param(
+        [Parameter(Mandatory = $true)][string]$ProductCode,
+        [Parameter(Mandatory = $true)][string]$LogPath,
+        [int[]]$AllowedExitCodes = @(0, 1605)
+    )
+
+    $msiExecPath = Join-Path $env:SystemRoot "System32\msiexec.exe"
+    Assert-Condition (Test-Path -LiteralPath $msiExecPath -PathType Leaf) "The trusted System32 msiexec.exe is unavailable."
+    $arguments = @("/x", $ProductCode, "/qn", "/norestart", "/L*V!", $LogPath)
+    $rendered = $arguments | ForEach-Object {
+        if ($_ -match "\s") { '"{0}"' -f $_ } else { $_ }
+    }
+    Write-Evidence ("Running and waiting: {0} {1}" -f $msiExecPath, ($rendered -join " "))
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $msiExecPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    foreach ($argument in $arguments) {
+        [void]$startInfo.ArgumentList.Add($argument)
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    try {
+        $process.StartInfo = $startInfo
+        Assert-Condition ($process.Start()) "Could not start msiexec.exe."
+        Assert-Condition ($process.WaitForExit(120000)) "msiexec.exe did not exit within 120 seconds."
+        $exitCode = $process.ExitCode
+    }
+    finally {
+        $process.Dispose()
+    }
+
+    if ($AllowedExitCodes -notcontains $exitCode) {
+        throw "msiexec.exe exited with code $exitCode."
+    }
+    Write-Evidence "msiexec.exe completed with exit code $exitCode after the uninstall process exited."
 }
 
 function Release-ComObject {
@@ -194,8 +237,8 @@ function Assert-CleanInstallState {
     Assert-Condition (@(Get-FlowtakeProcesses).Count -eq 0) "A Flowtake process remains $phase."
 
     $shortcuts = @(
-        (Join-Path $env:USERPROFILE "Desktop\Flowtake.lnk"),
-        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Flowtake\Flowtake.lnk")
+        $ExpectedDesktopShortcut,
+        $ExpectedStartMenuShortcut
     )
     Assert-Condition (-not (Test-Path -LiteralPath $ExpectedVendorKey)) "Installer-owned HKCU vendor key exists $phase."
     foreach ($shortcut in $shortcuts) {
@@ -205,6 +248,30 @@ function Assert-CleanInstallState {
     if ($AfterUninstall) {
         Write-Evidence "Installer-owned ARP, HKCU, shortcut, file, directory, and process state is absent after uninstall."
     }
+}
+
+function Wait-CleanInstallState {
+    param(
+        [int]$Attempts = 30,
+        [int]$DelaySeconds = 1
+    )
+
+    $lastFailure = $null
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            Assert-CleanInstallState -AfterUninstall
+            return
+        }
+        catch {
+            $lastFailure = $_
+            if ($attempt -lt $Attempts) {
+                Write-Evidence "Install state is not clean after uninstall attempt $attempt/$Attempts; waiting $DelaySeconds second(s): $($_.Exception.Message)"
+                Start-Sleep -Seconds $DelaySeconds
+            }
+        }
+    }
+
+    throw "Install state did not become clean after $Attempts bounded checks: $($lastFailure.Exception.Message)"
 }
 
 function Get-MpCmdRunPath {
@@ -574,9 +641,9 @@ try {
     Assert-Condition ($fileVersion -eq $ExpectedFileVersion) "Installed executable version mismatch: $fileVersion"
 
     $requiredShortcuts = @(
-        (Join-Path $env:USERPROFILE "Desktop\Flowtake.lnk"),
-        (Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Flowtake\Flowtake.lnk"),
-        (Join-Path $ExpectedInstallDirectory "Uninstall Flowtake.lnk")
+        $ExpectedDesktopShortcut,
+        $ExpectedStartMenuShortcut,
+        $ExpectedUninstallShortcut
     )
     foreach ($shortcut in $requiredShortcuts) {
         Assert-Condition (Test-Path -LiteralPath $shortcut -PathType Leaf) "Expected installer shortcut is missing: $shortcut"
@@ -616,8 +683,7 @@ try {
         "--verbose-logs", "--log", $wingetUninstallLog
     ) -LogPath (Join-Path $EvidenceDirectory "winget-uninstall-command.log") | Out-Null
     $installObserved = $false
-    Start-Sleep -Seconds 3
-    Assert-CleanInstallState -AfterUninstall
+    Wait-CleanInstallState
     Write-Evidence "WinGet manifest uninstall removed the MSI product, installer-owned registry state, shortcuts, files, and process."
 }
 catch {
@@ -650,9 +716,10 @@ finally {
             (Test-Path -LiteralPath $ExpectedInstallDirectory) -or
             (Test-Path -LiteralPath $ExpectedVendorKey)
         ) {
-            Invoke-NativeChecked -FilePath "msiexec.exe" -Arguments @(
-                "/x", $ExpectedProductCode, "/qn", "/norestart", "/L*V", $fallbackUninstallLog
-            ) -LogPath (Join-Path $EvidenceDirectory "msi-fallback-uninstall-command.log") -AllowedExitCodes @(0, 1605, 3010) | Out-Null
+            Invoke-MsiUninstallChecked `
+                -ProductCode $ExpectedProductCode `
+                -LogPath $fallbackUninstallLog `
+                -AllowedExitCodes @(0, 1605)
         }
     }
     catch {
@@ -698,7 +765,7 @@ finally {
     }
 
     try {
-        Assert-CleanInstallState -AfterUninstall
+        Wait-CleanInstallState
     }
     catch {
         $cleanupErrors.Add("final install-state assertion: $($_.Exception.Message)")

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -184,8 +184,10 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     const executableDefenderIndex = lifecycleScript.indexOf('Invoke-DefenderScan -TargetPath $ExpectedExecutable')
     const launchIndex = lifecycleScript.indexOf("Start-Process -FilePath $ExpectedExecutable")
     const uninstallIndex = lifecycleScript.indexOf('"uninstall", "--manifest"')
-    const finallyIndex = lifecycleScript.indexOf("finally {")
-    const fallbackUninstallIndex = lifecycleScript.indexOf('"msiexec.exe"', finallyIndex)
+    const outerCatchIndex = lifecycleScript.indexOf("$primaryFailure = $_")
+    const finallyIndex = lifecycleScript.indexOf("finally {", outerCatchIndex)
+    const fallbackUninstallIndex = lifecycleScript.indexOf("Invoke-MsiUninstallChecked", finallyIndex)
+    const finalCleanStateIndex = lifecycleScript.lastIndexOf("Wait-CleanInstallState")
 
     assert.ok(preDownloadDefenderIndex >= 0 && preDownloadDefenderIndex < firstFlowtakeDownloadIndex)
     assert.ok(firstFlowtakeDownloadIndex < checksumIndex)
@@ -199,7 +201,9 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     assert.ok(installedDefenderIndex < executableDefenderIndex)
     assert.ok(executableDefenderIndex < launchIndex)
     assert.ok(launchIndex < uninstallIndex)
-    assert.ok(finallyIndex >= 0 && fallbackUninstallIndex > finallyIndex)
+    assert.ok(outerCatchIndex > uninstallIndex)
+    assert.ok(finallyIndex > outerCatchIndex && fallbackUninstallIndex > finallyIndex)
+    assert.ok(finalCleanStateIndex > fallbackUninstallIndex)
 
     for (const requiredBoundary of [
         'GITHUB_REF -eq "refs/heads/main"',
@@ -243,10 +247,30 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
         "FinalReleaseComObject",
         'InvokeMember("Close", "InvokeMethod"',
         "DisplayVersion",
+        "$ExpectedFileVersion = $ExpectedVersion",
+        "Assert-Condition ($fileVersion -eq $ExpectedFileVersion)",
+        "[Environment+SpecialFolder]::CommonDesktopDirectory",
+        "[Environment+SpecialFolder]::CommonPrograms",
+        "$ExpectedUninstallShortcut = Join-Path $ExpectedInstallDirectory",
         "UninstallString",
         "WinGet list did not correlate",
         "Start-Sleep -Seconds 10",
         "Assert-CleanInstallState -AfterUninstall",
+        "function Invoke-MsiUninstallChecked",
+        'Join-Path $env:SystemRoot "System32\\msiexec.exe"',
+        "The trusted System32 msiexec.exe is unavailable",
+        "[System.Diagnostics.ProcessStartInfo]::new()",
+        "$startInfo.FileName = $msiExecPath",
+        "$startInfo.UseShellExecute = $false",
+        "$startInfo.ArgumentList.Add($argument)",
+        "$process.WaitForExit(120000)",
+        "msiexec.exe did not exit within 120 seconds",
+        "$exitCode = $process.ExitCode",
+        "$AllowedExitCodes -notcontains $exitCode",
+        "msiexec.exe completed with exit code",
+        "function Wait-CleanInstallState",
+        "for ($attempt = 1; $attempt -le $Attempts; $attempt++)",
+        "Install state did not become clean after $Attempts bounded checks",
         '-Arguments @("settings", "--disable", "LocalManifestFiles")',
         'winget-settings-after-disable.log',
         "Could not inspect flowtake process",
@@ -264,6 +288,37 @@ test("lifecycle script fails closed around integrity, Defender, install, and cle
     assert.doesNotMatch(lifecycleScript, /while\s*\(/)
     assert.doesNotMatch(lifecycleScript, /&\s+\$wingetPath\s+settings\s+--disable/)
     assert.doesNotMatch(lifecycleScript, /InvokeMember\("OpenDatabase"/)
+    assert.doesNotMatch(lifecycleScript, /Invoke-NativeChecked\s+-FilePath\s+["']msiexec\.exe["']/)
+    assert.doesNotMatch(lifecycleScript, /\$ExpectedFileVersion\s*=\s*["'][^"']+["']/)
+
+    const msiUninstallHelper = lifecycleScript.slice(
+        lifecycleScript.indexOf("function Invoke-MsiUninstallChecked"),
+        lifecycleScript.indexOf("function Release-ComObject")
+    )
+    assert.doesNotMatch(msiUninstallHelper, /3010/)
+
+    const fallbackInvocation = lifecycleScript.slice(fallbackUninstallIndex, finalCleanStateIndex)
+    assert.match(fallbackInvocation, /-AllowedExitCodes @\(0, 1605\)/)
+    assert.doesNotMatch(fallbackInvocation, /3010/)
+
+    const cleanStateAssertion = lifecycleScript.slice(
+        lifecycleScript.indexOf("function Assert-CleanInstallState"),
+        lifecycleScript.indexOf("function Wait-CleanInstallState")
+    )
+    assert.match(cleanStateAssertion, /\$ExpectedDesktopShortcut,\r?\n\s*\$ExpectedStartMenuShortcut/)
+
+    const installedShortcutAssertion = lifecycleScript.slice(
+        lifecycleScript.indexOf("$requiredShortcuts = @("),
+        lifecycleScript.indexOf("foreach ($shortcut in $requiredShortcuts)")
+    )
+    assert.match(
+        installedShortcutAssertion,
+        /\$ExpectedDesktopShortcut,\r?\n\s*\$ExpectedStartMenuShortcut,\r?\n\s*\$ExpectedUninstallShortcut/
+    )
+    assert.doesNotMatch(
+        lifecycleScript,
+        /\$env:USERPROFILE\s+"Desktop\\Flowtake\.lnk"|\$env:APPDATA\s+"Microsoft\\Windows\\Start Menu\\Programs\\Flowtake\\Flowtake\.lnk"/
+    )
 
     const defenderScan = lifecycleScript.slice(
         lifecycleScript.indexOf("function Invoke-DefenderScan"),


### PR DESCRIPTION
## What changed
- compare the installed executable's exact three-part FileVersion to the pinned release version
- wait on trusted System32 msiexec and validate its real exit code during fallback cleanup
- require bounded full-state cleanup convergence after normal and fallback uninstall
- verify ALLUSERS shortcuts in Common Desktop and Common Programs
- harden static tests around these fail-closed boundaries

## Why
Exact-main lifecycle run 29502583222 passed Defender scanning, WinGet hash verification, and installation, then exposed two proof defects: a four-part FileVersion assumption and an asynchronous GUI msiexec invocation. Its MSI log also proved the shortcuts are machine-wide, not per-user.

## Validation
- npm test: 147/147
- scoped ESLint: pass
- PowerShell parse: pass
- git diff --check: pass
- local WinGet manifest validation: pass; no Flowtake installer downloaded or executed
- three independent read-only reviews: GO

The exact-head PR probe and a new exact-main lifecycle dispatch remain required before upstream WinGet submission.