### PR TITLE
Website: add truthful storyboard proof

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -18,6 +18,7 @@ import { createLeadPayload, describeLeadFailure, sendEvent, submitLead } from ".
 const CONTACT_EMAIL = "jnxstartup@gmail.com";
 const RELEASE_VERSION = "1.6.0";
 const RELEASE_URL = `https://github.com/JNX03/Flowtake/releases/tag/v${RELEASE_VERSION}`;
+const PUBLIC_STORYBOARD_URL = "https://github.com/JNX03/Flowtake/discussions/169";
 const assetUrl = (name) => `${import.meta.env.BASE_URL}assets/${name}`;
 
 const workflow = [
@@ -54,6 +55,51 @@ const deliverables = [
   "One 16:9 master plus one social cutdown per demo",
   "Private review link and one focused revision round",
   "First cut within 3 business days of a usable brief and capture",
+];
+
+const storyboardBeats = [
+  {
+    number: "01",
+    time: "0–3s",
+    title: "Open the recorder",
+    caption: "Record the build once.",
+    plannedEvidence: "Flowtake brand and recorder shell",
+  },
+  {
+    number: "02",
+    time: "3–10s",
+    title: "Select safe sources",
+    caption: "Capture the IDE, terminal, browser, or desktop.",
+    plannedEvidence: "Source controls and recording state",
+  },
+  {
+    number: "03",
+    time: "10–18s",
+    title: "Open the saved take",
+    caption: "Keep the take editable.",
+    plannedEvidence: "Project handoff and timeline",
+  },
+  {
+    number: "04",
+    time: "18–28s",
+    title: "Shape one motion beat",
+    caption: "Shape the motion around the explanation.",
+    plannedEvidence: "Preview, properties, and timeline response",
+  },
+  {
+    number: "05",
+    time: "28–36s",
+    title: "Export locally",
+    caption: "Export locally with FFmpeg.",
+    plannedEvidence: "Export controls and a locally rendered MP4",
+  },
+  {
+    number: "06",
+    time: "36–42s",
+    title: "Hold on the end card",
+    caption: "Free. Local-first. MIT licensed.",
+    plannedEvidence: "Public repository and download action",
+  },
 ];
 
 const faqs = [
@@ -286,19 +332,46 @@ export function App() {
           </ol>
         </section>
 
-        <section className="section proof-section proof-section-copy-only">
+        <section className="section proof-section" aria-labelledby="storyboard-proof-title">
           <div className="proof-copy">
-            <p className="kicker">Why the capture matters</p>
-            <h2>Technical demos break when every scene is flattened too early.</h2>
+            <p className="kicker">Pre-production example · Flowtake v1.6.0</p>
+            <h2 id="storyboard-proof-title">See the six beats before the footage.</h2>
             <p>
-              Flowtake keeps the real product flow visible while the production pass handles framing, pace, captions, cursor treatment, and handoffs.
+              This capture plan maps a real recorder, editor, and export workflow in the published app. It shows how one technical release becomes a focused 42-second story before production starts.
             </p>
-            <ul className="check-list">
-              <li><CheckIcon /> Show the command and the result in one coherent story.</li>
-              <li><CheckIcon /> Reframe a scene without asking engineering to record the whole launch again.</li>
-              <li><CheckIcon /> Export a master and social cutdown from the same approved narrative.</li>
-            </ul>
+            <p className="proof-boundary" role="note">
+              <strong>Pre-production example—not customer work or a finished video.</strong>
+              Capture is still pending a privacy-safe isolated session, so this page makes no footage or delivery claim.
+            </p>
+            <a
+              className="button button-quiet proof-clinic-action"
+              href={PUBLIC_STORYBOARD_URL}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => track("github_clicked")}
+            >
+              Get a public six-beat storyboard
+              <ArrowRightIcon aria-hidden="true" />
+            </a>
+            <p className="proof-clinic-note">
+              Through July 23, 2026, up to the first three maintainers with a complete public developer-tool workflow can receive a no-obligation storyboard. GitHub sign-in is required; there is no separate Flowtake signup, footage request, or payment.
+            </p>
           </div>
+          <ol className="storyboard-list" aria-label="Flowtake v1.6.0 pre-production storyboard">
+            {storyboardBeats.map(({ number, time, title, caption, plannedEvidence }) => (
+              <li key={number} className="storyboard-beat">
+                <div className="storyboard-beat-meta">
+                  <span className="storyboard-number">{number}</span>
+                  <span className="storyboard-time">{time}</span>
+                </div>
+                <div>
+                  <h3>{title}</h3>
+                  <p className="storyboard-caption">“{caption}”</p>
+                  <p className="storyboard-evidence">Planned evidence: {plannedEvidence}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
         </section>
 
         <section className="section founding-section" id="founding-plan">
@@ -381,7 +454,7 @@ export function App() {
               <h3>Privacy and business contact</h3>
               <p>Lead requests send your name, work email, company, optional public URL and target date, release story, and consent record to Flowtake's HTTPS intake service so we can assess and reply. Lead records are encrypted at rest and declined or inactive leads are deleted within 90 days.</p>
               <p>This page also sends cookie-free aggregate counts for a short allowlist of actions. The service stores only UTC day, action name, and count - not event details, page URLs, device identifiers, or form content. IP addresses are used in server memory for abuse-rate limiting and are not written to lead or event files. No nonessential cookies are used.</p>
-              <p>Flowtake is operated from Thailand. Formal contracting identity and address will be disclosed before payment. Contact <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>; expected reply time is two business days. Thailand PDPA and customer-specific data terms will be reviewed before private footage is accepted.</p>
+              <p>Flowtake is operated from Thailand. Formal contracting identity and address will be disclosed before payment. Contact <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Direct email response is still being verified for the founding pilot; the <a href={PUBLIC_STORYBOARD_URL} target="_blank" rel="noreferrer">public storyboard clinic</a> is the currently reply-capable route. Thailand PDPA and customer-specific data terms will be reviewed before private footage is accepted.</p>
             </article>
           </div>
           <p className="trust-status">Effective pilot disclosure: July 16, 2026. Checkout remains disabled until the secure review path and final contracting details are verified.</p>
@@ -446,7 +519,7 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
   const [status, setStatus] = useState("idle");
   const [error, setError] = useState("");
   const [briefText, setBriefText] = useState("");
-  const [briefSubject, setBriefSubject] = useState("");
+  const [leadReference, setLeadReference] = useState("");
   const [fallbackAllowed, setFallbackAllowed] = useState(false);
   const firstInput = useRef(null);
   const dialogRef = useRef(null);
@@ -492,7 +565,7 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
     event.preventDefault();
     setError("");
     setBriefText("");
-    setBriefSubject("");
+    setLeadReference("");
     setFallbackAllowed(false);
     setStatus("sending");
 
@@ -515,10 +588,10 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
       payload.story,
     ].join("\n");
     setBriefText(text);
-    setBriefSubject(`Flowtake Release Studio brief - ${payload.company}`);
 
     try {
-      await submitLead(payload);
+      const result = await submitLead(payload);
+      setLeadReference(result.id);
       track("brief_submitted");
       setStatus("submitted");
     } catch (submissionError) {
@@ -529,13 +602,6 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
     }
   };
 
-  const openEmailFallback = () => {
-    if (!fallbackAllowed || !briefText) return;
-    track("brief_handoff_started");
-    window.location.href = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(briefSubject)}&body=${encodeURIComponent(briefText)}`;
-    setStatus("email");
-  };
-
   const copyBrief = async () => {
     if (!briefText || (status === "idle" && !fallbackAllowed)) return;
     try {
@@ -544,7 +610,7 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
       setStatus("copied");
       track("brief_copied");
     } catch {
-      setError(`Clipboard access failed. Select the brief manually or email ${CONTACT_EMAIL}.`);
+      setError("Clipboard access failed. Try again or use the public storyboard clinic.");
     }
   };
 
@@ -552,15 +618,13 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
     if (status === "submitted") {
       return {
         title: "Brief received.",
-        body: "We’ll review the workflow and reply with the next concrete step. No payment was taken.",
+        body: "Your encrypted request is stored for review. Save the reference below; no payment was taken.",
       };
     }
-    if (["email", "copied"].includes(status)) {
+    if (status === "copied") {
       return {
-        title: status === "copied" ? "Brief copied." : "Email draft opened.",
-        body: status === "copied"
-          ? `Paste it into an email to ${CONTACT_EMAIL}. Nothing was submitted automatically.`
-          : `Send the draft from your email app to complete the request. Nothing was submitted automatically.`,
+        title: "Private brief copied.",
+        body: "Keep the copied version private. Nothing was submitted automatically.",
       };
     }
     return null;
@@ -586,6 +650,12 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
             <CheckIcon aria-hidden="true" />
             <h3>{outcome.title}</h3>
             <p>{outcome.body}</p>
+            {leadReference && (
+              <p className="lead-reference">
+                <span>Private request reference — do not post publicly</span>
+                <code>{leadReference}</code>
+              </p>
+            )}
             {error && <p className="form-error" role="alert">{error}</p>}
             {briefText && status !== "submitted" && (
               <button className="button button-quiet" type="button" onClick={copyBrief}>
@@ -649,10 +719,23 @@ export function BriefDialog({ onClose, restoreFocusTo, privacyHref = "#privacy" 
             </div>
             {error && <p className="form-error" role="alert">{error}</p>}
             {error && fallbackAllowed && briefText && (
-              <div className="form-fallback-actions">
-                <button className="button button-quiet" type="button" onClick={openEmailFallback}>Open email draft instead</button>
-                <button className="text-link" type="button" onClick={copyBrief}>Copy brief</button>
-              </div>
+              <>
+                <p className="form-safety">
+                  The clinic requires GitHub sign-in and is public. Write a separate public-only summary with only a public project URL and workflow—never paste your email, this private brief, credentials, or customer data there.
+                </p>
+                <div className="form-fallback-actions">
+                  <a
+                    className="button button-quiet"
+                    href={PUBLIC_STORYBOARD_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => track("github_clicked")}
+                  >
+                    Open public clinic with a separate public-only summary
+                  </a>
+                  <button className="text-link" type="button" onClick={copyBrief}>Copy private brief</button>
+                </div>
+              </>
             )}
             <p className="form-status" aria-live="polite">{status === "sending" ? "Sending your brief..." : ""}</p>
             <button className="button button-primary form-submit" type="submit" disabled={status === "sending"}>

--- a/website/src/intake.js
+++ b/website/src/intake.js
@@ -10,7 +10,6 @@ const EVENT_NAMES = new Set([
   "github_clicked",
   "download_clicked",
   "brief_submitted",
-  "brief_handoff_started",
   "brief_copied",
 ]);
 
@@ -36,12 +35,12 @@ export function describeLeadFailure(error) {
   if (error?.status === 429) {
     return {
       fallbackAllowed: true,
-      message: "Too many attempts from this network. Wait 15 minutes or use email instead.",
+      message: "Too many attempts from this network. Wait 15 minutes or use the safe options below.",
     };
   }
   return {
     fallbackAllowed: true,
-    message: "We couldn't confirm that your brief was received. Try again or use email instead.",
+    message: "We couldn't confirm that your brief was received. Try again or use the safe options below.",
   };
 }
 
@@ -128,7 +127,12 @@ export async function submitLead(
       }
       // A malformed success response must never be shown as received.
     }
-    if (response.status !== 201 || result?.accepted !== true) {
+    if (
+      response.status !== 201
+      || result?.accepted !== true
+      || typeof result.id !== "string"
+      || result.id.trim() === ""
+    ) {
       throw new LeadSubmissionError("request_not_accepted", response.status);
     }
     return result;

--- a/website/src/intake.test.mjs
+++ b/website/src/intake.test.mjs
@@ -96,6 +96,10 @@ test("lead submission requires an explicit 201 accepted response", async () => {
     submitLead(payload, { fetchImpl: async () => ({ status: 201, json: async () => { throw new Error("bad json"); } }) }),
     (error) => error instanceof LeadSubmissionError && error.status === 201,
   );
+  await assert.rejects(
+    submitLead(payload, { fetchImpl: async () => ({ status: 201, json: async () => ({ accepted: true }) }) }),
+    (error) => error instanceof LeadSubmissionError && error.status === 201,
+  );
 });
 
 test("lead submission aborts a stalled request within the configured deadline", async () => {
@@ -133,14 +137,20 @@ test("lead submission aborts a stalled request within the configured deadline", 
   );
 });
 
-test("only recoverable transport and rate failures expose email or copy fallback", () => {
+test("only recoverable transport and rate failures expose a public or copy fallback", () => {
   assert.deepEqual(describeLeadFailure({ status: 400 }), {
     fallbackAllowed: false,
     message: "Please check the entered fields and try again.",
   });
   assert.equal(describeLeadFailure({ status: 413 }).fallbackAllowed, false);
-  assert.equal(describeLeadFailure({ status: 429 }).fallbackAllowed, true);
-  assert.equal(describeLeadFailure({ status: 500 }).fallbackAllowed, true);
+  assert.deepEqual(describeLeadFailure({ status: 429 }), {
+    fallbackAllowed: true,
+    message: "Too many attempts from this network. Wait 15 minutes or use the safe options below.",
+  });
+  assert.deepEqual(describeLeadFailure({ status: 500 }), {
+    fallbackAllowed: true,
+    message: "We couldn't confirm that your brief was received. Try again or use the safe options below.",
+  });
   assert.equal(describeLeadFailure({ status: 0 }).fallbackAllowed, true);
 });
 
@@ -149,15 +159,21 @@ test("the request form exposes privacy-safe limits and explicit failure fallback
   for (const required of [
     'name="website"',
     'maxLength="2000"',
-    "Open email draft instead",
-    "Copy brief",
+    "Open public clinic with a separate public-only summary",
+    "Copy private brief",
     "Try again",
     "stores only UTC day, action name, and count",
     "setFallbackAllowed(failure.fallbackAllowed)",
     "error && fallbackAllowed && briefText",
+    "Private request reference — do not post publicly",
+    "setLeadReference(result.id)",
+    "Direct email response is still being verified",
   ]) {
     assert.equal(source.includes(required), true, `missing ${required}`);
   }
+  assert.equal(source.includes("Open email draft instead"), false);
+  assert.equal(source.includes("expected reply time is two business days"), false);
+  assert.equal(source.includes("reply with the next concrete step"), false);
   assert.equal(source.includes("sendBeacon"), false);
   assert.equal(source.includes("analytics is unconfigured"), false);
 
@@ -182,4 +198,57 @@ test("the hero leads with the qualification-first paid offer and keeps the free 
   const metadata = await readFile(new URL("../index.html", import.meta.url), "utf8");
   assert.equal(metadata.includes("free recorder and developer demo studio"), true);
   assert.equal(metadata.includes("$99/month Release Studio"), true);
+});
+
+test("the homepage proof is a truthful six-beat pre-production storyboard", async () => {
+  const source = await readFile(new URL("./App.jsx", import.meta.url), "utf8");
+  const storyboard = source.slice(source.indexOf("const storyboardBeats = ["), source.indexOf("const faqs = ["));
+  const proof = source.slice(source.indexOf('<section className="section proof-section"'), source.indexOf('<section className="section founding-section"'));
+
+  assert.equal((storyboard.match(/number: "0[1-6]"/gu) || []).length, 6);
+  for (const required of [
+    "Record the build once.",
+    "Capture the IDE, terminal, browser, or desktop.",
+    "Keep the take editable.",
+    "Shape the motion around the explanation.",
+    "Export locally with FFmpeg.",
+    "Free. Local-first. MIT licensed.",
+  ]) {
+    assert.equal(storyboard.includes(required), true, `missing storyboard beat: ${required}`);
+  }
+
+  for (const required of [
+    "Pre-production example—not customer work or a finished video.",
+    "https://github.com/JNX03/Flowtake/discussions/169",
+    "Through July 23, 2026",
+    "first three maintainers",
+    "GitHub sign-in is required",
+    "no separate Flowtake signup",
+    "no footage or delivery claim",
+  ]) {
+    assert.equal(source.includes(required), true, `missing proof boundary: ${required}`);
+  }
+  assert.equal(proof.includes("storyboardBeats.map"), true);
+  assert.equal(proof.includes("Planned evidence:"), true);
+  assert.equal(storyboard.includes("plannedEvidence"), true);
+  assert.equal(storyboard.includes("completed MP4"), false);
+  assert.equal(proof.includes("Proof:"), false);
+  assert.equal(proof.includes("<img"), false);
+  assert.equal(proof.includes("<video"), false);
+  assert.equal(proof.includes("<canvas"), false);
+});
+
+test("private outcomes stay private and the public fallback warns before linking", async () => {
+  const source = await readFile(new URL("./App.jsx", import.meta.url), "utf8");
+  const outcome = source.slice(source.indexOf("{outcome ? ("), source.indexOf(") : (", source.indexOf("{outcome ? (")));
+  const fallback = source.slice(source.indexOf("{error && fallbackAllowed && briefText"), source.indexOf("{status === \"sending\""));
+
+  assert.equal(outcome.includes("PUBLIC_STORYBOARD_URL"), false);
+  assert.equal(outcome.includes("Private request reference — do not post publicly"), true);
+  assert.equal(fallback.includes("separate public-only summary"), true);
+  assert.equal(
+    fallback.indexOf("The clinic requires GitHub sign-in and is public")
+      < fallback.indexOf("href={PUBLIC_STORYBOARD_URL}"),
+    true,
+  );
 });

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -628,40 +628,125 @@ button.text-link {
 }
 
 .proof-section {
-  padding: 40px 0 120px;
+  padding: 56px 0 120px;
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(380px, 0.92fr);
-  align-items: center;
-  gap: clamp(48px, 7vw, 100px);
+  grid-template-columns: minmax(300px, 0.78fr) minmax(560px, 1.22fr);
+  align-items: start;
+  gap: clamp(42px, 6vw, 84px);
 }
 
-.proof-section-copy-only {
-  grid-template-columns: minmax(0, 920px);
-  justify-content: center;
+.proof-copy > p:not(.kicker, .proof-boundary, .proof-clinic-note) {
+  max-width: 560px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.75;
 }
 
-.proof-section-copy-only .proof-copy {
-  max-width: 920px;
+.proof-boundary {
+  margin: 28px 0 24px;
+  padding: 18px 20px;
+  display: grid;
+  gap: 6px;
+  color: var(--text-muted);
+  background: rgba(125, 106, 238, 0.08);
+  border: 1px solid rgba(155, 140, 255, 0.2);
+  border-radius: 12px;
+  font-size: 11px;
+  line-height: 1.65;
 }
 
-.check-list {
-  margin: 30px 0 0;
+.proof-boundary strong {
+  color: var(--text);
+  font-size: 12px;
+}
+
+.proof-clinic-action {
+  width: fit-content;
+}
+
+.proof-clinic-note {
+  max-width: 540px;
+  margin: 16px 0 0;
+  color: var(--text-dim);
+  font-size: 10px;
+  line-height: 1.65;
+}
+
+.storyboard-list {
+  margin: 0;
   padding: 0;
   list-style: none;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid rgba(155, 140, 255, 0.24);
+  border-radius: 20px;
+  box-shadow: inset 3px 0 0 var(--primary);
 }
 
-.check-list li {
-  padding: 16px 0;
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  color: #d3d0dc;
+.storyboard-beat {
+  min-height: 176px;
+  padding: 24px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: start;
+  gap: 16px;
   border-bottom: 1px solid var(--line);
-  font-size: 12px;
-  line-height: 1.6;
 }
 
-.check-list svg,
+.storyboard-beat:nth-child(odd) {
+  border-right: 1px solid var(--line);
+}
+
+.storyboard-beat:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.storyboard-beat-meta {
+  display: grid;
+  gap: 7px;
+}
+
+.storyboard-number {
+  color: var(--primary-bright);
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+  font-size: 24px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.storyboard-time {
+  color: var(--text-dim);
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.storyboard-beat h3 {
+  margin: 0 0 10px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.storyboard-caption,
+.storyboard-evidence {
+  margin: 0;
+  font-size: 10px;
+  line-height: 1.55;
+}
+
+.storyboard-caption {
+  color: #d3d0dc;
+}
+
+.storyboard-evidence {
+  margin-top: 10px;
+  color: var(--text-dim);
+}
+
 .plan-surface li svg {
   width: 18px;
   height: 18px;
@@ -1513,9 +1598,34 @@ button.text-link {
   line-height: 1.65;
 }
 
+.dialog-outcome .lead-reference {
+  margin: 18px 0 0;
+  padding: 13px 14px;
+  display: grid;
+  gap: 6px;
+  background: rgba(125, 106, 238, 0.08);
+  border: 1px solid rgba(155, 140, 255, 0.18);
+  border-radius: 10px;
+}
+
+.lead-reference span {
+  color: var(--text-dim);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.lead-reference code {
+  color: var(--text);
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
 .dialog-outcome .text-link {
   margin-top: 18px;
-  display: block;
+  margin-right: 18px;
+  display: inline-flex;
 }
 
 @media (max-width: 1040px) {
@@ -1583,6 +1693,10 @@ button.text-link {
 
   .proof-section {
     grid-template-columns: 1fr;
+  }
+
+  .proof-copy {
+    max-width: 760px;
   }
 
   .plan-surface {
@@ -1806,6 +1920,22 @@ button.text-link {
   .proof-section {
     padding: 20px 0 90px;
     gap: 40px;
+  }
+
+  .storyboard-list {
+    grid-template-columns: 1fr;
+  }
+
+  .storyboard-beat {
+    min-height: 0;
+  }
+
+  .storyboard-beat:nth-child(odd) {
+    border-right: 0;
+  }
+
+  .storyboard-beat:nth-last-child(2) {
+    border-bottom: 1px solid var(--line);
   }
 
   .founding-intro {


### PR DESCRIPTION
## Summary
- replace the copy-only homepage proof gap with a six-beat Flowtake v1.6.0 pre-production storyboard
- label every card as planned evidence and link the public-only storyboard clinic without claiming customer work, finished footage, or delivery
- remove the unverified email handoff and reply-time promise from lead intake
- fail closed unless intake returns an accepted response with a non-empty private request reference
- keep public fallback guidance separate from private lead data and place the privacy warning before the public action

## Validation
- `npm test` (14/14)
- `npx eslint src/App.jsx src/intake.js src/intake.test.mjs`
- `npm run build`
- `vite build --mode pages`
- `npm run verify:build`
- `git diff --check`
- in-app browser QA at desktop, tablet, and 390px mobile: no horizontal overflow or clipped storyboard cards
- dialog QA: initial focus, scroll lock, Escape dismissal, and trigger-focus restoration pass on desktop and mobile
- independent correctness and privacy/security reviews: MERGE

## Truth and privacy boundaries
- this is a pre-production capture plan, not customer work or a finished video
- no payment or footage collection is opened by this change
- public Discussion guidance explicitly forbids posting email, private briefs, credentials, or customer data
- successful lead references are labelled private and are not linked to the public clinic

The temporary unlinked QA preview was removed after validation; the existing `/v1/health` service remained healthy.