### PR TITLE
Add developer demo storyboard guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ For vulnerability reporting, follow the private process in [SECURITY.md](SECURIT
 
 Teams that want human-assisted production for a technical launch can visit [Flowtake Release Studio](https://jnx03.github.io/Flowtake/). It is a separate, optional service; Flowtake's desktop recorder and editor remain the primary open-source product.
 
+Maintainers planning their own release can use the free [six-beat developer-tool demo storyboard template](https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/) before recording. The guide includes a copyable brief, safe-capture exclusions, and a clearly labelled Flowtake v1.6.0 pre-production example.
+
 Through July 23, 2026, Flowtake will publicly reply with a no-obligation six-beat storyboard to up to the first three maintainers who [share a complete, publicly documented developer-tool workflow](https://github.com/JNX03/Flowtake/discussions/169). No separate Flowtake signup, footage, or payment is required.
 
 ## Development

--- a/website/DEPLOYMENT.md
+++ b/website/DEPLOYMENT.md
@@ -8,6 +8,10 @@ The physical comparison entry is served at:
 
 `https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/`
 
+The physical storyboard guide entry is served at:
+
+`https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/`
+
 No repository setting, custom domain, or DNS change is performed by this configuration.
 
 ## Build modes
@@ -15,7 +19,7 @@ No repository setting, custom domain, or DNS change is performed by this configu
 - `npm run dev` and `npm run build` use `/` as the asset base for normal local work.
 - `npm run build -- --mode pages` uses `/Flowtake/`, matching GitHub project Pages.
 - After a Pages-mode build, `npm run preview -- --mode pages` serves the generated site locally at `http://localhost:4173/Flowtake/` by default.
-- `npm run verify:build` requires both `dist/index.html` and `dist/screen-studio-alternative-windows/index.html`, validates their distinct metadata, parses the comparison JSON-LD, and checks the sitemap entry.
+- `npm run verify:build` requires `dist/index.html`, `dist/screen-studio-alternative-windows/index.html`, and `dist/developer-tool-demo-storyboard/index.html`; validates their distinct metadata and JSON-LD; and checks both physical-route sitemap entries.
 
 Public images used from React are joined to `import.meta.env.BASE_URL`. Vite rewrites the favicon and CSS font URLs during the Pages-mode build. This prevents requests from escaping to the domain root when the site is hosted below `/Flowtake/`.
 

--- a/website/developer-tool-demo-storyboard/index.html
+++ b/website/developer-tool-demo-storyboard/index.html
@@ -1,0 +1,386 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Plan a 45-second developer-tool demo with a copyable six-beat storyboard, safe capture checklist, and real Flowtake v1.6.0 pre-production example." />
+    <meta name="theme-color" content="#0a0a18" />
+    <meta name="robots" content="index,follow,max-image-preview:large" />
+    <link rel="canonical" href="https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Flowtake" />
+    <meta property="og:title" content="Developer Tool Demo Video: 6-Beat Storyboard Template | Flowtake" />
+    <meta property="og:description" content="Plan a 45-second developer-tool demo with a copyable six-beat storyboard and safe capture checklist." />
+    <meta property="og:url" content="https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/" />
+    <meta property="og:image" content="https://jnx03.github.io/Flowtake/assets/logo.png" />
+    <meta property="og:image:alt" content="Flowtake app icon" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Developer Tool Demo Video: 6-Beat Storyboard Template | Flowtake" />
+    <meta name="twitter:description" content="A copyable six-beat storyboard and safe capture checklist for maintainers planning a concise developer-tool demo." />
+    <meta name="twitter:image" content="https://jnx03.github.io/Flowtake/assets/logo.png" />
+    <link rel="icon" type="image/png" href="%BASE_URL%assets/logo.png" />
+    <link rel="stylesheet" href="/src/styles.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Developer Tool Demo Video: 6-Beat Storyboard Template",
+        "url": "https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/",
+        "description": "A copyable six-beat storyboard and safe capture checklist for maintainers planning a 45-second developer-tool demo.",
+        "datePublished": "2026-07-16",
+        "dateModified": "2026-07-16",
+        "isPartOf": {
+          "@type": "WebSite",
+          "name": "Flowtake",
+          "url": "https://jnx03.github.io/Flowtake/"
+        }
+      }
+    </script>
+    <title>Developer Tool Demo Video: 6-Beat Storyboard Template | Flowtake</title>
+  </head>
+  <body>
+    <div class="site-shell guide-page">
+      <a class="skip-link" href="#main-content">Skip to main content</a>
+
+      <header class="site-header">
+        <a class="brand" href="%BASE_URL%" aria-label="Flowtake home">
+          <img src="%BASE_URL%assets/logo.svg" alt="" />
+          <span>Flowtake</span>
+          <span class="brand-edition">Storyboard guide</span>
+        </a>
+
+        <nav class="desktop-nav" aria-label="Primary navigation">
+          <a href="#template">Six-beat template</a>
+          <a href="#brief">Copyable brief</a>
+          <a href="#flowtake-example">Flowtake example</a>
+          <a href="#safe-capture">Safe capture</a>
+        </nav>
+
+        <div class="header-actions">
+          <a class="text-link desktop-only" href="%BASE_URL%#founding-plan">Release Studio</a>
+          <a class="button button-small" href="https://github.com/JNX03/Flowtake/discussions/169" target="_blank" rel="noreferrer" data-track="github_clicked">Get a public storyboard</a>
+          <button class="menu-button" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="guide-mobile-navigation" data-menu-button>
+            <span data-menu-label>Menu</span>
+          </button>
+        </div>
+
+        <nav class="mobile-nav" id="guide-mobile-navigation" aria-label="Mobile navigation" hidden data-mobile-nav>
+          <a href="#template">Six-beat template</a>
+          <a href="#brief">Copyable brief</a>
+          <a href="#flowtake-example">Flowtake example</a>
+          <a href="#safe-capture">Safe capture</a>
+          <a href="%BASE_URL%">Flowtake home</a>
+          <a href="https://github.com/JNX03/Flowtake/discussions/169" target="_blank" rel="noreferrer" data-track="github_clicked">Get a public storyboard</a>
+        </nav>
+      </header>
+
+      <main id="main-content">
+        <section class="hero section guide-hero" id="top">
+          <div class="hero-copy">
+            <p class="eyebrow"><span class="eyebrow-line" aria-hidden="true"></span> Free planning template for maintainers</p>
+            <h1>
+              Plan a 45-second
+              <span>developer-tool demo <em>in six beats.</em></span>
+            </h1>
+            <p class="hero-lede">
+              Turn one public release workflow into a concise screen story. The template below gives each beat a purpose, visible proof, and a sensitive-content exclusion before capture begins.
+            </p>
+            <div class="hero-actions guide-hero-actions">
+              <a class="button button-primary" href="#template">Use the six-beat template</a>
+              <a class="button button-quiet" href="https://github.com/JNX03/Flowtake/discussions/169" target="_blank" rel="noreferrer" data-track="github_clicked">Get a public storyboard</a>
+            </div>
+            <p class="honest-note">
+              The 45-second timing is an editorial starting point, not a performance benchmark or a promise about audience response.
+            </p>
+          </div>
+
+          <aside class="guide-hero-panel" aria-labelledby="guide-hero-panel-title">
+            <div class="guide-panel-head">
+              <img src="%BASE_URL%assets/logo.png" alt="" />
+              <div>
+                <p>Before the first take</p>
+                <strong id="guide-hero-panel-title">Define the story boundary.</strong>
+              </div>
+            </div>
+            <ol class="guide-rule-list">
+              <li>
+                <span>01</span>
+                <div><strong>One audience</strong><p>Name the maintainer, developer, evaluator, or user who should care.</p></div>
+              </li>
+              <li>
+                <span>02</span>
+                <div><strong>One workflow</strong><p>Choose one complete action with a clear start and finish.</p></div>
+              </li>
+              <li>
+                <span>03</span>
+                <div><strong>One visible result</strong><p>Hold on evidence the viewer can actually inspect on screen.</p></div>
+              </li>
+              <li>
+                <span>04</span>
+                <div><strong>One call to action</strong><p>End on the release, documentation, repository, or signup that matters now.</p></div>
+              </li>
+            </ol>
+          </aside>
+        </section>
+
+        <div class="signal-bar guide-signal" aria-label="Storyboard guide principles">
+          <span>Six beats in about 45 seconds</span>
+          <span>Public or synthetic sources only</span>
+          <span>One observable result and one CTA</span>
+        </div>
+
+        <section class="section comparison-section guide-section" id="template">
+          <header class="section-heading">
+            <p class="kicker">Copy the structure, then replace the brackets</p>
+            <h2>A six-beat storyboard for one real developer workflow.</h2>
+            <p>
+              Start with the visible result, earn it with one uninterrupted action, then make the handoff obvious. Every row includes a capture boundary so secrets and customer data stay out of the recording plan.
+            </p>
+          </header>
+
+          <div class="comparison-table-wrap guide-table-wrap" tabindex="0" role="region" aria-label="Six-beat developer-tool demo storyboard template">
+            <table class="comparison-table guide-table">
+              <caption>The timing is adjustable. Keep the sequence focused on one audience, workflow, result, and call to action.</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Time and beat</th>
+                  <th scope="col">Screen action</th>
+                  <th scope="col">Narration prompt</th>
+                  <th scope="col">Visible proof</th>
+                  <th scope="col">Exclude from capture</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row"><span>0–4s</span> Outcome hook</th>
+                  <td>Open on the completed output or final state.</td>
+                  <td>“[Audience] can now [specific result].”</td>
+                  <td>Release name and the result the viewer should remember.</td>
+                  <td>Customer names, notifications, private URLs, or unexplained claims.</td>
+                </tr>
+                <tr>
+                  <th scope="row"><span>4–10s</span> Safe setup</th>
+                  <td>Show a local, public, or synthetic demo state and the starting control.</td>
+                  <td>“Start with [safe input] in [tool or feature].”</td>
+                  <td>Public version, sample project, and a clean source state.</td>
+                  <td>API keys, tokens, internal repositories, production access, or real user data.</td>
+                </tr>
+                <tr>
+                  <th scope="row"><span>10–22s</span> One real action</th>
+                  <td>Complete the core task without jumping to unrelated features.</td>
+                  <td>“Use [feature] to [single action].”</td>
+                  <td>One uninterrupted state change in the real interface.</td>
+                  <td>Fabricated results, decorative clicks, or steps that do not affect the outcome.</td>
+                </tr>
+                <tr>
+                  <th scope="row"><span>22–31s</span> Visible result</th>
+                  <td>Pause after the action so the outcome can be inspected.</td>
+                  <td>“The result is [observable output].”</td>
+                  <td>Result panel, generated file, preview, log, or other on-screen evidence.</td>
+                  <td>Metrics or benefits that are not visible and sourced in the take.</td>
+                </tr>
+                <tr>
+                  <th scope="row"><span>31–39s</span> Handoff or export</th>
+                  <td>Show how the viewer saves, exports, shares, or continues the work.</td>
+                  <td>“Save or export [artifact] for [next step].”</td>
+                  <td>The real control, destination type, and public-safe filename.</td>
+                  <td>Private paths, usernames, customer destinations, or hidden follow-up work.</td>
+                </tr>
+                <tr>
+                  <th scope="row"><span>39–45s</span> Single CTA</th>
+                  <td>Hold on one public next action long enough to read it.</td>
+                  <td>“Try [release], read [docs], or open [public page].”</td>
+                  <td>The exact project, release, documentation, or signup destination.</td>
+                  <td>Competing CTAs, false urgency, or unverified adoption and performance numbers.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="guide-template-copy">
+            <button class="button button-primary" type="button" data-copy-template>Copy the six-beat template</button>
+            <p class="guide-copy-status" role="status" aria-live="polite" data-template-copy-status>The storyboard text is not uploaded when you copy it. Flowtake records only a cookie-free aggregate copy count.</p>
+          </div>
+          <details class="guide-template-source" data-template-details>
+            <summary>View the plain-text template</summary>
+            <label for="six-beat-template">Plain-text six-beat storyboard</label>
+            <textarea id="six-beat-template" rows="34" readonly>45-second developer-tool demo — six-beat storyboard template
+
+0–4s — Outcome hook
+Screen action: Open on the completed output or final state.
+Narration prompt: “[Audience] can now [specific result].”
+Visible proof: Release name and the result the viewer should remember.
+Exclude from capture: Customer names, notifications, private URLs, or unexplained claims.
+
+4–10s — Safe setup
+Screen action: Show a local, public, or synthetic demo state and the starting control.
+Narration prompt: “Start with [safe input] in [tool or feature].”
+Visible proof: Public version, sample project, and a clean source state.
+Exclude from capture: API keys, tokens, internal repositories, production access, or real user data.
+
+10–22s — One real action
+Screen action: Complete the core task without jumping to unrelated features.
+Narration prompt: “Use [feature] to [single action].”
+Visible proof: One uninterrupted state change in the real interface.
+Exclude from capture: Fabricated results, decorative clicks, or steps that do not affect the outcome.
+
+22–31s — Visible result
+Screen action: Pause after the action so the outcome can be inspected.
+Narration prompt: “The result is [observable output].”
+Visible proof: Result panel, generated file, preview, log, or other on-screen evidence.
+Exclude from capture: Metrics or benefits that are not visible and sourced in the take.
+
+31–39s — Handoff or export
+Screen action: Show how the viewer saves, exports, shares, or continues the work.
+Narration prompt: “Save or export [artifact] for [next step].”
+Visible proof: The real control, destination type, and public-safe filename.
+Exclude from capture: Private paths, usernames, customer destinations, or hidden follow-up work.
+
+39–45s — Single CTA
+Screen action: Hold on one public next action long enough to read it.
+Narration prompt: “Try [release], read [docs], or open [public page].”
+Visible proof: The exact project, release, documentation, or signup destination.
+Exclude from capture: Competing CTAs, false urgency, or unverified adoption and performance numbers.</textarea>
+          </details>
+          <p class="source-note guide-template-note">
+            Adapt the words and timing to the workflow. Do not compress away consent, security warnings, installation caveats, or setup steps the viewer needs to reproduce the result.
+          </p>
+        </section>
+
+        <section class="section comparison-section comparison-section-bordered guide-brief-section" id="brief">
+          <div class="guide-brief-copy">
+            <p class="kicker">A brief another maintainer can understand</p>
+            <h2>Write the capture boundary before the shot list.</h2>
+            <p>
+              A useful brief names the public source, the exact workflow edges, and what must never appear. Paste this into an issue, planning document, or your own production workflow.
+            </p>
+            <ul class="guide-check-list">
+              <li>Use a public project URL and a named release or feature.</li>
+              <li>Describe the first and last visible state, not a vague product category.</li>
+              <li>List synthetic or public-safe inputs before listing shots.</li>
+              <li>Choose one final action the viewer can take immediately.</li>
+            </ul>
+          </div>
+
+          <div class="guide-copy-card">
+            <label for="maintainer-brief">Copyable maintainer brief</label>
+            <textarea id="maintainer-brief" rows="13" readonly>Public project URL:
+Audience:
+Release or feature:
+Workflow start:
+Workflow end:
+Expected visible output:
+Safe public or synthetic sources:
+Never capture:
+Deadline:
+Single call to action:</textarea>
+            <button class="button button-primary" type="button" data-copy-brief>Copy the maintainer brief</button>
+            <p class="guide-copy-status" role="status" aria-live="polite" data-brief-copy-status>The brief text is not uploaded when you copy it. Flowtake records only a cookie-free aggregate copy count.</p>
+            <p class="guide-public-warning">
+              The <a href="https://github.com/JNX03/Flowtake/discussions/169" target="_blank" rel="noreferrer" data-track="github_clicked">public storyboard clinic</a> is visible to anyone and requires GitHub sign-in. Never post email addresses, credentials, customer data, private repository details, or production access.
+            </p>
+          </div>
+        </section>
+
+        <section class="section comparison-section guide-section" id="flowtake-example">
+          <header class="section-heading compact guide-example-heading">
+            <p class="kicker">Filled example · Flowtake v1.6.0</p>
+            <h2>How the template maps a recorder-to-export workflow.</h2>
+            <p>
+              This example uses the published Flowtake recorder, editor, and local MP4 export path. It is deliberately limited to evidence available in the app and public repository.
+            </p>
+          </header>
+
+          <p class="proof-boundary guide-proof-boundary" role="note">
+            <strong>Pre-production example—not customer work or a finished video.</strong>
+            The six beats below are a capture plan. They do not claim that footage was recorded, a customer received a video, or the timing will produce a particular result.
+          </p>
+
+          <ol class="storyboard-list guide-storyboard-list" aria-label="Flowtake v1.6.0 pre-production storyboard">
+            <li class="storyboard-beat">
+              <div class="storyboard-beat-meta"><span class="storyboard-number">01</span><span class="storyboard-time">0–3s</span></div>
+              <div><h3>Open the recorder</h3><p class="storyboard-caption">“Record the build once.”</p><p class="storyboard-evidence">Planned evidence: Flowtake brand and recorder shell</p></div>
+            </li>
+            <li class="storyboard-beat">
+              <div class="storyboard-beat-meta"><span class="storyboard-number">02</span><span class="storyboard-time">3–10s</span></div>
+              <div><h3>Select safe sources</h3><p class="storyboard-caption">“Capture the IDE, terminal, browser, or desktop.”</p><p class="storyboard-evidence">Planned evidence: source controls and recording state</p></div>
+            </li>
+            <li class="storyboard-beat">
+              <div class="storyboard-beat-meta"><span class="storyboard-number">03</span><span class="storyboard-time">10–18s</span></div>
+              <div><h3>Open the saved take</h3><p class="storyboard-caption">“Keep the take editable.”</p><p class="storyboard-evidence">Planned evidence: project handoff and timeline</p></div>
+            </li>
+            <li class="storyboard-beat">
+              <div class="storyboard-beat-meta"><span class="storyboard-number">04</span><span class="storyboard-time">18–28s</span></div>
+              <div><h3>Shape one motion beat</h3><p class="storyboard-caption">“Shape the motion around the explanation.”</p><p class="storyboard-evidence">Planned evidence: preview, properties, and timeline response</p></div>
+            </li>
+            <li class="storyboard-beat">
+              <div class="storyboard-beat-meta"><span class="storyboard-number">05</span><span class="storyboard-time">28–36s</span></div>
+              <div><h3>Export locally</h3><p class="storyboard-caption">“Export locally with FFmpeg.”</p><p class="storyboard-evidence">Planned evidence: export controls and a locally rendered MP4</p></div>
+            </li>
+            <li class="storyboard-beat">
+              <div class="storyboard-beat-meta"><span class="storyboard-number">06</span><span class="storyboard-time">36–42s</span></div>
+              <div><h3>Hold on the end card</h3><p class="storyboard-caption">“Free. Local-first. MIT licensed.”</p><p class="storyboard-evidence">Planned evidence: public repository and download action</p></div>
+            </li>
+          </ol>
+        </section>
+
+        <section class="section comparison-section comparison-section-bordered honesty-section guide-safety-section" id="safe-capture">
+          <div class="honesty-copy">
+            <p class="kicker">Safe capture is part of the storyboard</p>
+            <h2>Make every source reviewable before recording.</h2>
+            <p>
+              Prefer a local fixture, public repository, synthetic account, or disposable test environment. Close notifications and password managers, remove tokens from terminals, and inspect filenames, browser tabs, logs, and recent-file menus before capture.
+            </p>
+            <p>
+              Flowtake is local-first for ordinary recording, project, and export work, but some explicit features can make network requests. Do not describe a workflow as fully offline unless every feature in the take has been verified that way.
+            </p>
+            <a class="text-link guide-inline-link" href="%BASE_URL%#privacy">Read the Release Studio privacy and file-handling boundary</a>
+          </div>
+
+          <aside class="download-card guide-facts-card" aria-label="Flowtake v1.6.0 product facts">
+            <p class="comparison-card-label">Flowtake v1.6.0 facts</p>
+            <h3>Record and edit on the published app.</h3>
+            <ul>
+              <li>Windows 10/11 x64 is the primary development and validation target.</li>
+              <li>macOS and Linux builds are previews.</li>
+              <li>Cursor-driven zoom and pan remain editable on the timeline.</li>
+              <li>FFmpeg renders a local MP4 export.</li>
+            </ul>
+            <a class="button button-primary" href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Download Flowtake v1.6.0</a>
+            <a class="text-link checksum-link" href="%BASE_URL%screen-studio-alternative-windows/">Compare the Windows workflow</a>
+            <p class="download-warning">Current Windows files are not Authenticode-signed and may trigger Microsoft SmartScreen. Download only from the official GitHub release and verify its published checksums.</p>
+          </aside>
+        </section>
+
+        <section class="section final-cta comparison-final-cta guide-final-cta">
+          <div>
+            <p class="eyebrow"><span class="eyebrow-line" aria-hidden="true"></span> Bring one public workflow</p>
+            <h2>Get a six-beat plan before you record.</h2>
+            <p>Through July 23, 2026, up to the first three maintainers with a complete public developer-tool workflow can request a no-obligation storyboard.</p>
+          </div>
+          <div class="comparison-final-actions">
+            <a class="button button-primary" href="https://github.com/JNX03/Flowtake/discussions/169" target="_blank" rel="noreferrer" data-track="github_clicked">Get a public storyboard</a>
+            <a class="button button-quiet" href="%BASE_URL%#founding-plan">See Release Studio scope</a>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer guide-footer">
+        <div class="brand footer-brand">
+          <img src="%BASE_URL%assets/logo.svg" alt="" />
+          <span>Flowtake</span>
+        </div>
+        <p>Open-source recorder. Optional release production.</p>
+        <div>
+          <a href="%BASE_URL%">Home</a>
+          <a href="%BASE_URL%#founding-plan">Release Studio</a>
+          <a href="%BASE_URL%screen-studio-alternative-windows/">Windows comparison</a>
+          <a href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer">GitHub</a>
+          <a href="%BASE_URL%#privacy">Privacy</a>
+        </div>
+      </footer>
+    </div>
+    <script type="module" src="/src/developerToolDemoStoryboard.main.js"></script>
+  </body>
+</html>

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -8,4 +8,8 @@
     <loc>https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/</loc>
     <lastmod>2026-07-16</lastmod>
   </url>
+  <url>
+    <loc>https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/</loc>
+    <lastmod>2026-07-16</lastmod>
+  </url>
 </urlset>

--- a/website/screen-studio-alternative-windows/index.html
+++ b/website/screen-studio-alternative-windows/index.html
@@ -303,6 +303,7 @@
           </div>
           <div class="comparison-final-actions">
             <a class="button button-primary" href="https://github.com/JNX03/Flowtake/releases/tag/v1.6.0" target="_blank" rel="noreferrer" data-track="download_clicked">Download Flowtake</a>
+            <a class="button button-quiet" href="%BASE_URL%developer-tool-demo-storyboard/">Use the six-beat template</a>
             <button class="button button-quiet" type="button" data-open-brief>Request a sample storyboard</button>
           </div>
         </section>
@@ -316,6 +317,7 @@
         <p>Independent, open-source, and not endorsed by Screen Studio.</p>
         <div>
           <a href="%BASE_URL%">Home</a>
+          <a href="%BASE_URL%developer-tool-demo-storyboard/">Storyboard guide</a>
           <a href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer">GitHub</a>
           <a href="https://github.com/JNX03/Flowtake/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT License</a>
           <a href="%BASE_URL%#privacy">Privacy</a>

--- a/website/scripts/verify-built-site.mjs
+++ b/website/scripts/verify-built-site.mjs
@@ -5,11 +5,13 @@ import { fileURLToPath } from "node:url";
 import { preview } from "vite";
 
 const comparisonUrl = "https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/";
+const guideUrl = "https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/";
 const distUrl = new URL("../dist/", import.meta.url);
 
-const [home, comparison, sitemap] = await Promise.all([
+const [home, comparison, guide, sitemap] = await Promise.all([
   readFile(new URL("index.html", distUrl), "utf8"),
   readFile(new URL("screen-studio-alternative-windows/index.html", distUrl), "utf8"),
+  readFile(new URL("developer-tool-demo-storyboard/index.html", distUrl), "utf8"),
   readFile(new URL("sitemap.xml", distUrl), "utf8"),
 ]);
 
@@ -35,6 +37,31 @@ for (const block of jsonLdBlocks) JSON.parse(block[1]);
 
 assert.equal(count(sitemap, `<loc>${comparisonUrl}</loc>`), 1, "comparison sitemap entry must be unique");
 
+assert.equal(guide.includes("Plan a 45-second"), true, "storyboard guide H1 content missing");
+assert.equal(guide.includes("A six-beat storyboard for one real developer workflow"), true, "storyboard guide template missing");
+assert.equal(guide.includes("data-copy-template>Copy the six-beat template</button>"), true, "storyboard copy action missing");
+assert.equal(guide.includes('id="six-beat-template"'), true, "serialized storyboard copy payload missing");
+assert.equal(
+  guide.includes("The brief text is not uploaded when you copy it. Flowtake records only a cookie-free aggregate copy count."),
+  true,
+  "storyboard copy privacy boundary missing",
+);
+assert.equal(guide.includes("Pre-production example—not customer work or a finished video"), true, "storyboard truth boundary missing");
+assert.equal(count(guide, "<title>"), 1, "storyboard guide title must be unique");
+assert.equal(count(guide, 'name="description"'), 1, "storyboard guide description must be unique");
+assert.equal(count(guide, 'rel="canonical"'), 1, "storyboard guide canonical must be unique");
+assert.equal(count(guide, 'property="og:url"'), 1, "storyboard guide og:url must be unique");
+assert.equal(guide.includes(`href="${guideUrl}"`), true, "storyboard guide canonical is wrong");
+assert.equal(guide.includes(`content="${guideUrl}"`), true, "storyboard guide og:url is wrong");
+assert.equal(guide.includes("/Flowtake/assets/"), true, "storyboard guide Pages asset base is missing");
+
+const guideJsonLdBlocks = [...guide.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/gu)];
+assert.equal(guideJsonLdBlocks.length, 1, "storyboard guide must have one JSON-LD block");
+const guideStructuredData = JSON.parse(guideJsonLdBlocks[0][1]);
+assert.equal(guideStructuredData["@type"], "WebPage", "storyboard guide structured data must remain WebPage-only");
+assert.equal(guide.includes("VideoObject"), false, "storyboard guide must not claim video structured data");
+assert.equal(count(sitemap, `<loc>${guideUrl}</loc>`), 1, "storyboard guide sitemap entry must be unique");
+
 const previewServer = await preview({
   root: fileURLToPath(new URL("../", import.meta.url)),
   mode: "pages",
@@ -47,19 +74,26 @@ const previewServer = await preview({
 
 try {
   const previewOrigin = "http://127.0.0.1:4174";
-  const [homeResponse, comparisonResponse, unknownResponse] = await Promise.all([
+  const [homeResponse, comparisonResponse, guideResponse, unknownResponse] = await Promise.all([
     fetch(`${previewOrigin}/Flowtake/`),
     fetch(`${previewOrigin}/Flowtake/screen-studio-alternative-windows/`),
+    fetch(`${previewOrigin}/Flowtake/developer-tool-demo-storyboard/`),
     fetch(`${previewOrigin}/Flowtake/not-a-real-page/`),
   ]);
 
   assert.equal(homeResponse.status, 200, "preview homepage must return 200");
   assert.equal(comparisonResponse.status, 200, "preview comparison route must return 200");
+  assert.equal(guideResponse.status, 200, "preview storyboard guide route must return 200");
   assert.equal(unknownResponse.status, 404, "preview unknown route must remain a real 404");
   assert.equal(
     (await comparisonResponse.text()).includes("A Screen Studio"),
     true,
     "preview comparison response must contain its static body",
+  );
+  assert.equal(
+    (await guideResponse.text()).includes("Plan a 45-second"),
+    true,
+    "preview storyboard guide response must contain its static body",
   );
 } finally {
   await new Promise((resolve, reject) => {
@@ -67,4 +101,4 @@ try {
   });
 }
 
-process.stdout.write("Verified root and Screen Studio alternative Pages artifacts.\n");
+process.stdout.write("Verified root, Screen Studio alternative, and storyboard guide Pages artifacts.\n");

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -356,6 +356,9 @@ export function App() {
             <p className="proof-clinic-note">
               Through July 23, 2026, up to the first three maintainers with a complete public developer-tool workflow can receive a no-obligation storyboard. GitHub sign-in is required; there is no separate Flowtake signup, footage request, or payment.
             </p>
+            <a className="text-link comparison-context-link" href={`${import.meta.env.BASE_URL}developer-tool-demo-storyboard/`}>
+              Use the full developer-tool demo storyboard template
+            </a>
           </div>
           <ol className="storyboard-list" aria-label="Flowtake v1.6.0 pre-production storyboard">
             {storyboardBeats.map(({ number, time, title, caption, plannedEvidence }) => (
@@ -497,6 +500,7 @@ export function App() {
         <p>Open-source recorder. Optional release production.</p>
         <div>
           <a href="https://github.com/JNX03/Flowtake" target="_blank" rel="noreferrer">GitHub</a>
+          <a href={`${import.meta.env.BASE_URL}developer-tool-demo-storyboard/`}>Storyboard guide</a>
           <a href={`${import.meta.env.BASE_URL}screen-studio-alternative-windows/`}>Windows comparison</a>
           <a href="#service-terms">Terms</a>
           <a href="#privacy">Privacy</a>

--- a/website/src/developerToolDemoStoryboard.main.js
+++ b/website/src/developerToolDemoStoryboard.main.js
@@ -1,0 +1,100 @@
+import { sendEvent } from "./intake.js";
+
+function track(name) {
+  void sendEvent(name);
+}
+
+const menuButton = document.querySelector("[data-menu-button]");
+const menuLabel = document.querySelector("[data-menu-label]");
+const mobileNav = document.querySelector("[data-mobile-nav]");
+const templateCopyButton = document.querySelector("[data-copy-template]");
+const templateCopyStatus = document.querySelector("[data-template-copy-status]");
+const templateDetails = document.querySelector("[data-template-details]");
+const templateText = document.querySelector("#six-beat-template");
+const briefCopyButton = document.querySelector("[data-copy-brief]");
+const briefCopyStatus = document.querySelector("[data-brief-copy-status]");
+const brief = document.querySelector("#maintainer-brief");
+
+function setMenuOpen(open) {
+  if (!menuButton || !mobileNav) return;
+  menuButton.setAttribute("aria-expanded", String(open));
+  menuButton.setAttribute("aria-label", open ? "Close navigation" : "Open navigation");
+  mobileNav.hidden = !open;
+  if (menuLabel) menuLabel.textContent = open ? "Close" : "Menu";
+}
+
+async function copyText({ button, status, source, successMessage, resetLabel, manualCopyMessage, reveal }) {
+  if (!button || !status || !source) return;
+
+  const text = source.value;
+  let copied = false;
+  try {
+    await navigator.clipboard.writeText(text);
+    copied = true;
+  } catch {
+    reveal?.();
+    try {
+      source.focus();
+      source.select();
+      copied = document.execCommand("copy") === true;
+    } catch {
+      copied = false;
+    }
+  }
+
+  if (!copied) {
+    status.textContent = manualCopyMessage;
+    return;
+  }
+
+  track("brief_copied");
+  button.focus();
+  button.textContent = "Copied";
+  status.textContent = successMessage;
+  window.setTimeout(() => {
+    button.textContent = resetLabel;
+  }, 2400);
+}
+
+track("page_viewed");
+
+menuButton?.addEventListener("click", () => {
+  setMenuOpen(menuButton.getAttribute("aria-expanded") !== "true");
+});
+
+templateCopyButton?.addEventListener("click", () => {
+  void copyText({
+    button: templateCopyButton,
+    status: templateCopyStatus,
+    source: templateText,
+    successMessage: "Six-beat template copied. Replace every bracketed field before using it.",
+    resetLabel: "Copy the six-beat template",
+    manualCopyMessage: "Copy was blocked. The plain-text template is selected; use your device's copy command.",
+    reveal: () => {
+      if (templateDetails) templateDetails.open = true;
+    },
+  });
+});
+
+briefCopyButton?.addEventListener("click", () => {
+  void copyText({
+    button: briefCopyButton,
+    status: briefCopyStatus,
+    source: brief,
+    successMessage: "Brief copied. Review every field before sharing it.",
+    resetLabel: "Copy the maintainer brief",
+    manualCopyMessage: "Copy was blocked. The brief is selected; use your device's copy command.",
+  });
+});
+
+document.addEventListener("click", (event) => {
+  const trackedLink = event.target.closest("[data-track]");
+  if (trackedLink) track(trackedLink.dataset.track);
+  if (event.target.closest("[data-mobile-nav] a")) setMenuOpen(false);
+});
+
+window.addEventListener("keydown", (event) => {
+  if (event.key !== "Escape" || menuButton?.getAttribute("aria-expanded") !== "true") return;
+  setMenuOpen(false);
+  menuButton.focus();
+});

--- a/website/src/developerToolDemoStoryboard.test.mjs
+++ b/website/src/developerToolDemoStoryboard.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+function createNode({ attributes = {}, value = "" } = {}) {
+  const listeners = new Map();
+  const state = new Map(Object.entries(attributes));
+  return {
+    dataset: {},
+    hidden: false,
+    open: false,
+    textContent: "",
+    value,
+    focusCount: 0,
+    selectCount: 0,
+    addEventListener(name, listener) {
+      listeners.set(name, listener);
+    },
+    emit(name, event = {}) {
+      return listeners.get(name)?.(event);
+    },
+    focus() {
+      this.focusCount += 1;
+    },
+    getAttribute(name) {
+      return state.get(name) ?? null;
+    },
+    select() {
+      this.selectCount += 1;
+    },
+    setAttribute(name, valueToSet) {
+      state.set(name, String(valueToSet));
+    },
+  };
+}
+
+function replaceGlobal(name, value) {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  return () => {
+    if (previous) Object.defineProperty(globalThis, name, previous);
+    else delete globalThis[name];
+  };
+}
+
+async function flushAsyncWork() {
+  await new Promise((resolve) => globalThis.setImmediate(resolve));
+}
+
+test("storyboard copying, blocked fallback, and Escape focus work as promised", async () => {
+  const page = await readFile(new URL("../developer-tool-demo-storyboard/index.html", import.meta.url), "utf8");
+  const templateMatch = page.match(/<textarea id="six-beat-template"[^>]*>([\s\S]*?)<\/textarea>/u);
+  assert.ok(templateMatch, "missing serialized storyboard fixture");
+
+  const menuButton = createNode({ attributes: { "aria-expanded": "false" } });
+  const menuLabel = createNode();
+  const mobileNav = createNode();
+  mobileNav.hidden = true;
+  const templateCopyButton = createNode();
+  const templateCopyStatus = createNode();
+  const templateDetails = createNode();
+  const templateText = createNode({ value: templateMatch[1] });
+  const briefCopyButton = createNode();
+  const briefCopyStatus = createNode();
+  const brief = createNode({ value: "Public project URL:\nAudience:" });
+  const documentListeners = new Map();
+  const windowListeners = new Map();
+  const eventNames = [];
+  const clipboardWrites = [];
+  let blockClipboard = false;
+
+  const nodes = new Map([
+    ["[data-menu-button]", menuButton],
+    ["[data-menu-label]", menuLabel],
+    ["[data-mobile-nav]", mobileNav],
+    ["[data-copy-template]", templateCopyButton],
+    ["[data-template-copy-status]", templateCopyStatus],
+    ["[data-template-details]", templateDetails],
+    ["#six-beat-template", templateText],
+    ["[data-copy-brief]", briefCopyButton],
+    ["[data-brief-copy-status]", briefCopyStatus],
+    ["#maintainer-brief", brief],
+  ]);
+
+  const restores = [
+    replaceGlobal("document", {
+      addEventListener(name, listener) {
+        documentListeners.set(name, listener);
+      },
+      execCommand() {
+        throw new Error("legacy copy unavailable");
+      },
+      querySelector(selector) {
+        return nodes.get(selector) ?? null;
+      },
+    }),
+    replaceGlobal("window", {
+      addEventListener(name, listener) {
+        windowListeners.set(name, listener);
+      },
+      setTimeout() {},
+    }),
+    replaceGlobal("navigator", {
+      clipboard: {
+        async writeText(value) {
+          if (blockClipboard) throw new Error("clipboard permission denied");
+          clipboardWrites.push(value);
+        },
+      },
+    }),
+    replaceGlobal("fetch", async (_url, options) => {
+      eventNames.push(JSON.parse(options.body).name);
+      return { ok: true };
+    }),
+  ];
+
+  try {
+    const moduleUrl = new URL(`./developerToolDemoStoryboard.main.js?test=${Date.now()}`, import.meta.url);
+    await import(moduleUrl);
+    await flushAsyncWork();
+
+    templateCopyButton.emit("click");
+    await flushAsyncWork();
+    assert.equal(clipboardWrites[0], templateMatch[1]);
+    assert.equal(templateCopyStatus.textContent, "Six-beat template copied. Replace every bracketed field before using it.");
+    assert.equal(eventNames.filter((name) => name === "brief_copied").length, 1);
+
+    blockClipboard = true;
+    briefCopyButton.emit("click");
+    await flushAsyncWork();
+    assert.equal(brief.focusCount, 1);
+    assert.equal(brief.selectCount, 1);
+    assert.equal(briefCopyStatus.textContent, "Copy was blocked. The brief is selected; use your device's copy command.");
+    assert.equal(eventNames.filter((name) => name === "brief_copied").length, 1, "blocked copies must not be counted");
+
+    menuButton.emit("click");
+    assert.equal(menuButton.getAttribute("aria-expanded"), "true");
+    assert.equal(mobileNav.hidden, false);
+    windowListeners.get("keydown")({ key: "Escape" });
+    assert.equal(menuButton.getAttribute("aria-expanded"), "false");
+    assert.equal(mobileNav.hidden, true);
+    assert.equal(menuButton.focusCount, 1);
+
+    windowListeners.get("keydown")({ key: "Escape" });
+    assert.equal(menuButton.focusCount, 1, "Escape must do nothing while the menu is collapsed");
+  } finally {
+    for (const restore of restores.reverse()) restore();
+  }
+});

--- a/website/src/siteRoutes.test.mjs
+++ b/website/src/siteRoutes.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const comparisonUrl = "https://jnx03.github.io/Flowtake/screen-studio-alternative-windows/";
+const guideUrl = "https://jnx03.github.io/Flowtake/developer-tool-demo-storyboard/";
 
 async function source(relativePath) {
   return readFile(new URL(relativePath, import.meta.url), "utf8");
@@ -77,4 +78,111 @@ test("the comparison route is discoverable and uses root privacy for the shared 
   assert.equal(app.includes('privacyHref = "#privacy"'), true);
   assert.equal(enhancements.includes('privacyHref={`${BASE_URL}#privacy`}'), true);
   assert.equal(occurrences(sitemap, `<loc>${comparisonUrl}</loc>`), 1);
+});
+
+test("the developer-tool storyboard guide is a physical Vite MPA route", async () => {
+  const [config, page] = await Promise.all([
+    source("../vite.config.mjs"),
+    source("../developer-tool-demo-storyboard/index.html"),
+  ]);
+
+  assert.equal(config.includes('appType: "mpa"'), true);
+  assert.equal(config.includes('"developer-tool-demo-storyboard/index.html"'), true);
+  assert.equal(page.includes("Plan a 45-second"), true);
+  assert.equal(page.includes("developer-tool demo <em>in six beats.</em>"), true);
+  assert.equal(page.includes('<div id="root"></div>'), false);
+  assert.equal(page.includes('/src/developerToolDemoStoryboard.main.js'), true);
+});
+
+test("storyboard guide metadata is unique, self-canonical, and WebPage-only", async () => {
+  const page = await source("../developer-tool-demo-storyboard/index.html");
+
+  assert.equal(occurrences(page, "<title>"), 1);
+  assert.equal(occurrences(page, 'name="description"'), 1);
+  assert.equal(occurrences(page, 'rel="canonical"'), 1);
+  assert.equal(occurrences(page, 'property="og:url"'), 1);
+  assert.equal(page.includes(`<link rel="canonical" href="${guideUrl}" />`), true);
+  assert.equal(page.includes(`<meta property="og:url" content="${guideUrl}" />`), true);
+  assert.equal(page.includes("Developer Tool Demo Video: 6-Beat Storyboard Template | Flowtake"), true);
+
+  const blocks = [...page.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/gu)];
+  assert.equal(blocks.length, 1);
+  const structuredData = JSON.parse(blocks[0][1]);
+  assert.equal(structuredData["@type"], "WebPage");
+  assert.equal(page.includes("VideoObject"), false);
+  assert.equal(page.includes("SoftwareApplication"), false);
+  assert.equal(page.includes("AggregateRating"), false);
+});
+
+test("storyboard guide includes six copyable beats and truthful boundaries", async () => {
+  const page = await source("../developer-tool-demo-storyboard/index.html");
+  const template = page.slice(page.indexOf('<section class="section comparison-section guide-section" id="template">'), page.indexOf('<section class="section comparison-section comparison-section-bordered guide-brief-section"'));
+  const rows = template.slice(template.indexOf("<tbody>"), template.indexOf("</tbody>"));
+  const plainTextMatch = template.match(/<textarea id="six-beat-template"[^>]*>([\s\S]*?)<\/textarea>/u);
+
+  assert.equal(occurrences(rows, "<tr>"), 6);
+  assert.ok(plainTextMatch, "missing serialized plain-text storyboard");
+  const plainTextTemplate = plainTextMatch[1];
+  for (const timing of ["0–4s", "4–10s", "10–22s", "22–31s", "31–39s", "39–45s"]) {
+    assert.equal(plainTextTemplate.includes(timing), true, `copy payload missing timing: ${timing}`);
+  }
+  for (const label of ["Screen action:", "Narration prompt:", "Visible proof:", "Exclude from capture:"]) {
+    assert.equal(occurrences(plainTextTemplate, label), 6, `copy payload must include ${label} for every beat`);
+  }
+  assert.equal(page.includes("data-copy-template>Copy the six-beat template</button>"), true);
+  assert.equal(page.includes("The storyboard text is not uploaded when you copy it. Flowtake records only a cookie-free aggregate copy count."), true);
+  assert.equal(page.includes("The brief text is not uploaded when you copy it. Flowtake records only a cookie-free aggregate copy count."), true);
+  for (const required of [
+    "0–4s",
+    "4–10s",
+    "10–22s",
+    "22–31s",
+    "31–39s",
+    "39–45s",
+    "Public project URL:",
+    "Safe public or synthetic sources:",
+    "Never capture:",
+    "Single call to action:",
+    "Pre-production example—not customer work or a finished video.",
+    "not a performance benchmark",
+    "Windows 10/11 x64 is the primary development and validation target",
+    "macOS and Linux builds are previews",
+    "Current Windows files are not Authenticode-signed",
+  ]) {
+    assert.equal(page.includes(required), true, `missing guide boundary: ${required}`);
+  }
+
+  for (const prohibited of [
+    "proven to convert",
+    "guaranteed",
+    "completely offline",
+    "customer testimonial",
+    "customer logo",
+  ]) {
+    assert.equal(page.toLowerCase().includes(prohibited), false, `unsafe guide claim: ${prohibited}`);
+  }
+
+  assert.equal(page.includes("<video"), false);
+  assert.equal(page.includes("<canvas"), false);
+});
+
+test("storyboard guide is linked, copy-enabled, and listed once in the sitemap", async () => {
+  const [app, comparison, readme, enhancements, sitemap] = await Promise.all([
+    source("./App.jsx"),
+    source("../screen-studio-alternative-windows/index.html"),
+    source("../../README.md"),
+    source("./developerToolDemoStoryboard.main.js"),
+    source("../public/sitemap.xml"),
+  ]);
+
+  assert.equal(app.includes("developer-tool-demo-storyboard/"), true);
+  assert.equal(comparison.includes("developer-tool-demo-storyboard/"), true);
+  assert.equal(readme.includes("developer-tool-demo-storyboard/"), true);
+  assert.equal(enhancements.includes('track("brief_copied")'), true);
+  assert.equal(enhancements.includes("navigator.clipboard.writeText"), true);
+  assert.equal(enhancements.includes('document.execCommand("copy") === true'), true);
+  assert.equal(enhancements.includes("manualCopyMessage"), true);
+  assert.equal(enhancements.includes('menuButton?.getAttribute("aria-expanded") !== "true"'), true);
+  assert.equal(enhancements.includes("menuButton.focus()"), true);
+  assert.equal(occurrences(sitemap, `<loc>${guideUrl}</loc>`), 1);
 });

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1390,6 +1390,302 @@ button.text-link {
   line-height: 1.55;
 }
 
+.guide-hero {
+  padding-top: 72px;
+  padding-bottom: 96px;
+  grid-template-columns: minmax(0, 0.92fr) minmax(500px, 1.08fr);
+}
+
+.guide-hero h1 {
+  font-size: clamp(50px, 5.1vw, 76px);
+}
+
+.guide-hero-actions {
+  margin-top: 30px;
+}
+
+.guide-hero-panel {
+  padding: 20px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.26);
+}
+
+.guide-panel-head {
+  padding: 4px 4px 18px;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: center;
+  gap: 13px;
+  border-bottom: 1px solid var(--line);
+}
+
+.guide-panel-head img {
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+}
+
+.guide-panel-head p {
+  margin: 0 0 2px;
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.guide-panel-head strong {
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+  font-size: 24px;
+  font-weight: 470;
+}
+
+.guide-rule-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.guide-rule-list li {
+  min-height: 102px;
+  padding: 22px 8px;
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  align-items: start;
+  gap: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.guide-rule-list li:last-child {
+  border-bottom: 0;
+}
+
+.guide-rule-list li > span {
+  color: var(--primary-bright);
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+  font-size: 23px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.guide-rule-list strong {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.guide-rule-list p {
+  margin: 7px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.65;
+}
+
+.guide-table {
+  min-width: 1120px;
+}
+
+.guide-table tbody th {
+  width: 15%;
+}
+
+.guide-table tbody td {
+  width: 21.25%;
+}
+
+.guide-table tbody th span {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--primary-bright);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.guide-template-copy {
+  max-width: 820px;
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: center;
+  gap: 14px 20px;
+}
+
+.guide-template-copy .button {
+  min-width: 232px;
+}
+
+.guide-template-source {
+  max-width: 820px;
+  margin-top: 14px;
+  padding: 16px 18px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+}
+
+.guide-template-source summary {
+  width: fit-content;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.guide-template-source label {
+  display: block;
+  margin: 18px 0 8px;
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.guide-template-source textarea {
+  width: 100%;
+  min-height: 640px;
+  padding: 18px;
+  resize: vertical;
+  color: #e6e3ed;
+  background: var(--ink-soft);
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 11px;
+  line-height: 1.65;
+}
+
+.guide-template-note {
+  max-width: 820px;
+  margin-top: 24px;
+  padding-left: 14px;
+  border-left: 2px solid var(--accent);
+}
+
+.guide-brief-section {
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(500px, 1.18fr);
+  align-items: start;
+  gap: clamp(48px, 7vw, 100px);
+}
+
+.guide-brief-copy > p:not(.kicker) {
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.8;
+}
+
+.guide-check-list,
+.guide-facts-card ul {
+  margin: 28px 0 0;
+  padding-left: 20px;
+  color: #d3d0dc;
+  font-size: 11px;
+  line-height: 1.8;
+}
+
+.guide-check-list li + li,
+.guide-facts-card li + li {
+  margin-top: 7px;
+}
+
+.guide-copy-card {
+  min-width: 0;
+  padding: 32px;
+  display: grid;
+  gap: 16px;
+  background: var(--surface);
+  border: 1px solid rgba(155, 140, 255, 0.28);
+  border-radius: 18px;
+  box-shadow: inset 3px 0 0 var(--primary);
+}
+
+.guide-copy-card label {
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.guide-copy-card textarea {
+  width: 100%;
+  min-width: 0;
+  min-height: 310px;
+  padding: 20px;
+  resize: vertical;
+  color: #e6e3ed;
+  background: var(--ink-soft);
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  font-family: ui-monospace, "Cascadia Code", monospace;
+  font-size: 12px;
+  line-height: 1.75;
+}
+
+.guide-copy-card .button {
+  width: 100%;
+}
+
+.guide-copy-status,
+.guide-public-warning {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.65;
+}
+
+.guide-copy-status {
+  min-height: 17px;
+}
+
+.guide-public-warning {
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+
+.guide-public-warning a,
+.guide-inline-link {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.guide-example-heading {
+  max-width: 820px;
+}
+
+.guide-proof-boundary {
+  max-width: 820px;
+  margin: 32px 0 42px;
+}
+
+.guide-storyboard-list {
+  width: 100%;
+}
+
+.guide-safety-section {
+  align-items: start;
+}
+
+.guide-inline-link {
+  margin-top: 18px;
+  display: inline-block;
+}
+
+.guide-facts-card ul {
+  margin-top: 22px;
+  margin-bottom: 22px;
+}
+
+.guide-footer p {
+  line-height: 1.55;
+}
+
 .dialog-backdrop {
   position: fixed;
   z-index: 80;
@@ -1731,7 +2027,15 @@ button.text-link {
     grid-template-columns: 1fr;
   }
 
+  .guide-hero {
+    grid-template-columns: 1fr;
+  }
+
   .comparison-hero-panel {
+    max-width: 850px;
+  }
+
+  .guide-hero-panel {
     max-width: 850px;
   }
 
@@ -1745,6 +2049,14 @@ button.text-link {
 
   .honesty-section {
     grid-template-columns: 1fr;
+  }
+
+  .guide-brief-section {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-copy-card {
+    max-width: 760px;
   }
 
   .download-card {
@@ -1792,6 +2104,10 @@ button.text-link {
   }
 
   .comparison-hero h1 {
+    font-size: clamp(43px, 12.5vw, 58px);
+  }
+
+  .guide-hero h1 {
     font-size: clamp(43px, 12.5vw, 58px);
   }
 
@@ -1863,6 +2179,25 @@ button.text-link {
     border-radius: 17px;
   }
 
+  .guide-hero-panel {
+    padding: 12px;
+    border-radius: 17px;
+  }
+
+  .guide-panel-head {
+    grid-template-columns: 38px minmax(0, 1fr);
+  }
+
+  .guide-panel-head img {
+    width: 38px;
+    height: 38px;
+  }
+
+  .guide-rule-list li {
+    min-height: 0;
+    padding: 20px 8px;
+  }
+
   .comparison-panel-head {
     grid-template-columns: 38px minmax(0, 1fr);
   }
@@ -1890,7 +2225,8 @@ button.text-link {
   .founding-section,
   .trust-section,
   .faq-section,
-  .comparison-section {
+  .comparison-section,
+  .guide-section {
     padding: 94px 0;
   }
 
@@ -1982,6 +2318,28 @@ button.text-link {
 
   .comparison-table-wrap {
     margin-top: 42px;
+  }
+
+  .guide-copy-card {
+    padding: 25px 22px;
+  }
+
+  .guide-copy-card textarea {
+    min-height: 340px;
+    padding: 17px;
+  }
+
+  .guide-template-copy {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-template-copy .button {
+    width: 100%;
+  }
+
+  .guide-template-source textarea {
+    min-height: 760px;
+    padding: 16px;
   }
 
   .comparison-table th,

--- a/website/vite.config.mjs
+++ b/website/vite.config.mjs
@@ -19,6 +19,10 @@ export default defineConfig(({ mode }) => ({
           __dirname,
           "screen-studio-alternative-windows/index.html",
         ),
+        developerToolDemoStoryboard: resolve(
+          __dirname,
+          "developer-tool-demo-storyboard/index.html",
+        ),
       },
     },
   },
@@ -29,7 +33,11 @@ export default defineConfig(({ mode }) => ({
     host: "0.0.0.0",
     allowedHosts: ["terminal.local"],
     warmup: {
-      clientFiles: ["./src/main.jsx", "./src/screenStudioAlternative.main.jsx"],
+      clientFiles: [
+        "./src/main.jsx",
+        "./src/screenStudioAlternative.main.jsx",
+        "./src/developerToolDemoStoryboard.main.js",
+      ],
     },
   },
   plugins: [react()],


### PR DESCRIPTION
## What changed

- Adds the physical `/developer-tool-demo-storyboard/` MPA route.
- Adds a copyable six-beat demo template and maintainer brief.
- Includes a truthful Flowtake v1.6.0 pre-production example with explicit safe-capture boundaries.
- Adds sitemap discovery, build verification, and automated tests.

## Why

This gives maintainers and prospective customers a useful planning artifact for developer-tool demos without claiming that a finished customer video already exists.

## Impact

Maintainers can plan public or synthetic developer-tool demos while the existing home and comparison pages remain unchanged.

## Validation

- 19/19 automated tests passed.
- Focused ESLint passed.
- Default and GitHub Pages builds passed.
- Both build-verification modes passed.
- Desktop and 480 CSS-pixel Chrome QA passed.
- Mobile navigation Escape behavior, focus return, copy actions, and overflow containment were verified.
- Independent reviewer returned PASS.
- `git diff --check` passed.