### PR TITLE
feat(macos): add native editor preview pipeline

### DIFF
--- a/app/shared/scene/Screen.js
+++ b/app/shared/scene/Screen.js
@@ -20,7 +20,10 @@ export default class Screen extends CanvasWrapper {
         this.fg.position.set(screen.width * 0.5, screen.height * 0.5)
         this.fg.mask = new Graphics()
 
-        this.fg.pivot.set(dims.x * 0.5, dims.y * 0.5)
+        // Pivot coordinates are local to the backing texture. Using logical
+        // source dimensions here offsets a downscaled preview texture and
+        // leaves only a small corner visible.
+        this.fg.pivot.set(textureDims.x * 0.5, textureDims.y * 0.5)
         this.fg.position.set(dims.x * 0.5, dims.y * 0.5)
         this.fg.width = dims.x
         this.fg.height = dims.y

--- a/app/windows/main/components/VideoWrapper.jsx
+++ b/app/windows/main/components/VideoWrapper.jsx
@@ -47,7 +47,7 @@ export default function VideoWrapper({ screenVideoRef, cameraVideoRef, extraVide
     const hasMicrophoneAudio = useSelector(selectHasMicrophoneAudio)
     const extraTracks = useSelector(selectExtraTracks)
 
-    const screenVideo = useVideoSrc("screen", projectId)
+    const screenVideo = useVideoSrc("screen-preview", projectId)
     const cameraVideo = useVideoSrc("camera", projectId)
     const microphoneAudio = useVideoSrc("microphone", projectId)
 

--- a/src-tauri/native/macos-capture/Sources/FlowtakeMacCapture/FlowtakeMacCaptureMain.swift
+++ b/src-tauri/native/macos-capture/Sources/FlowtakeMacCapture/FlowtakeMacCaptureMain.swift
@@ -20,6 +20,12 @@ enum FlowtakeMacCaptureMain {
             switch command {
             case "capabilities":
                 try printCapabilities()
+            case "make-preview-proxy":
+                let configuration = try PreviewProxyConfiguration.parse(arguments: arguments)
+                let result = try await PreviewProxyTranscoder.transcode(
+                    configuration: configuration
+                )
+                try printJSON(result)
             case "record":
                 guard #available(macOS 12.3, *) else {
                     throw CaptureRuntimeError.unsupportedSystem
@@ -56,6 +62,10 @@ enum FlowtakeMacCaptureMain {
             captureEngine: "ScreenCaptureKit",
             minimumSystemVersion: "12.3"
         )
+        try printJSON(payload)
+    }
+
+    private static func printJSON<T: Encodable>(_ payload: T) throws {
         let data = try JSONEncoder().encode(payload)
         FileHandle.standardOutput.write(data)
         FileHandle.standardOutput.write(Data("\n".utf8))

--- a/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/CaptureConfiguration.swift
+++ b/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/CaptureConfiguration.swift
@@ -16,7 +16,7 @@ package enum ConfigurationError: LocalizedError, Equatable {
     package var errorDescription: String? {
         switch self {
         case .missingCommand:
-            return "Missing command. Use capabilities or record."
+            return "Missing command. Use capabilities, record, or make-preview-proxy."
         case .unsupportedCommand(let command):
             return "Unsupported command: \(command)"
         case .missingValue(let option):

--- a/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/PreviewProxy.swift
+++ b/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/PreviewProxy.swift
@@ -1,0 +1,325 @@
+@preconcurrency import AVFoundation
+import CoreGraphics
+import Foundation
+
+package struct PreviewProxyConfiguration: Equatable, Sendable {
+    package let inputURL: URL
+    package let outputURL: URL
+    package let maximumWidth: Int
+    package let maximumHeight: Int
+
+    package static func parse(arguments: [String]) throws -> PreviewProxyConfiguration {
+        guard let command = arguments.first else {
+            throw ConfigurationError.missingCommand
+        }
+        guard command == "make-preview-proxy" else {
+            throw ConfigurationError.unsupportedCommand(command)
+        }
+
+        var values: [String: String] = [:]
+        var index = 1
+        while index < arguments.count {
+            let option = arguments[index]
+            guard option.hasPrefix("--") else {
+                throw ConfigurationError.invalidValue("argument", option)
+            }
+            guard index + 1 < arguments.count else {
+                throw ConfigurationError.missingValue(option)
+            }
+            values[option] = arguments[index + 1]
+            index += 2
+        }
+
+        func required(_ option: String) throws -> String {
+            guard let value = values[option], !value.isEmpty else {
+                throw ConfigurationError.missingRequiredOption(option)
+            }
+            return value
+        }
+
+        func positiveInteger(_ option: String, default defaultValue: Int) throws -> Int {
+            guard let value = values[option] else {
+                return defaultValue
+            }
+            guard let parsed = Int(value), parsed > 0 else {
+                throw ConfigurationError.invalidValue(option, value)
+            }
+            return parsed
+        }
+
+        return PreviewProxyConfiguration(
+            inputURL: URL(fileURLWithPath: try required("--input")),
+            outputURL: URL(fileURLWithPath: try required("--output")),
+            maximumWidth: try positiveInteger("--max-width", default: 1280),
+            maximumHeight: try positiveInteger("--max-height", default: 720)
+        )
+    }
+}
+
+package struct PreviewDimensions: Equatable, Sendable {
+    package let width: Int
+    package let height: Int
+
+    package init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
+
+    package func fits(maximumWidth: Int, maximumHeight: Int) -> Bool {
+        let landscape = width >= height
+        let widthLimit = landscape ? maximumWidth : maximumHeight
+        let heightLimit = landscape ? maximumHeight : maximumWidth
+        return width <= widthLimit && height <= heightLimit
+    }
+
+    package func scaledToFit(maximumWidth: Int, maximumHeight: Int) -> Self {
+        let landscape = width >= height
+        let widthLimit = landscape ? maximumWidth : maximumHeight
+        let heightLimit = landscape ? maximumHeight : maximumWidth
+        let scale = min(
+            min(Double(widthLimit) / Double(width), Double(heightLimit) / Double(height)),
+            1
+        )
+        let scaledWidth = max(Int((Double(width) * scale).rounded(.down)), 2)
+        let scaledHeight = max(Int((Double(height) * scale).rounded(.down)), 2)
+        return Self(
+            width: scaledWidth - (scaledWidth % 2),
+            height: scaledHeight - (scaledHeight % 2)
+        )
+    }
+
+    static func displayed(naturalSize: CGSize, preferredTransform: CGAffineTransform) -> Self {
+        let transformed = naturalSize.applying(preferredTransform)
+        return Self(
+            width: max(Int(abs(transformed.width).rounded()), 1),
+            height: max(Int(abs(transformed.height).rounded()), 1)
+        )
+    }
+}
+
+package struct PreviewProxyResult: Encodable, Sendable {
+    package let created: Bool
+    package let inputWidth: Int
+    package let inputHeight: Int
+    package let outputWidth: Int
+    package let outputHeight: Int
+    package let preservesAudio: Bool
+    package let elapsedMilliseconds: Int
+}
+
+package enum PreviewProxyError: LocalizedError {
+    case inputNotFound
+    case missingVideoTrack
+    case unsupportedMP4Export
+    case exportFailed(String)
+    case invalidOutput(String)
+
+    package var errorDescription: String? {
+        switch self {
+        case .inputNotFound:
+            return "The preview source recording does not exist."
+        case .missingVideoTrack:
+            return "The preview source does not contain a video track."
+        case .unsupportedMP4Export:
+            return "AVFoundation cannot export this recording as an MP4 preview."
+        case .exportFailed(let reason):
+            return "AVFoundation preview export failed: \(reason)"
+        case .invalidOutput(let reason):
+            return "AVFoundation created an invalid preview: \(reason)"
+        }
+    }
+}
+
+package enum PreviewProxyTranscoder {
+    package static func transcode(
+        configuration: PreviewProxyConfiguration
+    ) async throws -> PreviewProxyResult {
+        let start = Date()
+        let activity = ProcessInfo.processInfo.beginActivity(
+            options: [.userInitiated, .latencyCritical],
+            reason: "Preparing a responsive Flowtake editor preview"
+        )
+        defer {
+            ProcessInfo.processInfo.endActivity(activity)
+        }
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: configuration.inputURL.path) else {
+            throw PreviewProxyError.inputNotFound
+        }
+
+        let asset = AVURLAsset(
+            url: configuration.inputURL,
+            options: [AVURLAssetPreferPreciseDurationAndTimingKey: true]
+        )
+        guard let inputVideoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw PreviewProxyError.missingVideoTrack
+        }
+        let inputDimensions = try await dimensions(of: inputVideoTrack)
+        let inputHasAudio = try await !asset.loadTracks(withMediaType: .audio).isEmpty
+        if inputDimensions.fits(
+            maximumWidth: configuration.maximumWidth,
+            maximumHeight: configuration.maximumHeight
+        ) {
+            return PreviewProxyResult(
+                created: false,
+                inputWidth: inputDimensions.width,
+                inputHeight: inputDimensions.height,
+                outputWidth: inputDimensions.width,
+                outputHeight: inputDimensions.height,
+                preservesAudio: true,
+                elapsedMilliseconds: elapsedMilliseconds(since: start)
+            )
+        }
+
+        let outputDirectory = configuration.outputURL.deletingLastPathComponent()
+        try fileManager.createDirectory(
+            at: outputDirectory,
+            withIntermediateDirectories: true
+        )
+        let partialURL = outputDirectory.appendingPathComponent(
+            ".\(configuration.outputURL.deletingPathExtension().lastPathComponent)-\(UUID().uuidString).partial.mp4"
+        )
+        defer {
+            try? fileManager.removeItem(at: partialURL)
+        }
+
+        guard let exporter = AVAssetExportSession(
+            asset: asset,
+            presetName: AVAssetExportPreset1280x720
+        ) else {
+            throw PreviewProxyError.unsupportedMP4Export
+        }
+        guard exporter.supportedFileTypes.contains(.mp4) else {
+            throw PreviewProxyError.unsupportedMP4Export
+        }
+
+        exporter.outputURL = partialURL
+        exporter.outputFileType = .mp4
+        exporter.shouldOptimizeForNetworkUse = true
+        exporter.videoComposition = try await videoComposition(
+            asset: asset,
+            videoTrack: inputVideoTrack,
+            inputDimensions: inputDimensions,
+            outputDimensions: inputDimensions.scaledToFit(
+                maximumWidth: configuration.maximumWidth,
+                maximumHeight: configuration.maximumHeight
+            )
+        )
+        await withCheckedContinuation { continuation in
+            exporter.exportAsynchronously {
+                continuation.resume()
+            }
+        }
+
+        guard exporter.status == .completed else {
+            throw PreviewProxyError.exportFailed(
+                exporter.error?.localizedDescription ?? "export status \(exporter.status.rawValue)"
+            )
+        }
+        guard let outputSize = try? partialURL.resourceValues(
+            forKeys: [.fileSizeKey, .isRegularFileKey]
+        ), outputSize.isRegularFile == true, (outputSize.fileSize ?? 0) > 0 else {
+            throw PreviewProxyError.invalidOutput("the exported file is empty")
+        }
+
+        let outputAsset = AVURLAsset(
+            url: partialURL,
+            options: [AVURLAssetPreferPreciseDurationAndTimingKey: true]
+        )
+        let outputDimensions = try await dimensions(of: outputAsset)
+        guard outputDimensions.fits(
+            maximumWidth: configuration.maximumWidth,
+            maximumHeight: configuration.maximumHeight
+        ) else {
+            throw PreviewProxyError.invalidOutput(
+                "\(outputDimensions.width)x\(outputDimensions.height) exceeds the configured bounds"
+            )
+        }
+        let outputHasAudio = try await !outputAsset.loadTracks(withMediaType: .audio).isEmpty
+        guard !inputHasAudio || outputHasAudio else {
+            throw PreviewProxyError.invalidOutput("the source audio track was not preserved")
+        }
+
+        if fileManager.fileExists(atPath: configuration.outputURL.path) {
+            try fileManager.removeItem(at: configuration.outputURL)
+        }
+        try fileManager.moveItem(at: partialURL, to: configuration.outputURL)
+
+        return PreviewProxyResult(
+            created: true,
+            inputWidth: inputDimensions.width,
+            inputHeight: inputDimensions.height,
+            outputWidth: outputDimensions.width,
+            outputHeight: outputDimensions.height,
+            preservesAudio: !inputHasAudio || outputHasAudio,
+            elapsedMilliseconds: elapsedMilliseconds(since: start)
+        )
+    }
+
+    private static func dimensions(of asset: AVAsset) async throws -> PreviewDimensions {
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw PreviewProxyError.missingVideoTrack
+        }
+        return try await dimensions(of: videoTrack)
+    }
+
+    private static func dimensions(
+        of videoTrack: AVAssetTrack
+    ) async throws -> PreviewDimensions {
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let preferredTransform = try await videoTrack.load(.preferredTransform)
+        return PreviewDimensions.displayed(
+            naturalSize: naturalSize,
+            preferredTransform: preferredTransform
+        )
+    }
+
+    private static func videoComposition(
+        asset: AVAsset,
+        videoTrack: AVAssetTrack,
+        inputDimensions: PreviewDimensions,
+        outputDimensions: PreviewDimensions
+    ) async throws -> AVMutableVideoComposition {
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let preferredTransform = try await videoTrack.load(.preferredTransform)
+        let orientedRect = CGRect(origin: .zero, size: naturalSize).applying(preferredTransform)
+        let normalize = CGAffineTransform(
+            translationX: -orientedRect.minX,
+            y: -orientedRect.minY
+        )
+        let scale = CGAffineTransform(
+            scaleX: Double(outputDimensions.width) / Double(inputDimensions.width),
+            y: Double(outputDimensions.height) / Double(inputDimensions.height)
+        )
+
+        let layerInstruction = AVMutableVideoCompositionLayerInstruction(
+            assetTrack: videoTrack
+        )
+        layerInstruction.setTransform(
+            preferredTransform.concatenating(normalize).concatenating(scale),
+            at: .zero
+        )
+
+        let duration = try await asset.load(.duration)
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRange(start: .zero, duration: duration)
+        instruction.layerInstructions = [layerInstruction]
+
+        let nominalFrameRate = try await videoTrack.load(.nominalFrameRate)
+        let frameRate = max(min(Int32(nominalFrameRate.rounded()), 60), 1)
+        let composition = AVMutableVideoComposition()
+        composition.renderSize = CGSize(
+            width: outputDimensions.width,
+            height: outputDimensions.height
+        )
+        composition.frameDuration = CMTime(value: 1, timescale: frameRate)
+        composition.instructions = [instruction]
+        return composition
+    }
+
+    private static func elapsedMilliseconds(
+        since start: Date
+    ) -> Int {
+        max(Int(Date().timeIntervalSince(start) * 1_000), 0)
+    }
+}

--- a/src-tauri/native/macos-capture/Tests/FlowtakeMacCaptureTests/CaptureConfigurationTests.swift
+++ b/src-tauri/native/macos-capture/Tests/FlowtakeMacCaptureTests/CaptureConfigurationTests.swift
@@ -13,7 +13,10 @@ enum CaptureConfigurationTests {
         try testClampsAreaPercentagesToSelectedDisplay()
         try testRejectsFrameRatesThatAppDoesNotExpose()
         try testFixedFrameCadenceFillsIrregularCaptureGaps()
-        print("Flowtake macOS capture tests passed (5 tests)")
+        try testParsesPreviewProxyConfiguration()
+        try testPreviewBoundsHandleLandscapeAndPortraitVideos()
+        try testRejectsInvalidPreviewBounds()
+        print("Flowtake macOS capture tests passed (8 tests)")
     }
 
     static func expect(
@@ -125,5 +128,66 @@ enum CaptureConfigurationTests {
             cadence.frameIndex(forElapsedSeconds: 0.101) == 3,
             "Irregular source gaps must map to every missing fixed-cadence frame"
         )
+    }
+
+    static func testParsesPreviewProxyConfiguration() throws {
+        let configuration = try PreviewProxyConfiguration.parse(arguments: [
+            "make-preview-proxy",
+            "--input", "/tmp/source.mp4",
+            "--output", "/tmp/preview.mp4",
+            "--max-width", "1280",
+            "--max-height", "720"
+        ])
+
+        try expect(configuration.inputURL.path == "/tmp/source.mp4", "Proxy input was not parsed")
+        try expect(configuration.outputURL.path == "/tmp/preview.mp4", "Proxy output was not parsed")
+        try expect(configuration.maximumWidth == 1280, "Proxy width was not parsed")
+        try expect(configuration.maximumHeight == 720, "Proxy height was not parsed")
+    }
+
+    static func testPreviewBoundsHandleLandscapeAndPortraitVideos() throws {
+        let landscape = PreviewDimensions(width: 1280, height: 720)
+        let portrait = PreviewDimensions(width: 720, height: 1280)
+        let oversizedLandscape = PreviewDimensions(width: 2560, height: 1440)
+        let oversizedPortrait = PreviewDimensions(width: 1440, height: 2560)
+
+        try expect(
+            landscape.fits(maximumWidth: 1280, maximumHeight: 720),
+            "A 720p landscape preview must fit"
+        )
+        try expect(
+            portrait.fits(maximumWidth: 1280, maximumHeight: 720),
+            "A 720p portrait preview must fit with rotated limits"
+        )
+        try expect(
+            !oversizedLandscape.fits(maximumWidth: 1280, maximumHeight: 720),
+            "An oversized landscape recording must be transcoded"
+        )
+        try expect(
+            !oversizedPortrait.fits(maximumWidth: 1280, maximumHeight: 720),
+            "An oversized portrait recording must be transcoded"
+        )
+        try expect(
+            PreviewDimensions(width: 2940, height: 1912)
+                .scaledToFit(maximumWidth: 1280, maximumHeight: 720)
+                == PreviewDimensions(width: 1106, height: 720),
+            "A tall Mac display must fit within the complete 720p editor budget"
+        )
+        try expect(
+            oversizedPortrait.scaledToFit(maximumWidth: 1280, maximumHeight: 720)
+                == PreviewDimensions(width: 720, height: 1280),
+            "Portrait previews must rotate the editor bounds"
+        )
+    }
+
+    static func testRejectsInvalidPreviewBounds() throws {
+        try expectError(.invalidValue("--max-width", "0")) {
+            _ = try PreviewProxyConfiguration.parse(arguments: [
+                "make-preview-proxy",
+                "--input", "/tmp/source.mp4",
+                "--output", "/tmp/preview.mp4",
+                "--max-width", "0"
+            ])
+        }
     }
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -196,6 +196,7 @@ pub async fn get_video_path(
 
     let path = match video_type.as_str() {
         "screen" => state.screen_video_file(pid),
+        "screen-preview" => state.editor_screen_video_file(pid),
         "camera" | "microphone" => state.camera_video_file(pid),
         v if v.starts_with("extra-") => {
             let idx: usize = v

--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -19,6 +19,7 @@ fn project_storage_paths(
 
 fn remove_project_storage(state: &AppState, project_id: &str) -> AppResult<()> {
     let (temp, zip) = project_storage_paths(state, project_id)?;
+    let preview_cache = state.preview_cache_dir(project_id);
     if let Err(error) = std::fs::remove_dir_all(&temp) {
         if error.kind() != std::io::ErrorKind::NotFound {
             log::warn!(
@@ -33,6 +34,15 @@ fn remove_project_storage(state: &AppState, project_id: &str) -> AppResult<()> {
             log::error!("[delete_project] remove zip failed ({:?}): {}", zip, error);
             AppError::General(format!("Failed to delete project file: {}", error))
         })?;
+    }
+    if let Err(error) = std::fs::remove_dir_all(&preview_cache) {
+        if error.kind() != std::io::ErrorKind::NotFound {
+            log::warn!(
+                "[delete_project] remove preview cache failed ({:?}): {}",
+                preview_cache,
+                error
+            );
+        }
     }
     Ok(())
 }
@@ -134,6 +144,28 @@ pub async fn open_project(app: AppHandle, id: String) -> AppResult<Value> {
             let mut state = state.lock().unwrap();
             state.project_id = None;
             return Ok(Value::Null);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let (screen_path, preview_path) = {
+            let state = state.lock().unwrap();
+            (state.screen_video_file(&id), state.preview_video_file(&id))
+        };
+        if !preview_path
+            .metadata()
+            .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
+        {
+            app.emit("load", "Optimizing editor preview...").ok();
+            if let Err(error) =
+                crate::macos_capture::ensure_preview_proxy(&app, &screen_path, &preview_path).await
+            {
+                log::warn!(
+                    "[open_project] Native preview unavailable; using full source: {}",
+                    error
+                );
+            }
         }
     }
 
@@ -476,13 +508,17 @@ mod path_boundary_tests {
         let project_id = uuid::Uuid::new_v4().hyphenated().to_string();
         let project_temp = state.project_temp_dir(&project_id);
         let project_zip = state.project_zip_path(&project_id);
+        let preview_cache = state.preview_cache_dir(&project_id);
         std::fs::create_dir_all(&project_temp).unwrap();
+        std::fs::create_dir_all(&preview_cache).unwrap();
         std::fs::write(project_temp.join("project.json"), b"{}").unwrap();
         std::fs::write(&project_zip, b"zip").unwrap();
+        std::fs::write(preview_cache.join("screen-10.mp4"), b"preview").unwrap();
         remove_project_storage(&state, &project_id).unwrap();
 
         assert!(!project_temp.exists());
         assert!(!project_zip.exists());
+        assert!(!preview_cache.exists());
         assert_eq!(std::fs::read(sentinel.join("keep.txt")).unwrap(), b"keep");
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -2902,6 +2902,29 @@ async fn stop_recording_impl(app: AppHandle) -> AppResult<()> {
                     dest_video.metadata().map(|m| m.len()).unwrap_or(0)
                 );
 
+                #[cfg(target_os = "macos")]
+                {
+                    let preview_path = {
+                        let state = state.lock().unwrap();
+                        state.preview_video_file(pid)
+                    };
+                    app.emit_to("main", "load", "Optimizing editor preview...")
+                        .ok();
+                    if let Err(error) = crate::macos_capture::ensure_preview_proxy(
+                        &app,
+                        &dest_video,
+                        &preview_path,
+                    )
+                    .await
+                    {
+                        log::warn!(
+                            "[stop_recording] Native preview unavailable; editor will use full source: {}",
+                            error
+                        );
+                    }
+                    app.emit_to("main", "load", "Creating project...").ok();
+                }
+
                 let (
                     source_name,
                     left_trim,

--- a/src-tauri/src/macos_capture.rs
+++ b/src-tauri/src/macos_capture.rs
@@ -14,6 +14,18 @@ pub(crate) struct MacCaptureCapabilities {
     pub minimum_system_version: Option<String>,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PreviewProxyResult {
+    created: bool,
+    input_width: u32,
+    input_height: u32,
+    output_width: u32,
+    output_height: u32,
+    preserves_audio: bool,
+    elapsed_milliseconds: u64,
+}
+
 fn bundled_helper_names() -> &'static [&'static str] {
     #[cfg(target_arch = "aarch64")]
     {
@@ -189,9 +201,112 @@ pub(crate) async fn capabilities(app: &AppHandle) -> MacCaptureCapabilities {
     }
 }
 
+fn is_non_empty_file(path: &Path) -> bool {
+    path.metadata()
+        .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
+}
+
+fn remove_partial_preview_files(output_path: &Path) {
+    let Some(parent) = output_path.parent() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let is_partial = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with('.') && name.ends_with(".partial.mp4"));
+        if is_partial {
+            std::fs::remove_file(path).ok();
+        }
+    }
+}
+
+pub(crate) async fn ensure_preview_proxy(
+    app: &AppHandle,
+    input_path: &Path,
+    output_path: &Path,
+) -> Result<bool, String> {
+    if is_non_empty_file(output_path) {
+        return Ok(true);
+    }
+    if !is_non_empty_file(input_path) {
+        return Err(format!(
+            "preview source is missing or empty: {:?}",
+            input_path
+        ));
+    }
+
+    let Some(helper) = find_helper(app) else {
+        return Err("native macOS helper is unavailable".to_string());
+    };
+    remove_partial_preview_files(output_path);
+
+    let mut command = tokio::process::Command::new(&helper);
+    command
+        .arg("make-preview-proxy")
+        .arg("--input")
+        .arg(input_path)
+        .arg("--output")
+        .arg(output_path)
+        .arg("--max-width")
+        .arg("1280")
+        .arg("--max-height")
+        .arg("720")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(60), command.output()).await;
+    let output = match result {
+        Ok(Ok(output)) if output.status.success() => output,
+        Ok(Ok(output)) => {
+            remove_partial_preview_files(output_path);
+            return Err(format!(
+                "helper exited with {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+        Ok(Err(error)) => {
+            remove_partial_preview_files(output_path);
+            return Err(format!("could not launch {:?}: {}", helper, error));
+        }
+        Err(_) => {
+            remove_partial_preview_files(output_path);
+            return Err("native preview generation timed out after 60 seconds".to_string());
+        }
+    };
+
+    let result: PreviewProxyResult = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("invalid helper response: {error}"))?;
+    if result.created && !is_non_empty_file(output_path) {
+        return Err("helper reported success without a usable preview file".to_string());
+    }
+
+    log::info!(
+        "[macos-preview] created={}, {}x{} -> {}x{}, audio_preserved={}, elapsed={}ms",
+        result.created,
+        result.input_width,
+        result.input_height,
+        result.output_width,
+        result.output_height,
+        result.preserves_audio,
+        result.elapsed_milliseconds
+    );
+    Ok(result.created)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{bundled_helper_names, development_helper_names};
+    use super::{
+        bundled_helper_names, development_helper_names, is_non_empty_file,
+        remove_partial_preview_files,
+    };
 
     #[test]
     fn prefers_universal_helper_before_arch_specific_fallback() {
@@ -208,5 +323,41 @@ mod tests {
                 .first()
                 .is_some_and(|name| !name.contains("universal"))
         );
+    }
+
+    #[test]
+    fn preview_cache_accepts_only_non_empty_regular_files() {
+        let root = std::env::temp_dir().join(format!(
+            "flowtake-preview-file-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let empty = root.join("empty.mp4");
+        let usable = root.join("usable.mp4");
+        std::fs::write(&empty, []).unwrap();
+        std::fs::write(&usable, b"preview").unwrap();
+
+        assert!(!is_non_empty_file(&empty));
+        assert!(is_non_empty_file(&usable));
+        assert!(!is_non_empty_file(&root));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn preview_cleanup_removes_only_partial_mp4_files() {
+        let root = std::env::temp_dir().join(format!(
+            "flowtake-preview-cleanup-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let partial = root.join(".screen-a.partial.mp4");
+        let keep = root.join("screen-10.mp4");
+        std::fs::write(&partial, b"partial").unwrap();
+        std::fs::write(&keep, b"preview").unwrap();
+
+        remove_partial_preview_files(&keep);
+        assert!(!partial.exists());
+        assert!(keep.exists());
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -250,6 +250,32 @@ impl AppState {
         self.project_temp_dir(id).join("screen.mp4")
     }
 
+    pub fn preview_cache_dir(&self, id: &str) -> PathBuf {
+        self.app_data_dir.join("previews").join(id)
+    }
+
+    pub fn preview_video_file(&self, id: &str) -> PathBuf {
+        let source_size = self
+            .screen_video_file(id)
+            .metadata()
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        self.preview_cache_dir(id)
+            .join(format!("screen-{source_size}.mp4"))
+    }
+
+    pub fn editor_screen_video_file(&self, id: &str) -> PathBuf {
+        let preview = self.preview_video_file(id);
+        if preview
+            .metadata()
+            .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
+        {
+            preview
+        } else {
+            self.screen_video_file(id)
+        }
+    }
+
     pub fn camera_video_file(&self, id: &str) -> PathBuf {
         self.project_temp_dir(id).join("camera.webm")
     }
@@ -280,7 +306,7 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::{YoutubeOAuthCredentials, YoutubeOAuthSession, YoutubeOAuthTokens};
+    use super::{AppState, YoutubeOAuthCredentials, YoutubeOAuthSession, YoutubeOAuthTokens};
 
     fn credentials(suffix: &str) -> YoutubeOAuthCredentials {
         YoutubeOAuthCredentials {
@@ -322,5 +348,32 @@ mod tests {
         assert!(session
             .commit_tokens(current_generation, tokens("late"))
             .is_err());
+    }
+
+    #[test]
+    fn editor_screen_path_uses_size_keyed_preview_only_when_complete() {
+        let root = std::env::temp_dir().join(format!(
+            "flowtake-editor-preview-state-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let project_id = uuid::Uuid::new_v4().hyphenated().to_string();
+        let mut state = AppState::new();
+        state.app_data_dir = root.join("data");
+        state.temp_dir = root.join("temp");
+
+        let source = state.screen_video_file(&project_id);
+        std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, b"full-resolution").unwrap();
+        assert_eq!(state.editor_screen_video_file(&project_id), source);
+
+        let preview = state.preview_video_file(&project_id);
+        assert!(preview.to_string_lossy().contains("screen-15.mp4"));
+        std::fs::create_dir_all(preview.parent().unwrap()).unwrap();
+        std::fs::write(&preview, []).unwrap();
+        assert_eq!(state.editor_screen_video_file(&project_id), source);
+
+        std::fs::write(&preview, b"preview").unwrap();
+        assert_eq!(state.editor_screen_video_file(&project_id), preview);
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,6 +36,7 @@
         "enable": true,
         "scope": [
           "$APPDATA/temp/**",
+          "$APPDATA/previews/**",
           "$VIDEO/Flowtake/**",
           "$HOME/Flowtake/**"
         ]

--- a/test/macosNativeCapture.test.js
+++ b/test/macosNativeCapture.test.js
@@ -15,6 +15,7 @@ test('macOS native capture is built, bundled, and release-tested', () => {
     assert.match(packageJson.scripts['test:macos-capture'], /flowtake-macos-capture-tests/)
     assert.match(packageJson.scripts['build:macos-capture'], /build-macos-capture\.sh --native/)
     assert.ok(tauriConfig.bundle.resources.includes('binaries/*'))
+    assert.ok(tauriConfig.app.security.assetProtocol.scope.includes('$APPDATA/previews/**'))
     assert.match(ci, /Test native macOS capture helper/)
     assert.match(release, /build-macos-capture\.sh --universal/)
     assert.match(release, /flowtake-macos-capture-universal-apple-darwin/)
@@ -53,4 +54,34 @@ test('Rust lifecycle handshakes, finalizes, and keeps AVFoundation fallback', ()
     assert.match(encoding, /ScreenCaptureKit \(native\)/)
     assert.match(encoding, /AVFoundation \(compatibility\)/)
     assert.match(state, /macos_capture_process: Option<std::process::Child>/)
+})
+
+test('macOS editor uses an atomic AVFoundation preview cache with source fallback', () => {
+    const proxy = read(
+        'src-tauri',
+        'native',
+        'macos-capture',
+        'Sources',
+        'FlowtakeMacCaptureCore',
+        'PreviewProxy.swift'
+    )
+    const main = read(
+        'src-tauri',
+        'native',
+        'macos-capture',
+        'Sources',
+        'FlowtakeMacCapture',
+        'FlowtakeMacCaptureMain.swift'
+    )
+    const files = read('src-tauri', 'src', 'commands', 'files.rs')
+    const videoWrapper = read('app', 'windows', 'main', 'components', 'VideoWrapper.jsx')
+
+    assert.match(main, /make-preview-proxy/)
+    assert.match(proxy, /AVAssetExportSession/)
+    assert.match(proxy, /AVMutableVideoComposition/)
+    assert.match(proxy, /shouldOptimizeForNetworkUse = true/)
+    assert.match(proxy, /\.partial\.mp4/)
+    assert.match(proxy, /source audio track was not preserved/)
+    assert.match(files, /"screen-preview" => state\.editor_screen_video_file/)
+    assert.match(videoWrapper, /useVideoSrc\("screen-preview", projectId\)/)
 })

--- a/test/nativeCapabilitySecurity.test.js
+++ b/test/nativeCapabilitySecurity.test.js
@@ -78,6 +78,7 @@ test("production webviews cannot enable DevTools or read arbitrary asset paths",
     assert.doesNotMatch(cargoToml, /features\s*=\s*\[[^\]]*"devtools"/)
     assert.deepEqual(assetScope, [
         "$APPDATA/temp/**",
+        "$APPDATA/previews/**",
         "$VIDEO/Flowtake/**",
         "$HOME/Flowtake/**",
     ])

--- a/tests/editor-performance.test.mjs
+++ b/tests/editor-performance.test.mjs
@@ -20,6 +20,24 @@ test("Retina recordings use a bounded editor texture without changing source coo
     )
 })
 
+test("downscaled preview textures stay centered in full-resolution scene coordinates", async () => {
+    const screenSource = await readFile(
+        new URL("../app/shared/scene/Screen.js", import.meta.url),
+        "utf8"
+    )
+
+    assert.match(
+        screenSource,
+        /this\.fg\.pivot\.set\(textureDims\.x \* 0\.5, textureDims\.y \* 0\.5\)/
+    )
+    assert.match(
+        screenSource,
+        /this\.fg\.position\.set\(dims\.x \* 0\.5, dims\.y \* 0\.5\)/
+    )
+    assert.match(screenSource, /this\.fg\.width = dims\.x/)
+    assert.match(screenSource, /this\.fg\.height = dims\.y/)
+})
+
 test("preview texture bounds preserve small and portrait aspect ratios", () => {
     assert.deepEqual(
         getPreviewTextureDimensions({ x: 1280, y: 720 }),


### PR DESCRIPTION
## Summary

- generate a bounded macOS editor proxy with Swift and AVFoundation while preserving the original full-resolution recording for export
- keep preview files in an atomic, size-keyed cache outside project archives, clean them up with project deletion, and fall back safely to the source file on any failure or 60-second timeout
- fix downscaled texture centering so Retina recordings fill the editor canvas instead of showing only a small corner
- preserve audio, portrait orientation, even output dimensions, and exact source-coordinate behavior

## Measured performance

Measured on the same 2940×1912, 46.17-second Retina recording using hardware video decoding:

| Metric | Full source | Native editor proxy | Difference |
| --- | ---: | ---: | ---: |
| Decoded pixels per frame | 5,621,280 | 796,320 | 85.8% fewer (7.06× smaller) |
| Decode wall time | 12.16 s | 2.82 s | 76.8% lower (4.31× faster) |
| Decoder user CPU time | 1.82 s | 0.37 s | 79.7% lower |
| Maximum resident memory | 223.7 MB | 74.2 MB | 66.8% lower |
| Peak memory footprint | 132.9 MB | 38.2 MB | 71.3% lower |
| Preview file size | 55.1 MB | 17.8 MB | 67.7% lower |

The original recording remains 2940×1912 and is still used for final export. The 1106×720 proxy scored 40.09 dB average PSNR against the correctly scaled source.

A final bundled-helper run converted a separate 2940×1912, 41.12-second project in 4.36 seconds with a 37.2 MB peak footprint. Cached project reopen reached the editor in 1.83 seconds during real-app validation.

## Validation

- `npm test` — 157 passed
- `npm run test:macos-capture` — 8 passed
- `cargo test --lib --locked` — 69 passed
- `cargo check --locked --all-targets`
- `cargo clippy --locked --all-targets -- -D warnings --allow dead_code`
- `npm run lint` — 0 errors (41 pre-existing warnings)
- `npm run build:frontend`
- `npm run build:macos-capture`
- verified landscape, portrait, small-source skip, audio preservation, atomic failure cleanup, and source fallback using real media
- verified centered editor display, playback, and timeline seek in the real macOS app
