### PR TITLE
fix(macos): hide Flowtake from native recordings

### DIFF
--- a/app/shared/tauriBridge.js
+++ b/app/shared/tauriBridge.js
@@ -95,6 +95,7 @@ const COMMAND_MAP = {
     'select-area': 'select_area',
     'add-note': 'add_note',
     'toggle-drawing-overlay': 'toggle_drawing_overlay',
+    'get-content-protection': 'get_content_protection',
     'set-content-protection': 'set_content_protection',
     'get-window-at-point': 'get_window_at_point',
     'get-monitors': 'get_monitors',

--- a/app/windows/main/components/settings/GeneralSettings.jsx
+++ b/app/windows/main/components/settings/GeneralSettings.jsx
@@ -11,6 +11,10 @@ import Toggle from "../properties/Toggle"
 export default function GeneralSettings() {
 
     const dispatch = useDispatch()
+    const platform = window.electron?.process?.platform
+        || (navigator.platform?.includes("Mac") ? "darwin" : navigator.platform?.includes("Win") ? "win32" : "linux")
+    const isMacOS = platform === "darwin"
+    const isLinux = platform === "linux"
 
     const restartTutorial = useCallback(async () => {
         await window.electron.ipcRenderer.invoke("store-set", "hasCompletedTutorial", false)
@@ -33,7 +37,7 @@ export default function GeneralSettings() {
 
     const { data: contentProtectionEnabled, isPending: isContentProtPending, refetch: refetchContentProt } = useQuery({
         queryKey: ['contentProtectionEnabled'],
-        queryFn: () => window.electron.ipcRenderer.invoke("store-get", "contentProtectionEnabled"),
+        queryFn: () => window.electron.ipcRenderer.invoke("get-content-protection"),
         staleTime: Infinity
     })
 
@@ -58,11 +62,17 @@ export default function GeneralSettings() {
                 isIndeterminate={isAutoStartPending} />
         </Fieldset>
 
-        <Fieldset legend="Privacy" description="Control whether Flowtake is visible in screenshots and screen recordings.">
-            <Toggle leftLabel="Hide app from screenshots & recordings"
-                value={isContentProtPending ? true : (contentProtectionEnabled ?? true)}
-                onChange={onChangeContentProtection} disabled={isContentProtPending}
-                isIndeterminate={isContentProtPending} />
+        <Fieldset legend="Privacy" description={isMacOS
+            ? "Exclude Flowtake windows from Flowtake full-screen and area recordings. macOS no longer lets apps block system screenshots or third-party captures."
+            : isLinux
+                ? "Window capture protection is unavailable on Linux."
+                : "Control whether Flowtake is visible in screenshots and screen recordings."}>
+            {isLinux
+                ? <p className="text-sm text-base-content/70">Flowtake cannot request capture protection on this platform.</p>
+                : <Toggle leftLabel={isMacOS ? "Hide Flowtake from Flowtake recordings" : "Hide app from screenshots & recordings"}
+                    value={isContentProtPending ? true : (contentProtectionEnabled ?? true)}
+                    onChange={onChangeContentProtection} disabled={isContentProtPending}
+                    isIndeterminate={isContentProtPending} />}
         </Fieldset>
 
         <Button icon={FolderOpenIcon} onClick={openLogsDirectory}>Open logs folder</Button>

--- a/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/CaptureConfiguration.swift
+++ b/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/CaptureConfiguration.swift
@@ -35,6 +35,7 @@ package struct CaptureConfiguration: Equatable, Sendable {
     package let source: CaptureSource
     package let displayIndex: Int
     package let windowID: UInt32?
+    package let excludedProcessID: Int32?
     package let width: Int
     package let height: Int
     package let framesPerSecond: Int
@@ -143,12 +144,23 @@ package struct CaptureConfiguration: Equatable, Sendable {
             throw ConfigurationError.invalidValue("--display-index", String(displayIndex))
         }
 
+        let excludedProcessID: Int32?
+        if let value = values["--exclude-process-id"] {
+            guard let parsed = Int32(value), parsed > 0 else {
+                throw ConfigurationError.invalidValue("--exclude-process-id", value)
+            }
+            excludedProcessID = parsed
+        } else {
+            excludedProcessID = nil
+        }
+
         return CaptureConfiguration(
             outputURL: URL(fileURLWithPath: try required("--output")),
             readyFileURL: URL(fileURLWithPath: try required("--ready-file")),
             source: source,
             displayIndex: displayIndex,
             windowID: windowID,
+            excludedProcessID: excludedProcessID,
             width: width.roundedDownToEven(minimum: 16),
             height: height.roundedDownToEven(minimum: 16),
             framesPerSecond: fps,

--- a/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/CaptureSession.swift
+++ b/src-tauri/native/macos-capture/Sources/FlowtakeMacCaptureCore/CaptureSession.swift
@@ -433,14 +433,28 @@ package final class CaptureSession: NSObject, SCStreamOutput, SCStreamDelegate, 
                 throw CaptureRuntimeError.displayNotFound(configuration.displayIndex)
             }
             let display = content.displays[configuration.displayIndex]
-            let currentApplication = content.applications.first {
-                $0.processID == ProcessInfo.processInfo.processIdentifier
+            let excludedApplication = configuration.excludedProcessID.flatMap { processID in
+                content.applications.first { $0.processID == processID }
             }
-            let filter = SCContentFilter(
-                display: display,
-                excludingApplications: currentApplication.map { [$0] } ?? [],
-                exceptingWindows: []
-            )
+            let excludedWindows = configuration.excludedProcessID.map { processID in
+                content.windows.filter { $0.owningApplication?.processID == processID }
+            } ?? []
+            let filter: SCContentFilter
+            if let excludedApplication {
+                filter = SCContentFilter(
+                    display: display,
+                    excludingApplications: [excludedApplication],
+                    exceptingWindows: []
+                )
+            } else {
+                filter = SCContentFilter(
+                    display: display,
+                    excludingWindows: excludedWindows
+                )
+                if configuration.excludedProcessID != nil, excludedWindows.isEmpty {
+                    diagnostic("Requested app exclusion was not present in shareable content")
+                }
+            }
 
             if configuration.source == .area {
                 let width = Double(display.width)

--- a/src-tauri/native/macos-capture/Tests/FlowtakeMacCaptureTests/CaptureConfigurationTests.swift
+++ b/src-tauri/native/macos-capture/Tests/FlowtakeMacCaptureTests/CaptureConfigurationTests.swift
@@ -12,11 +12,12 @@ enum CaptureConfigurationTests {
         try testRequiresStableWindowIdentifier()
         try testClampsAreaPercentagesToSelectedDisplay()
         try testRejectsFrameRatesThatAppDoesNotExpose()
+        try testRejectsInvalidExcludedProcess()
         try testFixedFrameCadenceFillsIrregularCaptureGaps()
         try testParsesPreviewProxyConfiguration()
         try testPreviewBoundsHandleLandscapeAndPortraitVideos()
         try testRejectsInvalidPreviewBounds()
-        print("Flowtake macOS capture tests passed (8 tests)")
+        print("Flowtake macOS capture tests passed (9 tests)")
     }
 
     static func expect(
@@ -51,6 +52,7 @@ enum CaptureConfigurationTests {
             "--height", "1081",
             "--fps", "60",
             "--bitrate", "12000000",
+            "--exclude-process-id", "4321",
             "--audio"
         ])
 
@@ -60,6 +62,7 @@ enum CaptureConfigurationTests {
         try expect(configuration.height == 1080, "Height was not normalized")
         try expect(configuration.framesPerSecond == 60, "Frame rate was not parsed")
         try expect(configuration.capturesSystemAudio, "Audio flag was not parsed")
+        try expect(configuration.excludedProcessID == 4321, "Excluded app process was not parsed")
     }
 
     static func testRequiresStableWindowIdentifier() throws {
@@ -95,6 +98,7 @@ enum CaptureConfigurationTests {
         try expect(configuration.areaYPercent == 20, "Area y changed unexpectedly")
         try expect(configuration.areaWidthPercent == 100, "Area width was not clamped")
         try expect(configuration.areaHeightPercent == 75, "Area height changed unexpectedly")
+        try expect(configuration.excludedProcessID == nil, "Unexpected app exclusion was enabled")
     }
 
     static func testRejectsFrameRatesThatAppDoesNotExpose() throws {
@@ -108,6 +112,21 @@ enum CaptureConfigurationTests {
                 "--height", "1080",
                 "--fps", "24",
                 "--bitrate", "9000000"
+            ])
+        }
+    }
+
+    static func testRejectsInvalidExcludedProcess() throws {
+        try expectError(.invalidValue("--exclude-process-id", "0")) {
+            _ = try CaptureConfiguration.parse(arguments: [
+                "record",
+                "--output", "/tmp/screen.mp4",
+                "--ready-file", "/tmp/ready",
+                "--source-type", "screen",
+                "--width", "1920",
+                "--height", "1080",
+                "--bitrate", "9000000",
+                "--exclude-process-id", "0"
             ])
         }
     }

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -612,6 +612,7 @@ struct MacCaptureArgumentConfig<'a> {
     height: u32,
     quality: &'a str,
     captures_system_audio: bool,
+    excluded_process_id: Option<u32>,
 }
 
 #[cfg(target_os = "macos")]
@@ -628,6 +629,7 @@ fn macos_native_capture_arguments(
         height,
         quality,
         captures_system_audio,
+        excluded_process_id,
     } = config;
     let mut args = vec![
         "record".to_string(),
@@ -655,6 +657,10 @@ fn macos_native_capture_arguments(
             .saturating_mul(1_000)
             .to_string(),
     ];
+
+    if let Some(process_id) = excluded_process_id {
+        args.extend(["--exclude-process-id".to_string(), process_id.to_string()]);
+    }
 
     if source_type == "window" {
         args.extend([
@@ -1783,6 +1789,8 @@ async fn init_recording_impl(
                     height: recording_height,
                     quality: &quality,
                     captures_system_audio: has_system_audio,
+                    excluded_process_id: super::windows::is_content_protection_enabled(&app)
+                        .then_some(std::process::id()),
                 },
             )),
                 Some(ready_file),
@@ -4583,6 +4591,46 @@ mod tests {
             .position(|arg| arg == option)
             .and_then(|index| args.get(index + 1))
             .map(String::as_str)
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn native_capture_receives_the_flowtake_process_to_exclude() {
+        let source = serde_json::json!({"type": "screen", "monitorIndex": 0});
+        let protected = macos_native_capture_arguments(
+            &source,
+            MacCaptureArgumentConfig {
+                source_type: "screen",
+                output_path: "/tmp/screen.mp4",
+                ready_file_path: "/tmp/ready",
+                fps: 30,
+                width: 1920,
+                height: 1080,
+                quality: "balanced",
+                captures_system_audio: false,
+                excluded_process_id: Some(4242),
+            },
+        );
+        assert_eq!(
+            option_value(&protected, "--exclude-process-id"),
+            Some("4242")
+        );
+
+        let visible = macos_native_capture_arguments(
+            &source,
+            MacCaptureArgumentConfig {
+                source_type: "screen",
+                output_path: "/tmp/screen.mp4",
+                ready_file_path: "/tmp/ready",
+                fps: 30,
+                width: 1920,
+                height: 1080,
+                quality: "balanced",
+                captures_system_audio: false,
+                excluded_process_id: None,
+            },
+        );
+        assert_eq!(option_value(&visible, "--exclude-process-id"), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -6,19 +6,24 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindo
 use tauri_plugin_store::StoreExt;
 
 /// Read the content-protection preference from the store.
-/// Release builds default to protected/hidden so Flowtake never appears in a
-/// user's recording. Debug builds are deliberately capturable, which keeps
-/// visual QA possible without weakening production privacy.
-pub fn is_content_protection_enabled(app: &AppHandle) -> bool {
-    if cfg!(debug_assertions) {
-        return false;
-    }
+/// Release builds default to protected. Debug builds default to capturable for
+/// visual QA, but an explicit user choice must still take effect.
+fn resolve_content_protection_preference(stored: Option<bool>) -> bool {
+    stored.unwrap_or(!cfg!(debug_assertions))
+}
 
-    app.store("store.json")
+pub fn is_content_protection_enabled(app: &AppHandle) -> bool {
+    let stored = app
+        .store("store.json")
         .ok()
         .and_then(|s| s.get("contentProtectionEnabled"))
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true)
+        .and_then(|v| v.as_bool());
+    resolve_content_protection_preference(stored)
+}
+
+#[tauri::command]
+pub fn get_content_protection(app: AppHandle) -> bool {
+    is_content_protection_enabled(&app)
 }
 
 #[tauri::command]
@@ -35,7 +40,13 @@ pub async fn set_content_protection(app: AppHandle, enabled: bool) -> AppResult<
         if label == "drawingOverlay" {
             continue;
         }
-        window.set_content_protected(enabled).ok();
+        if let Err(error) = window.set_content_protected(enabled) {
+            log::warn!(
+                "[content-protection] Could not update window {}: {}",
+                label,
+                error
+            );
+        }
     }
 
     Ok(())
@@ -1406,7 +1417,17 @@ pub async fn close_live_composer(app: AppHandle) -> AppResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::intersect_window_with_desktop;
+    use super::{intersect_window_with_desktop, resolve_content_protection_preference};
+
+    #[test]
+    fn explicit_content_protection_choice_overrides_build_default() {
+        assert!(resolve_content_protection_preference(Some(true)));
+        assert!(!resolve_content_protection_preference(Some(false)));
+        assert_eq!(
+            resolve_content_protection_preference(None),
+            !cfg!(debug_assertions)
+        );
+    }
 
     #[test]
     fn window_intersection_keeps_secondary_monitor_coordinates() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -607,6 +607,7 @@ pub fn run() {
             commands::windows::get_window_at_point,
             commands::windows::get_monitors,
             commands::windows::toggle_drawing_overlay,
+            commands::windows::get_content_protection,
             commands::windows::set_content_protection,
             // App
             commands::app::get_version,

--- a/test/macosNativeCapture.test.js
+++ b/test/macosNativeCapture.test.js
@@ -30,6 +30,15 @@ test('native capture uses ScreenCaptureKit with a real MP4 writer and bounded qu
         'FlowtakeMacCaptureCore',
         'CaptureSession.swift'
     )
+    const configuration = read(
+        'src-tauri',
+        'native',
+        'macos-capture',
+        'Sources',
+        'FlowtakeMacCaptureCore',
+        'CaptureConfiguration.swift'
+    )
+    const recording = read('src-tauri', 'src', 'commands', 'recording.rs')
     const infoPlist = read('src-tauri', 'Info.plist')
 
     assert.match(capture, /import ScreenCaptureKit/)
@@ -38,6 +47,11 @@ test('native capture uses ScreenCaptureKit with a real MP4 writer and bounded qu
     assert.match(capture, /queueDepth = 5/)
     assert.match(capture, /capturesAudio = true/)
     assert.match(capture, /excludesCurrentProcessAudio = true/)
+    assert.match(configuration, /excludedProcessID: Int32\?/)
+    assert.match(recording, /"--exclude-process-id"/)
+    assert.match(capture, /excludingApplications: \[excludedApplication\]/)
+    assert.match(capture, /excludingWindows: excludedWindows/)
+    assert.doesNotMatch(capture, /ProcessInfo\.processInfo\.processIdentifier/)
     assert.match(infoPlist, /NSScreenCaptureUsageDescription/)
 })
 

--- a/test/recorderShell.test.js
+++ b/test/recorderShell.test.js
@@ -20,6 +20,7 @@ const [
     recorderTutorial,
     tutorialSteps,
     nativeRecording,
+    nativeWindows,
 ] = await Promise.all([
     readSource("../app/windows/main/App.jsx"),
     readSource("../app/windows/main/components/Launcher.jsx"),
@@ -36,6 +37,7 @@ const [
     readSource("../app/windows/recorder/components/RecorderTutorial.jsx"),
     readSource("../app/windows/main/components/tutorial/steps.js"),
     readSource("../src-tauri/src/commands/recording.rs"),
+    readSource("../src-tauri/src/commands/windows.rs"),
 ])
 
 test("cold hardware encoder probing does not hold the startup splash", () => {
@@ -102,6 +104,11 @@ test("settings show only controls backed by working behavior", () => {
     assert.match(recorderSettings, /store-get", "recordingQuality"/)
     assert.match(recorderSettings, /value="performance"/)
     assert.match(recorderSettings, /value="quality"/)
+    assert.match(generalSettings, /get-content-protection/)
+    assert.match(generalSettings, /macOS no longer lets apps block system screenshots or third-party captures/)
+    assert.match(generalSettings, /Window capture protection is unavailable on Linux/)
+    assert.match(nativeWindows, /stored\.unwrap_or\(!cfg!\(debug_assertions\)\)/)
+    assert.doesNotMatch(nativeWindows, /if cfg!\(debug_assertions\) \{[\s\S]*?return false/)
 })
 
 test("experimental page exposes runtime-backed built-ins without drop-in claims", () => {


### PR DESCRIPTION
## What changed

- pass the Flowtake process ID from the Rust app to the Swift ScreenCaptureKit helper
- exclude the owning application, with an owned-window fallback, from full-screen and area captures
- honor an explicit privacy preference in debug builds instead of forcing it off
- expose the effective preference to the settings UI and describe the current macOS limitation accurately
- hide the unsupported control on Linux and retain the existing Windows behavior

## Root cause

The helper previously excluded its own child-process PID, so no Flowtake window matched the ScreenCaptureKit filter. Debug builds also returned `false` before reading the stored preference, which made the toggle ineffective during development testing.

## User impact

When **Hide Flowtake from Flowtake recordings** is enabled, Flowtake full-screen and area recordings now omit Flowtake windows. The UI no longer claims that current macOS can block system screenshots or third-party capture tools.

## Validation

- `npm test` — 157 passed
- `npm run test:macos-capture` — 9 passed
- `cargo test --release --lib --locked` — 71 passed
- `cargo check --release --locked --all-targets`
- `cargo clippy --release --locked --all-targets -- -D warnings --allow dead_code`
- `npm run lint` — 0 errors
- `npm run build` — produced the macOS `.app` and `.dmg`
- real ScreenCaptureKit A/B capture — the control recording contained the test app window; the PID-filtered recording removed it completely
- launched the packaged Flowtake app and verified the macOS privacy setting in the real UI