### PR TITLE
feat(distribution): expose WinGet installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The desktop recorder and editor are free to use, inspect, modify, and redistribu
 
 ## 60-second quickstart
 
-1. Download the build for your OS from the [latest release](https://github.com/JNX03/Flowtake/releases/latest). On Windows, the `x64-setup.exe` is the simplest starting point.
+1. Install with `winget install --id JNX03.Flowtake --exact` on Windows, or download the build for your OS from the [latest release](https://github.com/JNX03/Flowtake/releases/latest).
 2. Open Flowtake, choose **Record**, then select **Screen**, **Window**, or **Area**. Add a camera, microphone, or system-audio source if needed.
 3. Start recording and use the compact recorder controls to pause or stop.
 4. Open the saved project from **Library**, adjust the timeline and effects, then choose **Export** to render an MP4.
@@ -56,6 +56,16 @@ All published artifacts are on the official [GitHub Releases page](https://githu
 | **Windows 10/11 x64** | `.exe`, `.msi`, portable `.zip` | Primary development and validation target. FFmpeg is bundled. |
 | **macOS 10.15+ Universal** | `.dmg`, portable `.zip` | Preview. Apple Silicon and Intel builds are published; expect rough edges and report reproducible issues. FFmpeg is bundled. |
 | **Linux x64** | `.AppImage`, `.deb`, `.rpm`, portable `.tar.gz` | Preview. Screen capture requires X11 or XWayland; pure Wayland capture is not supported. The `.deb` and `.rpm` declare required system packages. |
+
+### WinGet (Windows)
+
+Flowtake is published in the [Microsoft WinGet community repository](https://github.com/microsoft/winget-pkgs/tree/master/manifests/j/JNX03/Flowtake/1.6.0):
+
+```powershell
+winget install --id JNX03.Flowtake --exact
+```
+
+The WinGet package installs the same unsigned MSI published on the official release page, so the signing boundary below still applies.
 
 > **Platform signing:** the current Windows artifacts are not Authenticode-signed. The macOS artifacts are ad-hoc signed, not signed with an Apple Developer ID, and not notarized. SmartScreen or Gatekeeper may warn. Download Flowtake only from this repository's release page, and do not bypass a warning for a copy obtained elsewhere.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 ## Download
 
-Download the latest installer from the [Releases page](https://github.com/Jnx03/Flowtake/releases).
+Download the latest installer from the [Releases page](https://github.com/JNX03/Flowtake/releases).
 
 Available installer formats:
 
@@ -10,6 +10,7 @@ Available installer formats:
 |----------|--------|
 | Windows 10/11 | `.exe` (NSIS installer) or `.msi` |
 | macOS | `.dmg` |
+| Linux | `.AppImage`, `.deb`, or `.rpm` |
 
 ## System Requirements
 
@@ -22,11 +23,19 @@ Available installer formats:
 
 ## Windows Installation
 
-1. Download the `.exe` or `.msi` installer
+Install the published [WinGet package](https://github.com/microsoft/winget-pkgs/tree/master/manifests/j/JNX03/Flowtake/1.6.0):
+
+```powershell
+winget install --id JNX03.Flowtake --exact
+```
+
+Alternatively:
+
+1. Download the `.exe` or `.msi` installer from the official Releases page
 2. Run the installer and follow the on-screen steps
 3. Flowtake will appear in your Start Menu
 
-> **Note**: Windows may show a SmartScreen warning on first run since the app is not yet widely distributed. Click **More info → Run anyway** to proceed.
+> **Note**: The current Windows artifacts are not Authenticode-signed, so Windows may show a SmartScreen warning. Install only a copy obtained from the official Releases page or through the published WinGet manifest.
 
 ## macOS Installation
 

--- a/test/windowsMsiLifecycle.test.js
+++ b/test/windowsMsiLifecycle.test.js
@@ -16,6 +16,11 @@ const versionManifestSource = await readFile(new URL("JNX03.Flowtake.yaml", mani
 const localeManifestSource = await readFile(new URL("JNX03.Flowtake.locale.en-US.yaml", manifestRoot), "utf8")
 const installerManifestSource = await readFile(new URL("JNX03.Flowtake.installer.yaml", manifestRoot), "utf8")
 const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
+const readmeSource = await readFile(new URL("../README.md", import.meta.url), "utf8")
+const installationDocsSource = await readFile(
+    new URL("../docs/getting-started/installation.md", import.meta.url),
+    "utf8"
+)
 
 const workflow = yaml.load(workflowSource)
 const versionManifest = yaml.load(versionManifestSource)
@@ -62,6 +67,20 @@ test("tracked WinGet manifests describe the exact reviewed release", () => {
         InstallerUrl: expected.msiUrl,
         InstallerSha256: expected.msiSha256,
     })
+})
+
+test("public install guidance exposes the exact WinGet package", () => {
+    const installCommand = "winget install --id JNX03.Flowtake --exact"
+    const publicManifestUrl =
+        `https://github.com/microsoft/winget-pkgs/tree/master/manifests/j/JNX03/Flowtake/${expected.version}`
+
+    for (const source of [readmeSource, installationDocsSource]) {
+        assert.match(source, new RegExp(installCommand.replaceAll(".", "\\.")))
+        assert.match(source, new RegExp(publicManifestUrl.replaceAll(".", "\\.")))
+    }
+
+    assert.match(readmeSource, /same unsigned MSI published on the official release page/i)
+    assert.match(installationDocsSource, /not Authenticode-signed/i)
 })
 
 test("MSI execution is restricted to a manual main-branch dispatch", () => {


### PR DESCRIPTION
## What changed

- add the published WinGet command to the 60-second quickstart and download section
- link directly to Flowtake's public Microsoft community manifest
- update the installation guide with WinGet and the existing Linux packages
- add a regression test that binds public install guidance to the exact package ID and versioned manifest path

## Why

Flowtake 1.6.0 is already available from WinGet, but the repository only directed Windows users to manual release downloads. Exposing the package-manager path makes installation easier while keeping the unsigned-MSI boundary explicit.

## Validation

- `npm test` — 158 passed
- `npm run test:macos-capture` — 9 passed
- `npm run build:site`
- `npm run lint` — 0 errors, 41 existing warnings
- `git diff --check`
